### PR TITLE
feat(tests): Migrate OpenRouter API tests to VCR cassettes

### DIFF
--- a/tests/cassettes/TestOpenRouterClient.test_fetch_models_extracts_modalities.yaml
+++ b/tests/cassettes/TestOpenRouterClient.test_fetch_models_extracts_modalities.yaml
@@ -1,0 +1,24 @@
+version: 1
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - application/json
+      authorization:
+      - Bearer test-key
+      host:
+      - openrouter.ai
+      user-agent:
+      - python-httpx/0.27.0
+    method: GET
+    uri: https://openrouter.ai/api/v1/models
+  response:
+    body:
+      string: '{"data": [{"id": "test/model", "context_length": 4096, "architecture": {"input_modalities": ["text", "image"]}}]}'
+    headers:
+      content-type:
+      - application/json
+    status:
+      code: 200
+      message: OK

--- a/tests/cassettes/TestOpenRouterClient.test_fetch_models_extracts_pricing_correctly.yaml
+++ b/tests/cassettes/TestOpenRouterClient.test_fetch_models_extracts_pricing_correctly.yaml
@@ -1,0 +1,24 @@
+version: 1
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - application/json
+      authorization:
+      - Bearer test-key
+      host:
+      - openrouter.ai
+      user-agent:
+      - python-httpx/0.27.0
+    method: GET
+    uri: https://openrouter.ai/api/v1/models
+  response:
+    body:
+      string: '{"data": [{"id": "test/model", "context_length": 4096, "pricing": {"prompt": "0.0025", "completion": "0.01"}}]}'
+    headers:
+      content-type:
+      - application/json
+    status:
+      code: 200
+      message: OK

--- a/tests/cassettes/TestOpenRouterClient.test_fetch_models_returns_model_list.yaml
+++ b/tests/cassettes/TestOpenRouterClient.test_fetch_models_returns_model_list.yaml
@@ -1,0 +1,24 @@
+version: 1
+interactions:
+- request:
+    body: null
+    headers:
+      accept:
+      - application/json
+      authorization:
+      - Bearer test-key
+      host:
+      - openrouter.ai
+      user-agent:
+      - python-httpx/0.27.0
+    method: GET
+    uri: https://openrouter.ai/api/v1/models
+  response:
+    body:
+      string: '{"data": [{"id": "openai/gpt-4o", "name": "GPT-4o", "context_length": 128000, "pricing": {"prompt": "0.0025", "completion": "0.01"}, "architecture": {"input_modalities": ["text", "image"]}, "supported_parameters": ["temperature", "top_p"]}]}'
+    headers:
+      content-type:
+      - application/json
+    status:
+      code: 200
+      message: OK

--- a/tests/cassettes/test_query_model_with_status_success.yaml
+++ b/tests/cassettes/test_query_model_with_status_success.yaml
@@ -1,0 +1,26 @@
+version: 1
+interactions:
+- request:
+    body: '{"model": "test-model", "messages": [{"role": "user", "content": "test"}]}'
+    headers:
+      accept:
+      - application/json
+      authorization:
+      - Bearer test-key
+      content-type:
+      - application/json
+      host:
+      - openrouter.ai
+      user-agent:
+      - python-httpx/0.27.0
+    method: POST
+    uri: https://openrouter.ai/api/v1/chat/completions
+  response:
+    body:
+      string: '{"id": "gen-123", "choices": [{"message": {"role": "assistant", "content": "Test response"}}], "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}}'
+    headers:
+      content-type:
+      - application/json
+    status:
+      code: 200
+      message: OK

--- a/tests/cassettes/test_query_models_with_progress.yaml
+++ b/tests/cassettes/test_query_models_with_progress.yaml
@@ -1,0 +1,50 @@
+version: 1
+interactions:
+- request:
+    body: '{"model": "model-a", "messages": [{"role": "user", "content": "test"}]}'
+    headers:
+      accept:
+      - application/json
+      authorization:
+      - Bearer test-key
+      content-type:
+      - application/json
+      host:
+      - openrouter.ai
+      user-agent:
+      - python-httpx/0.27.0
+    method: POST
+    uri: https://openrouter.ai/api/v1/chat/completions
+  response:
+    body:
+      string: '{"id": "gen-a", "choices": [{"message": {"role": "assistant", "content": "Test"}}], "usage": {}}'
+    headers:
+      content-type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"model": "model-b", "messages": [{"role": "user", "content": "test"}]}'
+    headers:
+      accept:
+      - application/json
+      authorization:
+      - Bearer test-key
+      content-type:
+      - application/json
+      host:
+      - openrouter.ai
+      user-agent:
+      - python-httpx/0.27.0
+    method: POST
+    uri: https://openrouter.ai/api/v1/chat/completions
+  response:
+    body:
+      string: '{"id": "gen-b", "choices": [{"message": {"role": "assistant", "content": "Test"}}], "usage": {}}'
+    headers:
+      content-type:
+      - application/json
+    status:
+      code: 200
+      message: OK

--- a/tests/cassettes/test_query_models_with_progress_no_callback.yaml
+++ b/tests/cassettes/test_query_models_with_progress_no_callback.yaml
@@ -1,0 +1,26 @@
+version: 1
+interactions:
+- request:
+    body: '{"model": "model-a", "messages": [{"role": "user", "content": "test"}]}'
+    headers:
+      accept:
+      - application/json
+      authorization:
+      - Bearer test-key
+      content-type:
+      - application/json
+      host:
+      - openrouter.ai
+      user-agent:
+      - python-httpx/0.27.0
+    method: POST
+    uri: https://openrouter.ai/api/v1/chat/completions
+  response:
+    body:
+      string: '{"id": "gen-a", "choices": [{"message": {"role": "assistant", "content": "Test"}}], "usage": {}}'
+    headers:
+      content-type:
+      - application/json
+    status:
+      code: 200
+      message: OK

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -1,17 +1,23 @@
-"""Tests for llm_council OpenRouter client (ADR-012 reliability features)."""
-import pytest
-from unittest.mock import patch, AsyncMock, MagicMock
+"""Tests for llm_council OpenRouter client (ADR-012 reliability features).
+
+VCR cassettes are used for happy-path tests that make real HTTP calls.
+Mocks are retained for error handling tests (timeout, rate limit, auth errors).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import httpx
+import pytest
 
 
 def test_status_constants():
     """Test that status constants are defined."""
     from llm_council.openrouter import (
-        STATUS_OK,
-        STATUS_TIMEOUT,
-        STATUS_RATE_LIMITED,
         STATUS_AUTH_ERROR,
         STATUS_ERROR,
+        STATUS_OK,
+        STATUS_RATE_LIMITED,
+        STATUS_TIMEOUT,
     )
 
     assert STATUS_OK == "ok"
@@ -22,25 +28,14 @@ def test_status_constants():
 
 
 @pytest.mark.asyncio
+@pytest.mark.vcr()
 async def test_query_model_with_status_success():
     """Test query_model_with_status returns structured result on success."""
-    from llm_council.openrouter import query_model_with_status, STATUS_OK
+    from llm_council.openrouter import STATUS_OK, query_model_with_status
 
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "choices": [{"message": {"content": "Test response"}}],
-        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
-    }
-    mock_response.raise_for_status = MagicMock()
-
-    with patch('llm_council.openrouter.OPENROUTER_API_KEY', 'test-key'), \
-         patch('httpx.AsyncClient') as mock_client:
-        mock_client.return_value.__aenter__.return_value.post = AsyncMock(return_value=mock_response)
-
+    with patch("llm_council.openrouter.OPENROUTER_API_KEY", "test-key"):
         result = await query_model_with_status(
-            "test-model",
-            [{"role": "user", "content": "test"}]
+            "test-model", [{"role": "user", "content": "test"}]
         )
 
         assert result["status"] == STATUS_OK
@@ -52,18 +47,17 @@ async def test_query_model_with_status_success():
 @pytest.mark.asyncio
 async def test_query_model_with_status_timeout():
     """Test query_model_with_status handles timeout correctly."""
-    from llm_council.openrouter import query_model_with_status, STATUS_TIMEOUT
+    from llm_council.openrouter import STATUS_TIMEOUT, query_model_with_status
 
-    with patch('llm_council.openrouter.OPENROUTER_API_KEY', 'test-key'), \
-         patch('httpx.AsyncClient') as mock_client:
+    with patch("llm_council.openrouter.OPENROUTER_API_KEY", "test-key"), patch(
+        "httpx.AsyncClient"
+    ) as mock_client:
         mock_client.return_value.__aenter__.return_value.post = AsyncMock(
             side_effect=httpx.TimeoutException("Connection timeout")
         )
 
         result = await query_model_with_status(
-            "test-model",
-            [{"role": "user", "content": "test"}],
-            timeout=5.0
+            "test-model", [{"role": "user", "content": "test"}], timeout=5.0
         )
 
         assert result["status"] == STATUS_TIMEOUT
@@ -74,19 +68,21 @@ async def test_query_model_with_status_timeout():
 @pytest.mark.asyncio
 async def test_query_model_with_status_rate_limited():
     """Test query_model_with_status handles rate limiting (429)."""
-    from llm_council.openrouter import query_model_with_status, STATUS_RATE_LIMITED
+    from llm_council.openrouter import STATUS_RATE_LIMITED, query_model_with_status
 
     mock_response = MagicMock()
     mock_response.status_code = 429
     mock_response.headers = {"Retry-After": "30"}
 
-    with patch('llm_council.openrouter.OPENROUTER_API_KEY', 'test-key'), \
-         patch('httpx.AsyncClient') as mock_client:
-        mock_client.return_value.__aenter__.return_value.post = AsyncMock(return_value=mock_response)
+    with patch("llm_council.openrouter.OPENROUTER_API_KEY", "test-key"), patch(
+        "httpx.AsyncClient"
+    ) as mock_client:
+        mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+            return_value=mock_response
+        )
 
         result = await query_model_with_status(
-            "test-model",
-            [{"role": "user", "content": "test"}]
+            "test-model", [{"role": "user", "content": "test"}]
         )
 
         assert result["status"] == STATUS_RATE_LIMITED
@@ -97,18 +93,20 @@ async def test_query_model_with_status_rate_limited():
 @pytest.mark.asyncio
 async def test_query_model_with_status_auth_error():
     """Test query_model_with_status handles auth errors (401/403)."""
-    from llm_council.openrouter import query_model_with_status, STATUS_AUTH_ERROR
+    from llm_council.openrouter import STATUS_AUTH_ERROR, query_model_with_status
 
     mock_response = MagicMock()
     mock_response.status_code = 401
 
-    with patch('llm_council.openrouter.OPENROUTER_API_KEY', 'test-key'), \
-         patch('httpx.AsyncClient') as mock_client:
-        mock_client.return_value.__aenter__.return_value.post = AsyncMock(return_value=mock_response)
+    with patch("llm_council.openrouter.OPENROUTER_API_KEY", "test-key"), patch(
+        "httpx.AsyncClient"
+    ) as mock_client:
+        mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+            return_value=mock_response
+        )
 
         result = await query_model_with_status(
-            "test-model",
-            [{"role": "user", "content": "test"}]
+            "test-model", [{"role": "user", "content": "test"}]
         )
 
         assert result["status"] == STATUS_AUTH_ERROR
@@ -118,17 +116,17 @@ async def test_query_model_with_status_auth_error():
 @pytest.mark.asyncio
 async def test_query_model_with_status_generic_error():
     """Test query_model_with_status handles generic errors."""
-    from llm_council.openrouter import query_model_with_status, STATUS_ERROR
+    from llm_council.openrouter import STATUS_ERROR, query_model_with_status
 
-    with patch('llm_council.openrouter.OPENROUTER_API_KEY', 'test-key'), \
-         patch('httpx.AsyncClient') as mock_client:
+    with patch("llm_council.openrouter.OPENROUTER_API_KEY", "test-key"), patch(
+        "httpx.AsyncClient"
+    ) as mock_client:
         mock_client.return_value.__aenter__.return_value.post = AsyncMock(
             side_effect=Exception("Network error")
         )
 
         result = await query_model_with_status(
-            "test-model",
-            [{"role": "user", "content": "test"}]
+            "test-model", [{"role": "user", "content": "test"}]
         )
 
         assert result["status"] == STATUS_ERROR
@@ -141,46 +139,34 @@ async def test_query_model_backwards_compatible():
     """Test that query_model still returns None on failure (backwards compatibility)."""
     from llm_council.openrouter import query_model
 
-    with patch('llm_council.openrouter.OPENROUTER_API_KEY', 'test-key'), \
-         patch('httpx.AsyncClient') as mock_client:
+    with patch("llm_council.openrouter.OPENROUTER_API_KEY", "test-key"), patch(
+        "httpx.AsyncClient"
+    ) as mock_client:
         mock_client.return_value.__aenter__.return_value.post = AsyncMock(
             side_effect=httpx.TimeoutException("Connection timeout")
         )
 
-        result = await query_model(
-            "test-model",
-            [{"role": "user", "content": "test"}]
-        )
+        result = await query_model("test-model", [{"role": "user", "content": "test"}])
 
         assert result is None
 
 
 @pytest.mark.asyncio
+@pytest.mark.vcr()
 async def test_query_models_with_progress():
     """Test query_models_with_progress calls progress callback."""
-    from llm_council.openrouter import query_models_with_progress, STATUS_OK
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "choices": [{"message": {"content": "Test"}}],
-        "usage": {},
-    }
-    mock_response.raise_for_status = MagicMock()
+    from llm_council.openrouter import STATUS_OK, query_models_with_progress
 
     progress_calls = []
 
     async def track_progress(completed, total, message):
         progress_calls.append((completed, total, message))
 
-    with patch('llm_council.openrouter.OPENROUTER_API_KEY', 'test-key'), \
-         patch('httpx.AsyncClient') as mock_client:
-        mock_client.return_value.__aenter__.return_value.post = AsyncMock(return_value=mock_response)
-
+    with patch("llm_council.openrouter.OPENROUTER_API_KEY", "test-key"):
         results = await query_models_with_progress(
             ["model-a", "model-b"],
             [{"role": "user", "content": "test"}],
-            on_progress=track_progress
+            on_progress=track_progress,
         )
 
         # Should have initial progress + one per model
@@ -190,26 +176,14 @@ async def test_query_models_with_progress():
 
 
 @pytest.mark.asyncio
+@pytest.mark.vcr()
 async def test_query_models_with_progress_no_callback():
     """Test query_models_with_progress works without callback."""
-    from llm_council.openrouter import query_models_with_progress, STATUS_OK
+    from llm_council.openrouter import STATUS_OK, query_models_with_progress
 
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "choices": [{"message": {"content": "Test"}}],
-        "usage": {},
-    }
-    mock_response.raise_for_status = MagicMock()
-
-    with patch('llm_council.openrouter.OPENROUTER_API_KEY', 'test-key'), \
-         patch('httpx.AsyncClient') as mock_client:
-        mock_client.return_value.__aenter__.return_value.post = AsyncMock(return_value=mock_response)
-
+    with patch("llm_council.openrouter.OPENROUTER_API_KEY", "test-key"):
         results = await query_models_with_progress(
-            ["model-a"],
-            [{"role": "user", "content": "test"}],
-            on_progress=None  # No callback
+            ["model-a"], [{"role": "user", "content": "test"}], on_progress=None
         )
 
         assert results["model-a"]["status"] == STATUS_OK

--- a/tests/test_openrouter_client.py
+++ b/tests/test_openrouter_client.py
@@ -1,129 +1,71 @@
 """TDD tests for ADR-026: OpenRouter API Client.
 
 Tests for the OpenRouter Models API client that fetches model metadata.
+
+VCR cassettes are used for happy-path tests that make real HTTP calls.
+Mocks are retained for error handling tests (timeout, connection error, rate limit).
 """
 
-import pytest
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
+
 import httpx
+import pytest
 
 
 class TestOpenRouterClient:
     """Test OpenRouterClient API interactions."""
 
     @pytest.mark.asyncio
+    @pytest.mark.vcr()
     async def test_fetch_models_returns_model_list(self):
         """fetch_models() should return list of ModelInfo."""
         from llm_council.metadata.openrouter_client import OpenRouterClient
         from llm_council.metadata.types import ModelInfo
 
-        mock_response = {
-            "data": [
-                {
-                    "id": "openai/gpt-4o",
-                    "name": "GPT-4o",
-                    "context_length": 128000,
-                    "pricing": {"prompt": "0.0025", "completion": "0.01"},
-                    "architecture": {"input_modalities": ["text", "image"]},
-                    "supported_parameters": ["temperature", "top_p"],
-                }
-            ]
-        }
+        client = OpenRouterClient(api_key="test-key")
+        models = await client.fetch_models()
 
-        with patch("httpx.AsyncClient") as MockClient:
-            mock_client_instance = AsyncMock()
-            mock_response_obj = MagicMock()
-            mock_response_obj.status_code = 200
-            mock_response_obj.json.return_value = mock_response
-            mock_response_obj.raise_for_status = MagicMock()
-            mock_client_instance.get = AsyncMock(return_value=mock_response_obj)
-            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
-            mock_client_instance.__aexit__ = AsyncMock(return_value=None)
-            MockClient.return_value = mock_client_instance
-
-            client = OpenRouterClient()
-            models = await client.fetch_models()
-
-            assert len(models) == 1
-            assert isinstance(models[0], ModelInfo)
-            assert models[0].id == "openai/gpt-4o"
-            assert models[0].context_window == 128000
+        assert len(models) == 1
+        assert isinstance(models[0], ModelInfo)
+        assert models[0].id == "openai/gpt-4o"
+        assert models[0].context_window == 128000
 
     @pytest.mark.asyncio
+    @pytest.mark.vcr()
     async def test_fetch_models_extracts_pricing_correctly(self):
         """Pricing should be converted from string to float."""
         from llm_council.metadata.openrouter_client import OpenRouterClient
 
-        mock_response = {
-            "data": [
-                {
-                    "id": "test/model",
-                    "context_length": 4096,
-                    "pricing": {"prompt": "0.0025", "completion": "0.01"},
-                }
-            ]
-        }
+        client = OpenRouterClient(api_key="test-key")
+        models = await client.fetch_models()
 
-        with patch("httpx.AsyncClient") as MockClient:
-            mock_client_instance = AsyncMock()
-            mock_response_obj = MagicMock()
-            mock_response_obj.status_code = 200
-            mock_response_obj.json.return_value = mock_response
-            mock_response_obj.raise_for_status = MagicMock()
-            mock_client_instance.get = AsyncMock(return_value=mock_response_obj)
-            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
-            mock_client_instance.__aexit__ = AsyncMock(return_value=None)
-            MockClient.return_value = mock_client_instance
-
-            client = OpenRouterClient()
-            models = await client.fetch_models()
-
-            assert models[0].pricing == {"prompt": 0.0025, "completion": 0.01}
+        assert models[0].pricing == {"prompt": 0.0025, "completion": 0.01}
 
     @pytest.mark.asyncio
+    @pytest.mark.vcr()
     async def test_fetch_models_extracts_modalities(self):
         """Modalities should be extracted from architecture."""
         from llm_council.metadata.openrouter_client import OpenRouterClient
 
-        mock_response = {
-            "data": [
-                {
-                    "id": "test/model",
-                    "context_length": 4096,
-                    "architecture": {"input_modalities": ["text", "image"]},
-                }
-            ]
-        }
+        client = OpenRouterClient(api_key="test-key")
+        models = await client.fetch_models()
 
-        with patch("httpx.AsyncClient") as MockClient:
-            mock_client_instance = AsyncMock()
-            mock_response_obj = MagicMock()
-            mock_response_obj.status_code = 200
-            mock_response_obj.json.return_value = mock_response
-            mock_response_obj.raise_for_status = MagicMock()
-            mock_client_instance.get = AsyncMock(return_value=mock_response_obj)
-            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
-            mock_client_instance.__aexit__ = AsyncMock(return_value=None)
-            MockClient.return_value = mock_client_instance
-
-            client = OpenRouterClient()
-            models = await client.fetch_models()
-
-            assert "text" in models[0].modalities
-            # Image should be normalized to vision
-            assert "vision" in models[0].modalities
+        assert "text" in models[0].modalities
+        # Image should be normalized to vision
+        assert "vision" in models[0].modalities
 
     @pytest.mark.asyncio
     async def test_fetch_models_handles_timeout(self):
         """Should return empty list on timeout."""
         from llm_council.metadata.openrouter_client import OpenRouterClient
 
-        with patch("httpx.AsyncClient") as MockClient:
+        with patch("httpx.AsyncClient") as mock_client_cls:
             mock_client_instance = AsyncMock()
             mock_client_instance.get = AsyncMock(side_effect=httpx.TimeoutException("Timeout"))
             mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
             mock_client_instance.__aexit__ = AsyncMock(return_value=None)
-            MockClient.return_value = mock_client_instance
+            mock_client_cls.return_value = mock_client_instance
 
             client = OpenRouterClient()
             models = await client.fetch_models()
@@ -135,12 +77,12 @@ class TestOpenRouterClient:
         """Should return empty list on connection error."""
         from llm_council.metadata.openrouter_client import OpenRouterClient
 
-        with patch("httpx.AsyncClient") as MockClient:
+        with patch("httpx.AsyncClient") as mock_client_cls:
             mock_client_instance = AsyncMock()
             mock_client_instance.get = AsyncMock(side_effect=httpx.ConnectError("Connection failed"))
             mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
             mock_client_instance.__aexit__ = AsyncMock(return_value=None)
-            MockClient.return_value = mock_client_instance
+            mock_client_cls.return_value = mock_client_instance
 
             client = OpenRouterClient()
             models = await client.fetch_models()
@@ -152,7 +94,7 @@ class TestOpenRouterClient:
         """Should return empty list on 429 rate limit."""
         from llm_council.metadata.openrouter_client import OpenRouterClient
 
-        with patch("httpx.AsyncClient") as MockClient:
+        with patch("httpx.AsyncClient") as mock_client_cls:
             mock_client_instance = AsyncMock()
             mock_response_obj = MagicMock()
             mock_response_obj.status_code = 429
@@ -163,7 +105,7 @@ class TestOpenRouterClient:
             mock_client_instance.get = AsyncMock(return_value=mock_response_obj)
             mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
             mock_client_instance.__aexit__ = AsyncMock(return_value=None)
-            MockClient.return_value = mock_client_instance
+            mock_client_cls.return_value = mock_client_instance
 
             client = OpenRouterClient()
             models = await client.fetch_models()
@@ -177,7 +119,7 @@ class TestOpenRouterClient:
 
         mock_response = {"data": []}
 
-        with patch("httpx.AsyncClient") as MockClient:
+        with patch("httpx.AsyncClient") as mock_client_cls:
             mock_client_instance = AsyncMock()
             mock_response_obj = MagicMock()
             mock_response_obj.status_code = 200
@@ -186,7 +128,7 @@ class TestOpenRouterClient:
             mock_client_instance.get = AsyncMock(return_value=mock_response_obj)
             mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
             mock_client_instance.__aexit__ = AsyncMock(return_value=None)
-            MockClient.return_value = mock_client_instance
+            mock_client_cls.return_value = mock_client_instance
 
             client = OpenRouterClient(api_key="test-api-key")
             await client.fetch_models()
@@ -203,7 +145,7 @@ class TestOpenRouterClient:
 
         mock_response = {"data": []}
 
-        with patch("httpx.AsyncClient") as MockClient:
+        with patch("httpx.AsyncClient") as mock_client_cls:
             mock_client_instance = AsyncMock()
             mock_response_obj = MagicMock()
             mock_response_obj.status_code = 200
@@ -212,7 +154,7 @@ class TestOpenRouterClient:
             mock_client_instance.get = AsyncMock(return_value=mock_response_obj)
             mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
             mock_client_instance.__aexit__ = AsyncMock(return_value=None)
-            MockClient.return_value = mock_client_instance
+            mock_client_cls.return_value = mock_client_instance
 
             client = OpenRouterClient()
             await client.fetch_models()
@@ -359,7 +301,6 @@ class TestOpenRouterClientConfiguration:
     def test_client_reads_api_key_from_env(self):
         """Client should read API key from environment if not provided."""
         from llm_council.metadata.openrouter_client import OpenRouterClient
-        import os
 
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "env-api-key"}):
             client = OpenRouterClient()
@@ -368,7 +309,6 @@ class TestOpenRouterClientConfiguration:
     def test_client_explicit_api_key_overrides_env(self):
         """Explicit API key should override environment variable."""
         from llm_council.metadata.openrouter_client import OpenRouterClient
-        import os
 
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "env-api-key"}):
             client = OpenRouterClient(api_key="explicit-key")


### PR DESCRIPTION
## Summary
- Migrated 6 happy-path API tests from mocks to VCR cassettes
- VCR provides more realistic HTTP interaction testing
- Mocks retained for error handling (timeout, rate limit, connection errors)

## Changes
- **test_openrouter_client.py**: 3 tests migrated to VCR
- **test_openrouter.py**: 3 tests migrated to VCR  
- Created 6 cassette files in `tests/cassettes/`
- Fixed N806 lint violations (MockClient → mock_client_cls)

## Test Plan
- [x] All 29 tests in migrated files pass
- [x] Lint passes (ruff check)
- [x] VCR cassettes replay correctly

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)