### PR TITLE
feat(registry): Add missing models for tier pools

### DIFF
--- a/src/llm_council/models/registry.yaml
+++ b/src/llm_council/models/registry.yaml
@@ -11,12 +11,12 @@
 #   modalities: List of input modalities (text, vision, audio)
 #   quality_tier: frontier | standard | economy | local
 
-version: "1.0"
-updated: "2025-12-23"
+version: "1.1"
+updated: "2025-12-28"
 
 models:
   # ============================================================================
-  # OpenAI Models (7)
+  # OpenAI Models (9)
   # ============================================================================
   - id: "openai/gpt-4o"
     context_window: 128000
@@ -44,6 +44,24 @@ models:
     supported_parameters: ["temperature", "top_p", "tools", "json_mode", "reasoning"]
     modalities: ["text", "vision"]
     quality_tier: "frontier"
+
+  - id: "openai/gpt-5.2"
+    context_window: 400000
+    pricing:
+      prompt: 0.00175
+      completion: 0.014
+    supported_parameters: ["temperature", "top_p", "tools", "json_mode", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "frontier"
+
+  - id: "openai/gpt-5-mini"
+    context_window: 400000
+    pricing:
+      prompt: 0.00025
+      completion: 0.002
+    supported_parameters: ["temperature", "top_p", "tools", "json_mode", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "economy"
 
   - id: "openai/o1"
     context_window: 200000
@@ -82,7 +100,7 @@ models:
     quality_tier: "standard"
 
   # ============================================================================
-  # Anthropic Models (5)
+  # Anthropic Models (7)
   # ============================================================================
   - id: "anthropic/claude-opus-4.5"
     context_window: 200000
@@ -92,6 +110,24 @@ models:
     supported_parameters: ["temperature", "top_p", "tools"]
     modalities: ["text", "vision"]
     quality_tier: "frontier"
+
+  - id: "anthropic/claude-sonnet-4.5"
+    context_window: 200000
+    pricing:
+      prompt: 0.003
+      completion: 0.015
+    supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "frontier"
+
+  - id: "anthropic/claude-haiku-4.5"
+    context_window: 200000
+    pricing:
+      prompt: 0.001
+      completion: 0.005
+    supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "economy"
 
   - id: "anthropic/claude-3-5-sonnet-20241022"
     context_window: 200000
@@ -130,7 +166,7 @@ models:
     quality_tier: "standard"
 
   # ============================================================================
-  # Google Models (5)
+  # Google Models (6)
   # ============================================================================
   - id: "google/gemini-3-pro-preview"
     context_window: 1000000
@@ -140,6 +176,15 @@ models:
     supported_parameters: ["temperature", "top_p", "tools"]
     modalities: ["text", "vision"]
     quality_tier: "frontier"
+
+  - id: "google/gemini-3-flash-preview"
+    context_window: 1048576
+    pricing:
+      prompt: 0.0005
+      completion: 0.003
+    supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
+    modalities: ["text", "vision", "audio"]
+    quality_tier: "economy"
 
   - id: "google/gemini-2.5-pro-preview"
     context_window: 1000000
@@ -178,7 +223,7 @@ models:
     quality_tier: "economy"
 
   # ============================================================================
-  # xAI Models (2)
+  # xAI Models (3)
   # ============================================================================
   - id: "x-ai/grok-4"
     context_window: 131072
@@ -195,6 +240,15 @@ models:
       prompt: 0.0005
       completion: 0.002
     supported_parameters: ["temperature", "top_p", "tools"]
+    modalities: ["text"]
+    quality_tier: "economy"
+
+  - id: "x-ai/grok-code-fast-1"
+    context_window: 256000
+    pricing:
+      prompt: 0.0002
+      completion: 0.0015
+    supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
     modalities: ["text"]
     quality_tier: "economy"
 


### PR DESCRIPTION
## Summary

Adds 6 models to `registry.yaml` that are referenced in `unified_config.py` TierConfig but were missing from the offline registry.

## Models Added

| Model ID | Context | Pricing (per 1M) | Quality Tier |
|----------|---------|------------------|--------------|
| `openai/gpt-5-mini` | 400K | $0.25 / $2.00 | economy |
| `openai/gpt-5.2` | 400K | $1.75 / $14.00 | frontier |
| `anthropic/claude-sonnet-4.5` | 200K | $3.00 / $15.00 | frontier |
| `anthropic/claude-haiku-4.5` | 200K | $1.00 / $5.00 | economy |
| `google/gemini-3-flash-preview` | 1M | $0.50 / $3.00 | economy |
| `x-ai/grok-code-fast-1` | 256K | $0.20 / $1.50 | economy |

## Sources

Specifications researched from:
- [OpenRouter API](https://openrouter.ai/api/v1/models)
- [OpenRouter Models](https://openrouter.ai/models)
- [Anthropic Claude Sonnet 4.5](https://www.anthropic.com/news/claude-sonnet-4-5)
- [xAI Grok Code Fast 1](https://x.ai/news/grok-code-fast-1)

## Test plan

- [x] Verify registry.yaml parses correctly
- [x] Test offline mode with new models
- [x] CI passes

Fixes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)