### PR TITLE
fix(mcp): Add llm-council-mcp entry point and fix .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -20,8 +20,8 @@
     },
     "llm-council": {
       "type": "stdio",
-      "command": "/Users/christopherjoseph/projects/amiable/llm-council/.venv/bin/llm-council",
-      "args": [],
+      "command": "/Users/christopherjoseph/.local/share/mise/installs/python/3.11.14/bin/python3",
+      "args": ["-m", "llm_council.mcp_server"],
       "env": {}
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ Documentation = "https://llm-council.dev"
 
 [project.scripts]
 llm-council = "llm_council.cli:main"
+llm-council-mcp = "llm_council.mcp_server:main"
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]


### PR DESCRIPTION
## Summary

Fixes MCP server not starting in Claude Code.

## Root Cause

1. `.mcp.json` was configured to run `llm-council` CLI which executes `cli:main`
2. The MCP server is in `mcp_server:main` but had no CLI entry point
3. The command was pointing to `.venv` instead of the installed package

## Changes

- **pyproject.toml**: Add `llm-council-mcp` entry point for MCP server
- **.mcp.json**: Update to run `python -m llm_council.mcp_server`

## Test Plan

- [ ] Run `/mcp` in Claude Code to verify server starts
- [ ] Test `consult_council` tool works

🤖 Generated with [Claude Code](https://claude.com/claude-code)