### PR TITLE
docs: Update ADR-035 to reflect SLSA Level 3 implementation

### DIFF
--- a/docs/adr/ADR-035-devsecops-implementation.md
+++ b/docs/adr/ADR-035-devsecops-implementation.md
@@ -821,7 +821,6 @@ The council unanimously agreed that the **Layered Architecture** (fork-compatibl
 |----------------|--------|
 | Garak/Promptfoo LLM red-teaming | No runtime API yet; implement with Council Cloud |
 | Socket.dev for typosquatting | pip-audit covers basic cases; Socket is Phase 5 |
-| Full SLSA Level 3 | Level 2 sufficient initially; Level 3 in Phase 5 |
 
 ---
 
@@ -854,14 +853,19 @@ The ADR was reviewed by the LLM Council using reasoning tier (openai/o1, google/
 | Recommendation | Reason |
 |----------------|--------|
 | Modelscan/Picklescan | LLM Council doesn't load external model weights |
-| SLSA/Sigstore provenance | Adds complexity, implement in Phase 5 |
 | Custom Semgrep rules for prompts | Create after establishing patterns |
+
+### Recommendations Implemented (Post-Review)
+
+| Recommendation | Implementation |
+|----------------|----------------|
+| SLSA/Sigstore provenance | Implemented as SLSA Level 3 in Phase 4 using `actions/attest-build-provenance` |
 
 ## References
 
 - [GitHub Security Features](https://docs.github.com/en/code-security)
 - [OWASP DevSecOps Guideline](https://owasp.org/www-project-devsecops-guideline/)
-- [OpenSSF Scorecard](https://securityscorecards.dev/)
+- [OpenSSF Scorecard](https://scorecard.dev/)
 - [CycloneDX Specification](https://cyclonedx.org/specification/overview/)
 - [Trivy Documentation](https://aquasecurity.github.io/trivy/)
 - [Semgrep Registry](https://semgrep.dev/r)


### PR DESCRIPTION
## Summary
Follow-up documentation fixes that were missed in #234 squash merge.

## Changes
- Remove outdated "Full SLSA Level 3 | Level 2 sufficient initially" deferral
- Remove "SLSA/Sigstore provenance | implement in Phase 5" from deferred list
- Add "Recommendations Implemented (Post-Review)" section documenting SLSA implementation
- Fix OpenSSF Scorecard URL (`securityscorecards.dev` → `scorecard.dev`)

## Context
PR #234 was squash-merged before the second documentation commit was pushed, so these fixes need a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)