### PR TITLE
fix(deploy): Wrap Railway start command in shell for $PORT expansion

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "dockerfilePath": "deploy/railway/Dockerfile"
   },
   "deploy": {
-    "startCommand": "llm-council serve --host 0.0.0.0 --port $PORT",
+    "startCommand": "sh -c 'llm-council serve --host 0.0.0.0 --port $PORT'",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 30,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
## Summary

Fixes Railway deployment failure where `$PORT` was not being expanded.

## Problem

Railway deployment failed with:
```
llm-council serve: error: argument --port: invalid int value: '$PORT'
```

## Root Cause

The `startCommand` in `railway.json` used `$PORT` directly, but Railway executes commands without shell interpretation by default.

## Solution

Wrap the command in `sh -c '...'` to enable shell variable expansion:

```diff
- "startCommand": "llm-council serve --host 0.0.0.0 --port $PORT"
+ "startCommand": "sh -c 'llm-council serve --host 0.0.0.0 --port $PORT'"
```

## Testing

After merging, redeploy on Railway to verify:
1. Build completes
2. Health check passes (`/health` returns 200)
3. API responds correctly

Fixes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)