### PR TITLE
fix(docs): Correct API response example in deployment blog post

### DIFF
--- a/docs/blog/09-one-click-deployment.md
+++ b/docs/blog/09-one-click-deployment.md
@@ -148,13 +148,16 @@ The council is now running at `http://localhost:8000`.
      -d '{"prompt": "What is the capital of France?"}'
    ```
 
-   A successful council response looks like:
+   A successful response returns the 3-stage deliberation results plus metadata:
    ```json
    {
-     "stage1": [...],
-     "stage2": [...],
+     "stage1": [{"model": "...", "content": "..."}],
+     "stage2": [{"model": "...", "evaluation": "...", "parsed_ranking": [...]}],
      "stage3": {"synthesis": "Paris is the capital of France..."},
-     "metadata": {"tier": "balanced", "models_used": 3}
+     "metadata": {
+       "aggregate_rankings": {"Response A": 1.5, "Response B": 2.0},
+       "config": {"council_size": 3, "verdict_type": "synthesis"}
+     }
    }
    ```
 


### PR DESCRIPTION
## Summary

Fixes the example API response in the one-click deployment blog post which showed fictional metadata fields that don't exist in the actual API.

## Changes

The previous example showed:
```json
"metadata": {"tier": "balanced", "models_used": 3}
```

Updated to reflect the actual response structure:
```json
"metadata": {
  "aggregate_rankings": {"Response A": 1.5, "Response B": 2.0},
  "config": {"council_size": 3, "verdict_type": "synthesis"}
}
```

## Test Plan

- [x] Verified actual API response structure in `src/llm_council/council.py` (lines 2053-2070)
- [x] Verified `CouncilResponse` model in `src/llm_council/http_server.py` (lines 128-134)

🤖 Generated with [Claude Code](https://claude.com/claude-code)