### PR TITLE
docs: Remove badges from homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,16 +8,6 @@
   </div>
 </div>
 
-<div class="badges" markdown>
-[![CI](https://github.com/amiable-dev/llm-council/actions/workflows/ci.yml/badge.svg)](https://github.com/amiable-dev/llm-council/actions/workflows/ci.yml)
-[![Security](https://github.com/amiable-dev/llm-council/actions/workflows/security.yml/badge.svg)](https://github.com/amiable-dev/llm-council/actions/workflows/security.yml)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/amiable-dev/llm-council/badge)](https://scorecard.dev/viewer/?uri=github.com/amiable-dev/llm-council)
-[![PyPI](https://img.shields.io/pypi/v/llm-council-core.svg)](https://pypi.org/project/llm-council-core/)
-[![Python](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
-[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Roadmap](https://img.shields.io/badge/roadmap-project%20board-blue?logo=github)](https://github.com/users/amiable-dev/projects/1)
-</div>
-
 ## What is LLM Council?
 
 Instead of asking a single LLM for answers, LLM Council:

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -57,7 +57,7 @@
 
 .hero .hero-buttons a:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
 .hero .hero-buttons .primary {
@@ -104,28 +104,4 @@
 /* Navigation */
 .md-nav__link {
   font-size: 0.75rem;
-}
-
-/* Badges section */
-.badges {
-  text-align: center;
-  margin: 1.5rem 0 2rem;
-  padding: 0 1rem;
-}
-
-.badges p {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.5rem;
-  margin: 0;
-}
-
-.badges a {
-  display: inline-block;
-}
-
-.badges img {
-  height: 20px;
-  vertical-align: middle;
 }


### PR DESCRIPTION
## Summary

Remove badge clutter from the documentation homepage for a cleaner look.

Badges remain visible on:
- GitHub README
- PyPI package page

## Changes

- Remove badges section from `docs/index.md`
- Remove `.badges` CSS styling from `docs/stylesheets/extra.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)