### PR TITLE
feat(verification): Add VerificationRequest and VerificationResult types

### DIFF
--- a/src/llm_council/verification/__init__.py
+++ b/src/llm_council/verification/__init__.py
@@ -1,0 +1,32 @@
+"""
+Verification module for ADR-034 Agent Skills Integration.
+
+Provides types, context isolation, transcript persistence, and API
+for structured work verification using LLM Council deliberation.
+"""
+
+from llm_council.verification.types import (
+    AgentIdentifier,
+    BlockingIssue,
+    ConsensusResult,
+    IssueSeverity,
+    RubricScores,
+    VerdictType,
+    VerificationContext,
+    VerificationRequest,
+    VerificationResult,
+    VerifierResponse,
+)
+
+__all__ = [
+    "AgentIdentifier",
+    "BlockingIssue",
+    "ConsensusResult",
+    "IssueSeverity",
+    "RubricScores",
+    "VerdictType",
+    "VerificationContext",
+    "VerificationRequest",
+    "VerificationResult",
+    "VerifierResponse",
+]

--- a/src/llm_council/verification/types.py
+++ b/src/llm_council/verification/types.py
@@ -1,0 +1,222 @@
+"""
+Verification types for ADR-034 Agent Skills Integration.
+
+Defines Pydantic models for:
+- VerificationRequest: Input schema for verification API
+- VerificationResult: Output schema with machine-actionable verdict
+- Supporting types: VerdictType, RubricScores, BlockingIssue, etc.
+
+These types match the JSON schema defined in ADR-034 and support
+cross-agent consistency validation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class VerdictType(str, Enum):
+    """Verification verdict types per ADR-034."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    UNCLEAR = "unclear"
+
+
+class IssueSeverity(str, Enum):
+    """Severity levels for blocking issues."""
+
+    CRITICAL = "critical"
+    MAJOR = "major"
+    MINOR = "minor"
+
+
+class AgentIdentifier(str, Enum):
+    """Known agent platforms for cross-agent consistency tracking."""
+
+    CLAUDE_CODE = "claude-code"
+    GITHUB_COPILOT = "github-copilot"
+    CURSOR = "cursor"
+    CODEX_CLI = "codex-cli"
+    VS_CODE = "vs-code"
+    WINDSURF = "windsurf"
+    CLINE = "cline"
+    UNKNOWN = "unknown"
+
+
+class RubricScores(BaseModel):
+    """Multi-dimensional rubric scores per ADR-016."""
+
+    accuracy: float = Field(..., ge=0, le=10, description="Correctness score (0-10)")
+    completeness: float = Field(..., ge=0, le=10, description="Completeness score (0-10)")
+    clarity: float = Field(..., ge=0, le=10, description="Clarity score (0-10)")
+    conciseness: float = Field(..., ge=0, le=10, description="Conciseness score (0-10)")
+    relevance: Optional[float] = Field(None, ge=0, le=10, description="Relevance score (0-10)")
+
+
+class BlockingIssue(BaseModel):
+    """A blocking issue that caused verification to fail."""
+
+    severity: IssueSeverity = Field(..., description="Issue severity level")
+    file: str = Field(..., description="File path where issue was found")
+    line: Optional[int] = Field(None, description="Line number (1-based)")
+    message: str = Field(..., description="Description of the issue")
+
+
+class VerificationContext(BaseModel):
+    """
+    Isolated verification context per ADR-034.
+
+    Context is fresh for each verification, not inherited from session.
+    This ensures verification independence and reproducibility.
+    """
+
+    session_id: Optional[str] = Field(
+        default=None, description="Session ID (empty for isolated context)"
+    )
+    inherited_from_session: bool = Field(
+        default=False, description="Whether context was inherited (should be False)"
+    )
+
+
+class VerificationRequest(BaseModel):
+    """
+    Request schema for verification API per ADR-034.
+
+    Requires snapshot_id for reproducibility and target_paths
+    to specify what should be verified.
+    """
+
+    snapshot_id: str = Field(..., min_length=1, description="Git commit SHA for reproducibility")
+    target_paths: List[str] = Field(..., min_length=1, description="Files or directories to verify")
+    rubric_focus: Optional[str] = Field(
+        None, description="Optional focus area (Security, Performance, etc.)"
+    )
+    context: VerificationContext = Field(
+        default_factory=VerificationContext,
+        description="Isolated verification context",
+    )
+    confidence_threshold: float = Field(
+        default=0.7, ge=0, le=1, description="Minimum confidence for PASS verdict"
+    )
+
+    @field_validator("target_paths")
+    @classmethod
+    def validate_target_paths(cls, v: List[str]) -> List[str]:
+        """Ensure target_paths is not empty."""
+        if not v:
+            raise ValueError("target_paths must contain at least one path")
+        return v
+
+
+class VerifierResponse(BaseModel):
+    """Response from a single verifier model."""
+
+    model_id: str = Field(..., description="Model identifier")
+    verdict: VerdictType = Field(..., description="Model's verdict")
+    confidence: float = Field(..., ge=0, le=1, description="Model's confidence")
+    rationale: Optional[str] = Field(None, description="Model's reasoning")
+    rubric_scores: Optional[RubricScores] = Field(None, description="Detailed rubric scores")
+
+
+class ConsensusResult(BaseModel):
+    """Aggregated consensus from all verifiers."""
+
+    decision: VerdictType = Field(..., description="Final consensus verdict")
+    agreement_ratio: float = Field(..., ge=0, le=1, description="Ratio of verifiers agreeing")
+    dissenting_models: List[str] = Field(default_factory=list, description="Models that disagreed")
+
+
+class VersionInfo(BaseModel):
+    """Version information for reproducibility."""
+
+    rubric: str = Field(default="1.0", description="Rubric version")
+    models: List[str] = Field(default_factory=list, description="Model versions used")
+    aggregator: Optional[str] = Field(None, description="Aggregator/chairman model")
+
+
+class VerificationResult(BaseModel):
+    """
+    Result schema for verification API per ADR-034.
+
+    Provides machine-actionable output with verdict, confidence,
+    blocking issues, and full audit trail support.
+
+    Supports cross-agent consistency validation for multi-platform
+    verification (Claude Code, GitHub Copilot, Cursor, etc.).
+    """
+
+    # Core identification
+    verification_id: str = Field(..., description="Unique verification ID")
+
+    # Core verification properties
+    verdict: VerdictType = Field(..., description="Final verdict: pass/fail/unclear")
+    confidence: float = Field(..., ge=0, le=1, description="Confidence score (0-1)")
+    timestamp: datetime = Field(..., description="Verification timestamp (UTC)")
+
+    # Response integrity
+    original_response_hash: str = Field(
+        ..., description="Hash of original content for reproducibility"
+    )
+
+    # Verifier details
+    verifier_responses: List[VerifierResponse] = Field(
+        ..., description="Individual verifier responses"
+    )
+    consensus_result: ConsensusResult = Field(..., description="Aggregated consensus result")
+
+    # Detailed scoring (optional)
+    rubric_scores: Optional[RubricScores] = Field(None, description="Aggregated rubric scores")
+    blocking_issues: List[BlockingIssue] = Field(
+        default_factory=list, description="Issues that block approval"
+    )
+
+    # Synthesis
+    rationale: Optional[str] = Field(None, description="Chairman's synthesis rationale")
+    dissent: Optional[str] = Field(None, description="Notable dissenting opinions")
+
+    # Cross-agent consistency fields (ADR-034 v2.0)
+    invoking_agent: AgentIdentifier = Field(..., description="Platform that invoked verification")
+    skill_version: str = Field(..., description="SKILL.md version used")
+    protocol_version: str = Field(default="1.0", description="Verification protocol version")
+
+    # Audit trail
+    transcript_location: str = Field(..., description="Path to full transcript (.council/logs/...)")
+    reproducibility_hash: str = Field(..., description="Hash of all inputs for reproducibility")
+
+    # Version info
+    version: Optional[VersionInfo] = Field(default=None, description="Version information")
+
+    def validate_cross_agent_consistency(
+        self, reference: VerificationResult, confidence_tolerance: float = 0.01
+    ) -> bool:
+        """
+        Verify results are consistent across different invoking agents.
+
+        Per ADR-034 v2.0, verification results should be consistent
+        regardless of the invoking platform (Claude Code, Copilot, etc.).
+
+        Args:
+            reference: Another VerificationResult to compare against
+            confidence_tolerance: Maximum allowed confidence difference
+
+        Returns:
+            True if results are consistent, False otherwise
+        """
+        # Same input must produce same output
+        if self.original_response_hash != reference.original_response_hash:
+            return False
+
+        # Verdict must match
+        if self.consensus_result.decision != reference.consensus_result.decision:
+            return False
+
+        # Confidence must be within tolerance
+        if abs(self.confidence - reference.confidence) > confidence_tolerance:
+            return False
+
+        return True

--- a/tests/unit/verification/__init__.py
+++ b/tests/unit/verification/__init__.py
@@ -1,0 +1,1 @@
+# Verification tests package

--- a/tests/unit/verification/test_types.py
+++ b/tests/unit/verification/test_types.py
@@ -1,0 +1,411 @@
+"""
+Tests for verification types per ADR-034.
+
+TDD Red Phase: These tests should fail until types.py is implemented.
+"""
+
+import json
+from datetime import datetime
+from typing import List
+
+import pytest
+
+from llm_council.verification.types import (
+    AgentIdentifier,
+    BlockingIssue,
+    ConsensusResult,
+    IssueSeverity,
+    RubricScores,
+    VerdictType,
+    VerificationContext,
+    VerificationRequest,
+    VerificationResult,
+    VerifierResponse,
+)
+
+
+class TestVerificationRequest:
+    """Tests for VerificationRequest schema."""
+
+    def test_verification_request_requires_snapshot_id(self):
+        """VerificationRequest requires snapshot_id."""
+        with pytest.raises(ValueError):
+            VerificationRequest(
+                target_paths=["src/main.py"],
+                # Missing snapshot_id
+            )
+
+    def test_verification_request_requires_target_paths(self):
+        """VerificationRequest requires target_paths."""
+        with pytest.raises(ValueError):
+            VerificationRequest(
+                snapshot_id="abc123",
+                # Missing target_paths
+            )
+
+    def test_verification_request_valid_construction(self):
+        """VerificationRequest with valid fields constructs correctly."""
+        request = VerificationRequest(
+            snapshot_id="abc123def456",
+            target_paths=["src/main.py", "tests/test_main.py"],
+            rubric_focus="Security",
+        )
+        assert request.snapshot_id == "abc123def456"
+        assert len(request.target_paths) == 2
+        assert request.rubric_focus == "Security"
+
+    def test_verification_request_optional_fields(self):
+        """VerificationRequest optional fields have sensible defaults."""
+        request = VerificationRequest(
+            snapshot_id="abc123",
+            target_paths=["src/main.py"],
+        )
+        assert request.rubric_focus is None
+        assert request.context is not None  # Should have default context
+
+    def test_verification_request_serialization(self):
+        """VerificationRequest serializes to JSON correctly."""
+        request = VerificationRequest(
+            snapshot_id="abc123",
+            target_paths=["src/main.py"],
+            rubric_focus="Performance",
+        )
+        json_str = request.model_dump_json()
+        data = json.loads(json_str)
+        assert data["snapshot_id"] == "abc123"
+        assert data["target_paths"] == ["src/main.py"]
+        assert data["rubric_focus"] == "Performance"
+
+
+class TestVerificationResult:
+    """Tests for VerificationResult schema."""
+
+    def test_verification_result_required_fields(self):
+        """VerificationResult requires verdict, confidence, timestamp, version."""
+        with pytest.raises(ValueError):
+            VerificationResult(
+                # Missing required fields
+            )
+
+    def test_verification_result_verdict_enum(self):
+        """VerificationResult verdict must be pass, fail, or unclear."""
+        result = VerificationResult(
+            verification_id="test-123",
+            verdict=VerdictType.PASS,
+            confidence=0.95,
+            timestamp=datetime.utcnow(),
+            original_response_hash="abc123",
+            verifier_responses=[],
+            consensus_result=ConsensusResult(
+                decision=VerdictType.PASS,
+                agreement_ratio=1.0,
+            ),
+            invoking_agent=AgentIdentifier.CLAUDE_CODE,
+            skill_version="1.0.0",
+            transcript_location=".council/logs/test-123/",
+            reproducibility_hash="hash123",
+        )
+        assert result.verdict == VerdictType.PASS
+
+    def test_verification_result_confidence_bounds(self):
+        """VerificationResult confidence must be between 0 and 1."""
+        with pytest.raises(ValueError):
+            VerificationResult(
+                verification_id="test-123",
+                verdict=VerdictType.PASS,
+                confidence=1.5,  # Invalid: > 1
+                timestamp=datetime.utcnow(),
+                original_response_hash="abc123",
+                verifier_responses=[],
+                consensus_result=ConsensusResult(
+                    decision=VerdictType.PASS,
+                    agreement_ratio=1.0,
+                ),
+                invoking_agent=AgentIdentifier.CLAUDE_CODE,
+                skill_version="1.0.0",
+                transcript_location=".council/logs/test-123/",
+                reproducibility_hash="hash123",
+            )
+
+    def test_verification_result_matches_adr034_schema(self):
+        """VerificationResult matches ADR-034 JSON schema structure."""
+        result = VerificationResult(
+            verification_id="test-123",
+            verdict=VerdictType.PASS,
+            confidence=0.85,
+            timestamp=datetime.utcnow(),
+            original_response_hash="abc123def456",
+            verifier_responses=[
+                VerifierResponse(
+                    model_id="gpt-4o",
+                    verdict=VerdictType.PASS,
+                    confidence=0.9,
+                    rationale="Code looks good.",
+                )
+            ],
+            consensus_result=ConsensusResult(
+                decision=VerdictType.PASS,
+                agreement_ratio=1.0,
+            ),
+            rubric_scores=RubricScores(
+                accuracy=8.5,
+                completeness=7.0,
+                clarity=9.0,
+                conciseness=8.0,
+            ),
+            blocking_issues=[],
+            rationale="All verifiers agreed the code meets requirements.",
+            dissent=None,
+            invoking_agent=AgentIdentifier.CLAUDE_CODE,
+            skill_version="1.0.0",
+            protocol_version="1.0",
+            transcript_location=".council/logs/test-123/",
+            reproducibility_hash="hash123",
+        )
+
+        # Verify JSON schema structure
+        json_data = json.loads(result.model_dump_json())
+        assert "verdict" in json_data
+        assert json_data["verdict"] in ["pass", "fail", "unclear"]
+        assert "confidence" in json_data
+        assert 0 <= json_data["confidence"] <= 1
+        assert "timestamp" in json_data
+        assert "rubric_scores" in json_data
+
+    def test_verification_result_blocking_issues_structure(self):
+        """VerificationResult blocking_issues match ADR-034 schema."""
+        result = VerificationResult(
+            verification_id="test-123",
+            verdict=VerdictType.FAIL,
+            confidence=0.95,
+            timestamp=datetime.utcnow(),
+            original_response_hash="abc123",
+            verifier_responses=[],
+            consensus_result=ConsensusResult(
+                decision=VerdictType.FAIL,
+                agreement_ratio=1.0,
+            ),
+            blocking_issues=[
+                BlockingIssue(
+                    severity=IssueSeverity.CRITICAL,
+                    file="src/main.py",
+                    line=42,
+                    message="SQL injection vulnerability detected",
+                ),
+                BlockingIssue(
+                    severity=IssueSeverity.MAJOR,
+                    file="src/auth.py",
+                    line=15,
+                    message="Missing input validation",
+                ),
+            ],
+            invoking_agent=AgentIdentifier.CLAUDE_CODE,
+            skill_version="1.0.0",
+            transcript_location=".council/logs/test-123/",
+            reproducibility_hash="hash123",
+        )
+
+        assert len(result.blocking_issues) == 2
+        assert result.blocking_issues[0].severity == IssueSeverity.CRITICAL
+        assert result.blocking_issues[0].line == 42
+
+
+class TestCrossAgentConsistency:
+    """Tests for cross-agent consistency validation (ADR-034 v2.0)."""
+
+    def test_validate_cross_agent_consistency_same_results(self):
+        """validate_cross_agent_consistency returns True for identical results."""
+        base_kwargs = dict(
+            verification_id="test-123",
+            verdict=VerdictType.PASS,
+            confidence=0.85,
+            timestamp=datetime.utcnow(),
+            original_response_hash="abc123",
+            verifier_responses=[],
+            consensus_result=ConsensusResult(
+                decision=VerdictType.PASS,
+                agreement_ratio=1.0,
+            ),
+            skill_version="1.0.0",
+            transcript_location=".council/logs/test-123/",
+            reproducibility_hash="hash123",
+        )
+
+        result1 = VerificationResult(
+            invoking_agent=AgentIdentifier.CLAUDE_CODE,
+            **base_kwargs,
+        )
+        result2 = VerificationResult(
+            invoking_agent=AgentIdentifier.GITHUB_COPILOT,
+            **base_kwargs,
+        )
+
+        assert result1.validate_cross_agent_consistency(result2) is True
+
+    def test_validate_cross_agent_consistency_different_hash(self):
+        """validate_cross_agent_consistency returns False for different input hashes."""
+        base_kwargs = dict(
+            verification_id="test-123",
+            verdict=VerdictType.PASS,
+            confidence=0.85,
+            timestamp=datetime.utcnow(),
+            verifier_responses=[],
+            consensus_result=ConsensusResult(
+                decision=VerdictType.PASS,
+                agreement_ratio=1.0,
+            ),
+            skill_version="1.0.0",
+            transcript_location=".council/logs/test-123/",
+            reproducibility_hash="hash123",
+        )
+
+        result1 = VerificationResult(
+            invoking_agent=AgentIdentifier.CLAUDE_CODE,
+            original_response_hash="abc123",
+            **base_kwargs,
+        )
+        result2 = VerificationResult(
+            invoking_agent=AgentIdentifier.GITHUB_COPILOT,
+            original_response_hash="xyz789",  # Different hash
+            **base_kwargs,
+        )
+
+        assert result1.validate_cross_agent_consistency(result2) is False
+
+    def test_validate_cross_agent_consistency_different_verdict(self):
+        """validate_cross_agent_consistency returns False for different verdicts."""
+        base_kwargs = dict(
+            verification_id="test-123",
+            confidence=0.85,
+            timestamp=datetime.utcnow(),
+            original_response_hash="abc123",
+            verifier_responses=[],
+            skill_version="1.0.0",
+            transcript_location=".council/logs/test-123/",
+            reproducibility_hash="hash123",
+        )
+
+        result1 = VerificationResult(
+            invoking_agent=AgentIdentifier.CLAUDE_CODE,
+            verdict=VerdictType.PASS,
+            consensus_result=ConsensusResult(
+                decision=VerdictType.PASS,
+                agreement_ratio=1.0,
+            ),
+            **base_kwargs,
+        )
+        result2 = VerificationResult(
+            invoking_agent=AgentIdentifier.GITHUB_COPILOT,
+            verdict=VerdictType.FAIL,  # Different verdict
+            consensus_result=ConsensusResult(
+                decision=VerdictType.FAIL,
+                agreement_ratio=1.0,
+            ),
+            **base_kwargs,
+        )
+
+        assert result1.validate_cross_agent_consistency(result2) is False
+
+    def test_validate_cross_agent_consistency_confidence_tolerance(self):
+        """validate_cross_agent_consistency allows small confidence differences."""
+        base_kwargs = dict(
+            verification_id="test-123",
+            verdict=VerdictType.PASS,
+            timestamp=datetime.utcnow(),
+            original_response_hash="abc123",
+            verifier_responses=[],
+            consensus_result=ConsensusResult(
+                decision=VerdictType.PASS,
+                agreement_ratio=1.0,
+            ),
+            skill_version="1.0.0",
+            transcript_location=".council/logs/test-123/",
+            reproducibility_hash="hash123",
+        )
+
+        result1 = VerificationResult(
+            invoking_agent=AgentIdentifier.CLAUDE_CODE,
+            confidence=0.850,
+            **base_kwargs,
+        )
+        result2 = VerificationResult(
+            invoking_agent=AgentIdentifier.GITHUB_COPILOT,
+            confidence=0.855,  # Within 0.01 tolerance
+            **base_kwargs,
+        )
+
+        assert result1.validate_cross_agent_consistency(result2) is True
+
+
+class TestAgentIdentifier:
+    """Tests for AgentIdentifier enum."""
+
+    def test_agent_identifier_values(self):
+        """AgentIdentifier includes major platforms."""
+        assert AgentIdentifier.CLAUDE_CODE.value == "claude-code"
+        assert AgentIdentifier.GITHUB_COPILOT.value == "github-copilot"
+        assert AgentIdentifier.CURSOR.value == "cursor"
+        assert AgentIdentifier.CODEX_CLI.value == "codex-cli"
+
+
+class TestVerdictType:
+    """Tests for VerdictType enum."""
+
+    def test_verdict_type_values(self):
+        """VerdictType has pass, fail, unclear values."""
+        assert VerdictType.PASS.value == "pass"
+        assert VerdictType.FAIL.value == "fail"
+        assert VerdictType.UNCLEAR.value == "unclear"
+
+
+class TestRubricScores:
+    """Tests for RubricScores model."""
+
+    def test_rubric_scores_bounds(self):
+        """RubricScores values must be between 0 and 10."""
+        with pytest.raises(ValueError):
+            RubricScores(
+                accuracy=11.0,  # Invalid: > 10
+                completeness=5.0,
+                clarity=5.0,
+                conciseness=5.0,
+            )
+
+    def test_rubric_scores_valid(self):
+        """RubricScores accepts valid values."""
+        scores = RubricScores(
+            accuracy=8.5,
+            completeness=7.0,
+            clarity=9.0,
+            conciseness=8.0,
+        )
+        assert scores.accuracy == 8.5
+
+
+class TestVerificationContext:
+    """Tests for VerificationContext model."""
+
+    def test_verification_context_isolation(self):
+        """VerificationContext should be isolated (not inherit from session)."""
+        ctx = VerificationContext()
+        assert ctx.session_id is None or ctx.session_id == ""
+        # Context should be fresh, not inherited
+
+
+class TestJSONSchemaExport:
+    """Tests for JSON Schema export capability."""
+
+    def test_verification_result_json_schema_export(self):
+        """VerificationResult can export JSON Schema."""
+        schema = VerificationResult.model_json_schema()
+        assert schema["type"] == "object"
+        assert "verdict" in schema["properties"]
+        assert "confidence" in schema["properties"]
+        assert "timestamp" in schema["properties"]
+
+    def test_verification_request_json_schema_export(self):
+        """VerificationRequest can export JSON Schema."""
+        schema = VerificationRequest.model_json_schema()
+        assert schema["type"] == "object"
+        assert "snapshot_id" in schema["properties"]
+        assert "target_paths" in schema["properties"]


### PR DESCRIPTION
## Summary

Implements ADR-034 Issue A1: Define VerificationRequest and VerificationResult schemas for the verification API.

### Changes

- **`VerificationRequest`** Pydantic model:
  - Required: `snapshot_id`, `target_paths`
  - Optional: `rubric_focus`, `context`, `confidence_threshold`
  - Validation ensures required fields are present

- **`VerificationResult`** Pydantic model matching ADR-034 JSON schema:
  - Core: `verification_id`, `verdict`, `confidence`, `timestamp`
  - Cross-agent consistency: `invoking_agent`, `skill_version`, `protocol_version`
  - Audit trail: `transcript_location`, `reproducibility_hash`
  - `validate_cross_agent_consistency()` method for multi-platform verification

- **Supporting types**:
  - `VerdictType`: pass/fail/unclear enum
  - `AgentIdentifier`: claude-code, github-copilot, cursor, codex-cli
  - `RubricScores`: accuracy, completeness, clarity, conciseness (0-10)
  - `BlockingIssue`: severity, file, line, message
  - `ConsensusResult`: decision, agreement_ratio, dissenting_models

### TDD Approach

- 21 tests written first (red phase)
- Implementation added to pass tests (green phase)
- Tests cover validation, serialization, cross-agent consistency

## Test plan

- [x] `pytest tests/unit/verification/test_types.py` - 21 tests pass
- [x] `ruff check` - Linting passes
- [x] `mypy` - Type checks pass

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)