### PR TITLE
feat(skills): Add cross-platform skills directory structure

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.github/skills

--- a/.github/skills/council-gate/SKILL.md
+++ b/.github/skills/council-gate/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: council-gate
+description: |
+  Quality gate using LLM Council multi-model consensus for CI/CD pipelines.
+  Use for automated approval workflows and pipeline quality checks.
+  Keywords: gate, CI, CD, pipeline, automated approval, quality gate, GitHub Actions
+
+license: Apache-2.0
+compatibility: "llm-council >= 2.0, mcp >= 1.0, github-actions >= 2.0"
+metadata:
+  category: ci-cd
+  domain: devops
+  council-version: "2.0"
+  author: amiable-dev
+  repository: https://github.com/amiable-dev/llm-council
+
+allowed-tools: "Read Grep mcp:llm-council/verify mcp:llm-council/audit"
+---
+
+# Council Gate Skill
+
+Automated quality gate using multi-model consensus for CI/CD pipelines.
+
+## When to Use
+
+- Add AI-powered quality checks to GitHub Actions
+- Automate PR approval workflows
+- Gate deployments on multi-model verification
+- Enforce quality standards in pipelines
+
+## Exit Codes
+
+| Code | Verdict | CI/CD Behavior |
+|------|---------|----------------|
+| `0` | PASS | Pipeline continues |
+| `1` | FAIL | Pipeline fails |
+| `2` | UNCLEAR | Pipeline pauses for human review |
+
+## Transcript Location
+
+All deliberations are saved for audit:
+
+```
+.council/logs/{timestamp}-{hash}/
+├── request.json      # Input snapshot
+├── stage1.json       # Model responses
+├── stage2.json       # Peer reviews
+├── stage3.json       # Synthesis
+└── result.json       # Final verdict
+```
+
+## GitHub Actions Integration
+
+```yaml
+name: Council Quality Gate
+
+on:
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  council-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install LLM Council
+        run: pip install llm-council-core
+
+      - name: Run Council Gate
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          llm-council gate \
+            --snapshot ${{ github.sha }} \
+            --rubric-focus Security \
+            --confidence-threshold 0.8
+
+      - name: Upload Transcript
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: council-transcript
+          path: .council/logs/
+```
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `confidence_threshold` | 0.7 | Minimum confidence for PASS |
+| `rubric_focus` | null | Focus area (Security, Performance) |
+| `timeout` | 300s | Maximum execution time |
+| `tier` | balanced | Council tier (quick, balanced, high) |
+
+## Output Schema
+
+```json
+{
+  "verdict": "pass",
+  "confidence": 0.85,
+  "blocking_issues": [],
+  "rationale": "All models agreed...",
+  "exit_code": 0,
+  "transcript_path": ".council/logs/2025-12-31T..."
+}
+```
+
+## Example Usage
+
+```bash
+# Basic gate check
+council-gate --snapshot $(git rev-parse HEAD)
+
+# Security-focused gate
+council-gate --rubric-focus Security --confidence-threshold 0.9
+
+# Quick tier for faster feedback
+council-gate --tier quick --timeout 60
+```
+
+## Progressive Disclosure
+
+- **Level 1**: This metadata (~200 tokens)
+- **Level 2**: Full instructions above (~800 tokens)
+- **Level 3**: See `references/ci-cd-rubric.md` for CI/CD-specific scoring
+
+## Related Skills
+
+- `council-verify`: General verification
+- `council-review`: Code review with feedback

--- a/.github/skills/council-review/SKILL.md
+++ b/.github/skills/council-review/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: council-review
+description: |
+  Multi-model code review with structured feedback using LLM Council peer evaluation.
+  Use for PR reviews, code quality checks, or implementation review.
+  Keywords: code review, PR, pull request, quality check, peer review, feedback
+
+license: Apache-2.0
+compatibility: "llm-council >= 2.0, mcp >= 1.0"
+metadata:
+  category: code-review
+  domain: software-engineering
+  council-version: "2.0"
+  author: amiable-dev
+  repository: https://github.com/amiable-dev/llm-council
+
+allowed-tools: "Read Grep Glob mcp:llm-council/verify mcp:llm-council/audit"
+---
+
+# Council Code Review Skill
+
+Get multiple AI perspectives on code changes with structured, actionable feedback.
+
+## When to Use
+
+- Review pull requests before merging
+- Get code quality feedback on implementations
+- Identify potential issues across multiple dimensions
+- Validate changes against coding standards
+
+## Workflow
+
+1. **Prepare Input**: Provide file paths or git diff
+2. **Invoke Review**: Call `mcp:llm-council/verify` with code-review rubric
+3. **Process Feedback**: Receive structured scores and issue list
+4. **Address Issues**: Fix blocking issues before proceeding
+
+## Input Formats
+
+Supports both:
+- `file_paths`: List of files to review (full file analysis)
+- `git_diff`: Unified diff format for change-focused review
+- `snapshot_id`: Git commit SHA (required for reproducibility)
+
+## Rubric (ADR-016)
+
+| Dimension | Weight | Focus |
+|-----------|--------|-------|
+| Accuracy | 35% | Correctness, no bugs, logic errors |
+| Completeness | 20% | All requirements addressed |
+| Clarity | 20% | Readable, maintainable code |
+| Conciseness | 15% | No unnecessary complexity |
+| Relevance | 10% | Addresses stated requirements |
+
+## Output Schema
+
+```json
+{
+  "verdict": "pass|fail|unclear",
+  "confidence": 0.82,
+  "rubric_scores": {
+    "accuracy": 7.5,
+    "completeness": 8.0,
+    "clarity": 9.0,
+    "conciseness": 8.5,
+    "relevance": 9.0
+  },
+  "blocking_issues": [
+    {
+      "severity": "major",
+      "file": "src/api.py",
+      "line": 42,
+      "message": "Missing input validation"
+    }
+  ],
+  "suggestions": [...],
+  "rationale": "Overall, the code is well-structured..."
+}
+```
+
+## Example Usage
+
+```bash
+# Review specific files
+council-review --file-paths "src/main.py,src/utils.py" --snapshot abc123
+
+# Review git diff
+council-review --git-diff "$(git diff HEAD~1)" --snapshot $(git rev-parse HEAD)
+
+# Review with custom focus
+council-review --rubric-focus Security --file-paths "src/auth.py"
+```
+
+## Progressive Disclosure
+
+- **Level 1**: This metadata (~200 tokens)
+- **Level 2**: Full instructions above (~800 tokens)
+- **Level 3**: See `references/code-review-rubric.md` for detailed scoring anchors
+
+## Related Skills
+
+- `council-verify`: General verification
+- `council-gate`: CI/CD quality gate

--- a/.github/skills/council-verify/SKILL.md
+++ b/.github/skills/council-verify/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: council-verify
+description: |
+  Verify code, documents, or implementation against requirements using LLM Council multi-model deliberation.
+  Use when you need multi-model consensus on correctness, completeness, or quality.
+  Keywords: verify, check, validate, review, approve, pass/fail, consensus, multi-model
+
+license: Apache-2.0
+compatibility: "llm-council >= 2.0, mcp >= 1.0"
+metadata:
+  category: verification
+  domain: ai-governance
+  council-version: "2.0"
+  author: amiable-dev
+  repository: https://github.com/amiable-dev/llm-council
+
+allowed-tools: "Read Grep Glob mcp:llm-council/verify mcp:llm-council/audit"
+---
+
+# Council Verification Skill
+
+Use LLM Council's multi-model deliberation to verify work with structured, machine-actionable verdicts.
+
+## When to Use
+
+- Verify code changes before committing
+- Validate implementation against requirements
+- Check documents for accuracy and completeness
+- Get multi-model consensus on quality
+
+## Workflow
+
+1. **Capture Snapshot**: Capture current git diff or file state (snapshot pinning for reproducibility)
+2. **Invoke Verification**: Call `mcp:llm-council/verify` with isolated context
+3. **Receive Verdict**: Get structured JSON with verdict, confidence, and blocking issues
+4. **Audit Trail**: Persist transcript via `mcp:llm-council/audit`
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `rubric_focus` | string | null | Focus area: "Security", "Performance", "Accessibility" |
+| `confidence_threshold` | float | 0.7 | Minimum confidence for PASS verdict |
+| `snapshot_id` | string | required | Git commit SHA for reproducibility |
+
+## Output Schema
+
+```json
+{
+  "verdict": "pass|fail|unclear",
+  "confidence": 0.85,
+  "rubric_scores": {
+    "accuracy": 8.5,
+    "completeness": 7.0,
+    "clarity": 9.0,
+    "conciseness": 8.0
+  },
+  "blocking_issues": [...],
+  "rationale": "Chairman synthesis...",
+  "transcript_location": ".council/logs/..."
+}
+```
+
+## Exit Codes (for CI/CD)
+
+- `0`: PASS - Approved with confidence >= threshold
+- `1`: FAIL - Rejected
+- `2`: UNCLEAR - Confidence below threshold, requires human review
+
+## Example Usage
+
+```bash
+# Verify current changes
+council-verify --snapshot $(git rev-parse HEAD) --rubric-focus Security
+
+# Verify specific files
+council-verify --target-paths "src/auth.py,src/api.py" --snapshot abc123
+```
+
+## Progressive Disclosure
+
+- **Level 1**: This metadata (~200 tokens)
+- **Level 2**: Full instructions above (~600 tokens)
+- **Level 3**: See `references/rubrics.md` for detailed rubric definitions
+
+## Related Skills
+
+- `council-review`: Code review with structured feedback
+- `council-gate`: CI/CD quality gate

--- a/.github/skills/marketplace.json
+++ b/.github/skills/marketplace.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://agentskills.io/schemas/marketplace.json",
+  "name": "llm-council-skills",
+  "version": "2.0.0",
+  "description": "Multi-model verification and code review skills using LLM Council deliberation",
+  "author": "amiable-dev",
+  "repository": "https://github.com/amiable-dev/llm-council",
+  "license": "Apache-2.0",
+  "skills": [
+    {
+      "name": "council-verify",
+      "path": "./council-verify/SKILL.md",
+      "description": "Verify code, documents, or implementation against requirements using multi-model consensus",
+      "category": "verification",
+      "tags": ["verify", "validate", "review", "consensus", "multi-model"]
+    },
+    {
+      "name": "council-review",
+      "path": "./council-review/SKILL.md",
+      "description": "Multi-model code review with structured feedback and rubric scoring",
+      "category": "code-review",
+      "tags": ["code-review", "PR", "pull-request", "quality", "feedback"]
+    },
+    {
+      "name": "council-gate",
+      "path": "./council-gate/SKILL.md",
+      "description": "CI/CD quality gate using LLM Council multi-model consensus",
+      "category": "ci-cd",
+      "tags": ["gate", "CI", "CD", "pipeline", "automation", "GitHub-Actions"]
+    }
+  ],
+  "compatibility": {
+    "llm-council": ">=2.0.0",
+    "mcp": ">=1.0.0"
+  },
+  "platforms": [
+    "claude-code",
+    "github-copilot",
+    "vs-code",
+    "cursor",
+    "codex-cli",
+    "windsurf",
+    "cline"
+  ],
+  "links": {
+    "documentation": "https://llm-council.dev/docs/skills",
+    "issues": "https://github.com/amiable-dev/llm-council/issues",
+    "changelog": "https://github.com/amiable-dev/llm-council/blob/master/CHANGELOG.md"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,8 @@ site/
 # Claude Code agent workspace
 .agent/
 
+# Claude Code local settings (may contain user preferences)
+.claude/settings.local.json
+
 # MCP server configuration (may contain API keys)
 .mcp.json


### PR DESCRIPTION
## Summary

Implements ADR-034 Issue B0: Skills Distribution Architecture for cross-platform skill deployment.

### Changes

**Cross-Platform Skills Directory (`.github/skills/`)**
- `council-verify/SKILL.md`: General verification skill
- `council-review/SKILL.md`: Code review with structured feedback
- `council-gate/SKILL.md`: CI/CD quality gate with exit codes
- `marketplace.json`: Marketplace discovery metadata

**Symlink for Claude Code (`.claude/skills/`)**
- Symlinks to `.github/skills/` for backward compatibility
- Ensures Claude Code discovers skills

**Gitignore Update**
- Excludes `.claude/settings.local.json` (user preferences)
- Allows `.claude/skills` symlink to be tracked

### Platform Compatibility

Per Dec 2025 updates, `.github/skills/` is supported by:
- GitHub Copilot (VS Code)
- Claude Code
- Cursor
- OpenAI Codex CLI
- Windsurf, Cline

### SKILL.md Contents

Each skill includes:
- YAML frontmatter per agentskills.io spec
- Workflow instructions
- Parameter documentation
- Output schema (JSON)
- Example usage
- Progressive disclosure markers

## Test plan

- [x] Skills directory structure created
- [x] Symlink works correctly
- [x] Marketplace.json validates
- [x] gitignore excludes sensitive files

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)