### PR TITLE
feat(verification): Transcript persistence (A3, #265)

### DIFF
--- a/src/llm_council/verification/__init__.py
+++ b/src/llm_council/verification/__init__.py
@@ -1,0 +1,24 @@
+"""
+Verification module for ADR-034 Agent Skills Integration.
+
+Provides transcript persistence for work verification audit trails.
+"""
+
+from llm_council.verification.transcript import (
+    TranscriptError,
+    TranscriptIntegrityError,
+    TranscriptNotFoundError,
+    TranscriptStore,
+    create_transcript_store,
+    get_transcript_path,
+)
+
+__all__ = [
+    # Transcript persistence (ADR-034 A3)
+    "create_transcript_store",
+    "get_transcript_path",
+    "TranscriptStore",
+    "TranscriptError",
+    "TranscriptNotFoundError",
+    "TranscriptIntegrityError",
+]

--- a/src/llm_council/verification/transcript.py
+++ b/src/llm_council/verification/transcript.py
@@ -1,0 +1,321 @@
+"""
+Transcript persistence for verification audit trail per ADR-034.
+
+Provides atomic writes, directory management, and integrity validation
+for verification transcripts. Each verification creates a timestamped
+directory containing JSON files for each stage.
+
+Directory structure:
+    .council/logs/
+    ├── 2025-12-31T10-30-00-abc123/
+    │   ├── request.json
+    │   ├── stage1.json
+    │   ├── stage2.json
+    │   ├── stage3.json
+    │   └── result.json
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class TranscriptError(Exception):
+    """Base exception for transcript operations."""
+
+    pass
+
+
+class TranscriptNotFoundError(TranscriptError):
+    """Raised when a transcript or stage is not found."""
+
+    pass
+
+
+class TranscriptIntegrityError(TranscriptError):
+    """Raised when transcript integrity validation fails."""
+
+    pass
+
+
+def get_transcript_path() -> Path:
+    """
+    Get the path for transcript storage.
+
+    Priority:
+    1. LLM_COUNCIL_TRANSCRIPT_PATH environment variable
+    2. .council/logs relative to current working directory
+
+    Returns:
+        Path to transcript storage directory
+    """
+    env_path = os.environ.get("LLM_COUNCIL_TRANSCRIPT_PATH")
+    if env_path:
+        return Path(env_path)
+
+    return Path.cwd() / ".council" / "logs"
+
+
+@dataclass
+class TranscriptStore:
+    """
+    Store for verification transcripts.
+
+    Provides atomic writes, directory management, and integrity validation.
+    Each verification gets its own timestamped directory.
+    """
+
+    base_path: Path
+    readonly: bool = False
+    _verification_dirs: Dict[str, Path] = field(default_factory=dict)
+
+    def __post_init__(self):
+        """Ensure base directory exists unless readonly."""
+        if not self.readonly:
+            self.base_path.mkdir(parents=True, exist_ok=True)
+
+    def create_verification_directory(self, verification_id: str) -> Path:
+        """
+        Create a timestamped directory for a verification.
+
+        Args:
+            verification_id: The verification identifier
+
+        Returns:
+            Path to the created directory
+
+        Raises:
+            TranscriptError: If in readonly mode
+        """
+        if self.readonly:
+            raise TranscriptError("Cannot create directory in readonly mode")
+
+        # Format: 2025-12-31T10-30-00-abc123
+        timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H-%M-%S")
+        dir_name = f"{timestamp}-{verification_id}"
+
+        path = self.base_path / dir_name
+        path.mkdir(parents=True, exist_ok=True)
+
+        # Cache the mapping for later retrieval
+        self._verification_dirs[verification_id] = path
+
+        return path
+
+    def _find_verification_dir(self, verification_id: str) -> Path:
+        """
+        Find the directory for a verification ID.
+
+        Searches cached mappings first, then scans base_path.
+
+        Args:
+            verification_id: The verification identifier
+
+        Returns:
+            Path to the verification directory
+
+        Raises:
+            TranscriptNotFoundError: If directory not found
+        """
+        # Check cache first
+        if verification_id in self._verification_dirs:
+            path = self._verification_dirs[verification_id]
+            if path.exists():
+                return path
+
+        # Scan base_path for matching directory
+        if self.base_path.exists():
+            for item in self.base_path.iterdir():
+                if item.is_dir() and item.name.endswith(f"-{verification_id}"):
+                    self._verification_dirs[verification_id] = item
+                    return item
+
+        raise TranscriptNotFoundError(f"No transcript found for verification: {verification_id}")
+
+    def write_stage(self, verification_id: str, stage: str, data: Dict[str, Any]) -> Path:
+        """
+        Write stage data atomically to the transcript.
+
+        Uses atomic rename pattern: write to temp file, then rename.
+        This ensures either complete success or no partial writes.
+
+        Args:
+            verification_id: The verification identifier
+            stage: Stage name (request, stage1, stage2, stage3, result)
+            data: Stage data to write
+
+        Returns:
+            Path to the written file
+
+        Raises:
+            TranscriptError: If in readonly mode
+            TranscriptNotFoundError: If verification directory not found
+        """
+        if self.readonly:
+            raise TranscriptError("Cannot write in readonly mode")
+
+        verification_dir = self._find_verification_dir(verification_id)
+        target_path = verification_dir / f"{stage}.json"
+
+        # Atomic write pattern: write to temp, then rename
+        fd, tmp_path = tempfile.mkstemp(suffix=".tmp", dir=verification_dir, prefix=f"{stage}_")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(data, f, indent=2, default=str)
+
+            # Atomic rename
+            os.rename(tmp_path, target_path)
+        except Exception:
+            # Clean up temp file on failure
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+            raise
+
+        return target_path
+
+    def read_stage(self, verification_id: str, stage: str) -> Dict[str, Any]:
+        """
+        Read stage data from a transcript.
+
+        Args:
+            verification_id: The verification identifier
+            stage: Stage name to read
+
+        Returns:
+            Stage data as dictionary
+
+        Raises:
+            TranscriptNotFoundError: If stage file not found
+        """
+        verification_dir = self._find_verification_dir(verification_id)
+        stage_path = verification_dir / f"{stage}.json"
+
+        if not stage_path.exists():
+            raise TranscriptNotFoundError(
+                f"Stage '{stage}' not found for verification: {verification_id}"
+            )
+
+        with open(stage_path) as f:
+            return json.load(f)
+
+    def read_all_stages(self, verification_id: str) -> Dict[str, Dict[str, Any]]:
+        """
+        Read all stages from a transcript.
+
+        Args:
+            verification_id: The verification identifier
+
+        Returns:
+            Dictionary mapping stage names to stage data
+        """
+        verification_dir = self._find_verification_dir(verification_id)
+
+        stages = {}
+        for stage_file in verification_dir.glob("*.json"):
+            stage_name = stage_file.stem
+            with open(stage_file) as f:
+                stages[stage_name] = json.load(f)
+
+        return stages
+
+    def list_verifications(self) -> List[Dict[str, Any]]:
+        """
+        List all verifications in the store.
+
+        Returns:
+            List of verification metadata dictionaries
+        """
+        verifications: List[Dict[str, Any]] = []
+
+        if not self.base_path.exists():
+            return verifications
+
+        for item in sorted(self.base_path.iterdir(), reverse=True):
+            if item.is_dir():
+                # Parse directory name: 2025-12-31T10-30-00-abc123
+                parts = item.name.rsplit("-", 1)
+                if len(parts) == 2:
+                    verification_id = parts[1]
+                    timestamp_str = parts[0]
+
+                    verifications.append(
+                        {
+                            "verification_id": verification_id,
+                            "directory": item.name,
+                            "path": str(item),
+                            "timestamp": timestamp_str,
+                        }
+                    )
+
+        return verifications
+
+    def compute_integrity_hash(self, verification_id: str) -> str:
+        """
+        Compute SHA256 hash of all transcript contents.
+
+        Includes all stage files sorted by name for determinism.
+
+        Args:
+            verification_id: The verification identifier
+
+        Returns:
+            SHA256 hex digest
+        """
+        verification_dir = self._find_verification_dir(verification_id)
+
+        hasher = hashlib.sha256()
+
+        # Process files in sorted order for determinism
+        for stage_file in sorted(verification_dir.glob("*.json")):
+            # Hash the filename and content
+            hasher.update(stage_file.name.encode("utf-8"))
+            with open(stage_file, "rb") as f:
+                hasher.update(f.read())
+
+        return hasher.hexdigest()
+
+    def validate_integrity(self, verification_id: str, expected_hash: str) -> None:
+        """
+        Validate transcript integrity against expected hash.
+
+        Args:
+            verification_id: The verification identifier
+            expected_hash: Expected SHA256 hex digest
+
+        Raises:
+            TranscriptIntegrityError: If hash doesn't match
+        """
+        actual_hash = self.compute_integrity_hash(verification_id)
+
+        if actual_hash != expected_hash:
+            raise TranscriptIntegrityError(
+                f"Integrity check failed for verification {verification_id}: "
+                f"expected {expected_hash}, got {actual_hash}"
+            )
+
+
+def create_transcript_store(
+    base_path: Optional[Path] = None,
+    readonly: bool = False,
+) -> TranscriptStore:
+    """
+    Create a transcript store.
+
+    Args:
+        base_path: Path to store transcripts (defaults to get_transcript_path())
+        readonly: If True, reject write operations
+
+    Returns:
+        Configured TranscriptStore instance
+    """
+    if base_path is None:
+        base_path = get_transcript_path()
+
+    return TranscriptStore(base_path=base_path, readonly=readonly)

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for LLM Council."""

--- a/tests/unit/verification/__init__.py
+++ b/tests/unit/verification/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for verification module (ADR-034)."""

--- a/tests/unit/verification/test_transcript.py
+++ b/tests/unit/verification/test_transcript.py
@@ -1,0 +1,430 @@
+"""
+Tests for transcript persistence per ADR-034.
+
+TDD Red Phase: These tests should fail until transcript.py is implemented.
+
+Transcript persistence provides:
+1. Atomic writes for each verification stage
+2. Directory structure for audit trail
+3. Retrieval and integrity validation
+"""
+
+import json
+import os
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from llm_council.verification.transcript import (
+    TranscriptError,
+    TranscriptIntegrityError,
+    TranscriptNotFoundError,
+    TranscriptStore,
+    create_transcript_store,
+    get_transcript_path,
+)
+
+
+class TestTranscriptStore:
+    """Tests for transcript store initialization."""
+
+    def test_create_transcript_store_default_path(self):
+        """Transcript store should use default .council/logs path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir))
+            assert store.base_path == Path(tmpdir)
+
+    def test_create_transcript_store_creates_directory(self):
+        """Transcript store should create base directory if not exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logs_path = Path(tmpdir) / ".council" / "logs"
+            assert not logs_path.exists()
+
+            store = create_transcript_store(base_path=logs_path)
+            assert logs_path.exists()
+
+    def test_transcript_store_readonly_mode(self):
+        """Transcript store can be opened in readonly mode."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir), readonly=True)
+            assert store.readonly is True
+
+
+class TestDirectoryStructure:
+    """Tests for verification transcript directory creation."""
+
+    def test_creates_verification_directory(self):
+        """Should create timestamped directory for verification."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir))
+            verification_id = "abc1234"
+
+            path = store.create_verification_directory(verification_id)
+
+            assert path.exists()
+            assert verification_id in path.name
+
+    def test_directory_name_format(self):
+        """Directory name should be ISO timestamp + verification_id."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir))
+            verification_id = "def5678"
+
+            path = store.create_verification_directory(verification_id)
+
+            # Format: 2025-12-31T10-30-00-def5678
+            dir_name = path.name
+            assert verification_id in dir_name
+            # Should have timestamp prefix (YYYY-MM-DDTHH-MM-SS)
+            assert dir_name[4] == "-"  # Year separator
+            assert dir_name[10] == "T"  # Date-time separator
+
+    def test_directory_isolation(self):
+        """Each verification should get unique directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir))
+
+            path1 = store.create_verification_directory("abc1234")
+            path2 = store.create_verification_directory("def5678")
+
+            assert path1 != path2
+            assert path1.exists()
+            assert path2.exists()
+
+
+class TestAtomicWrites:
+    """Tests for atomic stage writes."""
+
+    @pytest.fixture
+    def store_with_dir(self) -> tuple:
+        """Create store with verification directory."""
+        tmpdir = tempfile.mkdtemp()
+        store = create_transcript_store(base_path=Path(tmpdir))
+        verification_id = "abc1234"
+        path = store.create_verification_directory(verification_id)
+        return store, path, verification_id, tmpdir
+
+    def test_write_request_stage(self, store_with_dir):
+        """Should write request.json atomically."""
+        store, path, vid, tmpdir = store_with_dir
+        try:
+            request_data = {
+                "snapshot_id": "abc1234",
+                "target_paths": ["src/"],
+                "rubric_focus": "Security",
+            }
+
+            store.write_stage(vid, "request", request_data)
+
+            request_file = path / "request.json"
+            assert request_file.exists()
+
+            with open(request_file) as f:
+                saved = json.load(f)
+            assert saved["snapshot_id"] == "abc1234"
+        finally:
+            import shutil
+
+            shutil.rmtree(tmpdir)
+
+    def test_write_stage1_responses(self, store_with_dir):
+        """Should write stage1.json with model responses."""
+        store, path, vid, tmpdir = store_with_dir
+        try:
+            stage1_data = {
+                "responses": {
+                    "openai/gpt-4": {"content": "Response 1", "latency_ms": 100},
+                    "anthropic/claude-3": {"content": "Response 2", "latency_ms": 150},
+                },
+                "timestamp": datetime.utcnow().isoformat(),
+            }
+
+            store.write_stage(vid, "stage1", stage1_data)
+
+            stage1_file = path / "stage1.json"
+            assert stage1_file.exists()
+        finally:
+            import shutil
+
+            shutil.rmtree(tmpdir)
+
+    def test_write_stage2_rankings(self, store_with_dir):
+        """Should write stage2.json with peer rankings."""
+        store, path, vid, tmpdir = store_with_dir
+        try:
+            stage2_data = {
+                "rankings": [
+                    {"reviewer": "model_a", "ranking": ["Response B", "Response A"]},
+                    {"reviewer": "model_b", "ranking": ["Response A", "Response B"]},
+                ],
+                "label_to_model": {"Response A": "openai/gpt-4"},
+            }
+
+            store.write_stage(vid, "stage2", stage2_data)
+
+            stage2_file = path / "stage2.json"
+            assert stage2_file.exists()
+        finally:
+            import shutil
+
+            shutil.rmtree(tmpdir)
+
+    def test_write_stage3_synthesis(self, store_with_dir):
+        """Should write stage3.json with final synthesis."""
+        store, path, vid, tmpdir = store_with_dir
+        try:
+            stage3_data = {
+                "synthesis": "Final synthesized response...",
+                "chairman_model": "openai/gpt-4",
+            }
+
+            store.write_stage(vid, "stage3", stage3_data)
+
+            stage3_file = path / "stage3.json"
+            assert stage3_file.exists()
+        finally:
+            import shutil
+
+            shutil.rmtree(tmpdir)
+
+    def test_write_result(self, store_with_dir):
+        """Should write result.json with verification verdict."""
+        store, path, vid, tmpdir = store_with_dir
+        try:
+            result_data = {
+                "verification_id": vid,
+                "verdict": "pass",
+                "confidence": 0.92,
+                "blocking_issues": [],
+            }
+
+            store.write_stage(vid, "result", result_data)
+
+            result_file = path / "result.json"
+            assert result_file.exists()
+        finally:
+            import shutil
+
+            shutil.rmtree(tmpdir)
+
+    def test_atomic_write_survives_crash(self, store_with_dir):
+        """Atomic write should not leave partial files on failure."""
+        store, path, vid, tmpdir = store_with_dir
+        try:
+            # Write should either succeed completely or leave no trace
+            # We can't easily simulate crash, but we can verify
+            # that write uses atomic rename pattern
+
+            data = {"test": "data"}
+            store.write_stage(vid, "test", data)
+
+            # No .tmp files should remain
+            tmp_files = list(path.glob("*.tmp"))
+            assert len(tmp_files) == 0
+        finally:
+            import shutil
+
+            shutil.rmtree(tmpdir)
+
+    def test_readonly_store_rejects_writes(self):
+        """Readonly store should reject write operations."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir), readonly=True)
+
+            with pytest.raises(TranscriptError) as exc_info:
+                store.write_stage("abc1234", "test", {"data": "test"})
+            assert "readonly" in str(exc_info.value).lower()
+
+
+class TestTranscriptRetrieval:
+    """Tests for reading transcripts back."""
+
+    def test_read_stage(self):
+        """Should read stage data by verification_id."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir))
+            vid = "abc1234"
+            store.create_verification_directory(vid)
+
+            original = {"key": "value", "number": 42}
+            store.write_stage(vid, "request", original)
+
+            retrieved = store.read_stage(vid, "request")
+            assert retrieved == original
+
+    def test_read_all_stages(self):
+        """Should read all stages for a verification."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir))
+            vid = "abc1234"
+            store.create_verification_directory(vid)
+
+            store.write_stage(vid, "request", {"stage": "request"})
+            store.write_stage(vid, "stage1", {"stage": "stage1"})
+            store.write_stage(vid, "result", {"stage": "result"})
+
+            all_stages = store.read_all_stages(vid)
+
+            assert "request" in all_stages
+            assert "stage1" in all_stages
+            assert "result" in all_stages
+
+    def test_read_nonexistent_verification(self):
+        """Should raise error for nonexistent verification."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir))
+
+            with pytest.raises(TranscriptNotFoundError):
+                store.read_stage("nonexistent", "request")
+
+    def test_read_nonexistent_stage(self):
+        """Should raise error for nonexistent stage."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir))
+            vid = "abc1234"
+            store.create_verification_directory(vid)
+            store.write_stage(vid, "request", {"data": "test"})
+
+            with pytest.raises(TranscriptNotFoundError):
+                store.read_stage(vid, "nonexistent_stage")
+
+    def test_list_verifications(self):
+        """Should list all verification IDs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir))
+
+            store.create_verification_directory("abc1234")
+            store.create_verification_directory("def5678")
+
+            verifications = store.list_verifications()
+
+            assert len(verifications) == 2
+            # Should contain the verification IDs
+            ids = [v["verification_id"] for v in verifications]
+            assert "abc1234" in ids
+            assert "def5678" in ids
+
+
+class TestTranscriptIntegrity:
+    """Tests for transcript integrity validation."""
+
+    def test_compute_integrity_hash(self):
+        """Should compute SHA256 hash of transcript contents."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir))
+            vid = "abc1234"
+            store.create_verification_directory(vid)
+
+            store.write_stage(vid, "request", {"data": "test"})
+            store.write_stage(vid, "result", {"verdict": "pass"})
+
+            hash1 = store.compute_integrity_hash(vid)
+            hash2 = store.compute_integrity_hash(vid)
+
+            # Same content should produce same hash
+            assert hash1 == hash2
+            assert len(hash1) == 64  # SHA256 hex
+
+    def test_different_content_different_hash(self):
+        """Different content should produce different hash."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir))
+
+            vid1 = "abc1234"
+            vid2 = "def5678"
+            store.create_verification_directory(vid1)
+            store.create_verification_directory(vid2)
+
+            store.write_stage(vid1, "request", {"data": "test1"})
+            store.write_stage(vid2, "request", {"data": "test2"})
+
+            hash1 = store.compute_integrity_hash(vid1)
+            hash2 = store.compute_integrity_hash(vid2)
+
+            assert hash1 != hash2
+
+    def test_validate_integrity_success(self):
+        """Should validate integrity when hash matches."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir))
+            vid = "abc1234"
+            store.create_verification_directory(vid)
+            store.write_stage(vid, "request", {"data": "test"})
+
+            expected_hash = store.compute_integrity_hash(vid)
+
+            # Should not raise
+            store.validate_integrity(vid, expected_hash)
+
+    def test_validate_integrity_failure(self):
+        """Should raise error when hash doesn't match."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = create_transcript_store(base_path=Path(tmpdir))
+            vid = "abc1234"
+            store.create_verification_directory(vid)
+            store.write_stage(vid, "request", {"data": "test"})
+
+            wrong_hash = "0" * 64  # Invalid hash
+
+            with pytest.raises(TranscriptIntegrityError):
+                store.validate_integrity(vid, wrong_hash)
+
+
+class TestTranscriptPath:
+    """Tests for transcript path utilities."""
+
+    def test_get_transcript_path_default(self):
+        """Should return default .council/logs path."""
+        path = get_transcript_path()
+        assert path.name == "logs"
+        assert ".council" in str(path)
+
+    def test_get_transcript_path_from_env(self, monkeypatch):
+        """Should use LLM_COUNCIL_TRANSCRIPT_PATH if set."""
+        monkeypatch.setenv("LLM_COUNCIL_TRANSCRIPT_PATH", "/custom/path")
+        path = get_transcript_path()
+        assert path == Path("/custom/path")
+
+    def test_get_transcript_path_from_project_root(self):
+        """Should find .council/logs relative to project root."""
+        # This tests the actual behavior - may vary based on cwd
+        path = get_transcript_path()
+        assert isinstance(path, Path)
+
+
+class TestConcurrentWrites:
+    """Tests for concurrent write safety."""
+
+    def test_concurrent_writes_different_verifications(self):
+        """Concurrent writes to different verifications should not conflict."""
+        import asyncio
+
+        async def write_verification(store: TranscriptStore, vid: str):
+            store.create_verification_directory(vid)
+            store.write_stage(vid, "request", {"vid": vid})
+            store.write_stage(vid, "result", {"verdict": "pass"})
+            await asyncio.sleep(0.01)
+            return vid
+
+        async def run_concurrent():
+            with tempfile.TemporaryDirectory() as tmpdir:
+                store = create_transcript_store(base_path=Path(tmpdir))
+
+                results = await asyncio.gather(
+                    write_verification(store, "abc1234"),
+                    write_verification(store, "def5678"),
+                    write_verification(store, "aabb112"),
+                )
+
+                # All should succeed
+                assert len(results) == 3
+
+                # All should be readable
+                for vid in results:
+                    data = store.read_stage(vid, "request")
+                    assert data["vid"] == vid
+
+        asyncio.run(run_concurrent())


### PR DESCRIPTION
## Summary

TDD implementation of transcript persistence for verification audit trail per ADR-034.

### New Files
- `src/llm_council/verification/__init__.py` - Module exports
- `src/llm_council/verification/transcript.py` - Transcript persistence implementation
- `tests/unit/verification/test_transcript.py` - 26 comprehensive tests
- `tests/unit/__init__.py`, `tests/unit/verification/__init__.py` - Package markers

### Directory Structure

```
.council/logs/
├── 2025-12-31T10-30-00-abc123/
│   ├── request.json
│   ├── stage1.json
│   ├── stage2.json
│   ├── stage3.json
│   └── result.json
```

### TranscriptStore Features

| Feature | Description |
|---------|-------------|
| **Atomic Writes** | Temp file + rename pattern prevents partial writes |
| **Timestamped Dirs** | ISO format + verification_id for sorting |
| **Stage Persistence** | request, stage1-3, result stages |
| **Integrity Hash** | SHA256 across all stage files |
| **Readonly Mode** | Safe audit queries without write risk |

### Test Coverage (26 tests)

| Category | Tests |
|----------|-------|
| Store Creation | 3 |
| Directory Structure | 3 |
| Atomic Writes | 7 |
| Transcript Retrieval | 5 |
| Integrity Validation | 4 |
| Path Utilities | 3 |
| Concurrent Writes | 1 |

### Configuration

| Variable | Default | Description |
|----------|---------|-------------|
| `LLM_COUNCIL_TRANSCRIPT_PATH` | `.council/logs` | Custom transcript storage path |

## Test Plan
- [x] All 26 unit tests pass
- [x] ruff linting passes
- [x] mypy type checking passes
- [ ] CI pipeline passes

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)