### PR TITLE
[ADR-034] B2: Progressive Disclosure Skill Loader

### DIFF
--- a/src/llm_council/skills/__init__.py
+++ b/src/llm_council/skills/__init__.py
@@ -1,0 +1,36 @@
+"""
+Skills module for ADR-034 Agent Skills Integration.
+
+Provides progressive disclosure loading for agent skills:
+- Level 1: Metadata only (~100-200 tokens)
+- Level 2: Full SKILL.md content
+- Level 3: Resources on demand
+"""
+
+from llm_council.skills.loader import (
+    SkillError,
+    SkillFull,
+    SkillLoader,
+    SkillMetadata,
+    SkillNotFoundError,
+    SkillParseError,
+    load_skill_full,
+    load_skill_metadata,
+    load_skill_resource,
+)
+
+__all__ = [
+    # Exceptions
+    "SkillError",
+    "SkillNotFoundError",
+    "SkillParseError",
+    # Data classes
+    "SkillMetadata",
+    "SkillFull",
+    # Functions
+    "load_skill_metadata",
+    "load_skill_full",
+    "load_skill_resource",
+    # Loader class
+    "SkillLoader",
+]

--- a/src/llm_council/skills/loader.py
+++ b/src/llm_council/skills/loader.py
@@ -1,0 +1,366 @@
+"""
+Progressive disclosure skill loader for ADR-034.
+
+Provides three levels of skill loading to minimize token usage:
+- Level 1: Metadata only (~100-200 tokens) - YAML frontmatter
+- Level 2: Full SKILL.md content (~500-1000 tokens)
+- Level 3: Resources on demand - files from references/ directory
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+
+
+class SkillError(Exception):
+    """Base exception for skill loading errors."""
+
+    pass
+
+
+class SkillNotFoundError(SkillError):
+    """Raised when a skill or resource is not found."""
+
+    pass
+
+
+class SkillParseError(SkillError):
+    """Raised when skill content cannot be parsed."""
+
+    pass
+
+
+@dataclass
+class SkillMetadata:
+    """Level 1: Skill metadata from YAML frontmatter.
+
+    Contains only essential information for skill discovery and selection.
+    Target: ~100-200 tokens.
+    """
+
+    name: str
+    description: str
+    license: Optional[str] = None
+    compatibility: Optional[str] = None
+    allowed_tools: List[str] = field(default_factory=list)
+    category: Optional[str] = None
+    domain: Optional[str] = None
+    author: Optional[str] = None
+    repository: Optional[str] = None
+
+    @property
+    def estimated_tokens(self) -> int:
+        """Estimate token count for this metadata.
+
+        Uses rough approximation of ~4 characters per token.
+        """
+        text = f"{self.name} {self.description}"
+        if self.license:
+            text += f" {self.license}"
+        if self.compatibility:
+            text += f" {self.compatibility}"
+        if self.allowed_tools:
+            text += f" {' '.join(self.allowed_tools)}"
+        if self.category:
+            text += f" {self.category}"
+        if self.domain:
+            text += f" {self.domain}"
+
+        return len(text) // 4
+
+
+@dataclass
+class SkillFull:
+    """Level 2: Full skill content including body.
+
+    Contains metadata plus the complete SKILL.md body.
+    Target: ~500-1000 tokens.
+    """
+
+    metadata: SkillMetadata
+    body: str
+
+    @property
+    def estimated_tokens(self) -> int:
+        """Estimate token count for full content."""
+        return self.metadata.estimated_tokens + len(self.body) // 4
+
+
+# Regex to match YAML frontmatter
+FRONTMATTER_PATTERN = re.compile(
+    r"^---\s*\n(.*?)\n---\s*\n",
+    re.DOTALL,
+)
+
+
+def _parse_frontmatter(content: str) -> tuple[Dict, str]:
+    """Parse YAML frontmatter from skill content.
+
+    Args:
+        content: Full SKILL.md content
+
+    Returns:
+        Tuple of (frontmatter dict, body string)
+
+    Raises:
+        SkillParseError: If frontmatter is missing or invalid
+    """
+    match = FRONTMATTER_PATTERN.match(content)
+    if not match:
+        raise SkillParseError("SKILL.md must start with YAML frontmatter (--- delimiters)")
+
+    try:
+        frontmatter = yaml.safe_load(match.group(1))
+        if not isinstance(frontmatter, dict):
+            raise SkillParseError("YAML frontmatter must be a mapping")
+    except yaml.YAMLError as e:
+        raise SkillParseError(f"Invalid YAML in frontmatter: {e}")
+
+    body = content[match.end() :].strip()
+    return frontmatter, body
+
+
+def _parse_allowed_tools(value: Optional[str]) -> List[str]:
+    """Parse allowed-tools string into list.
+
+    Args:
+        value: Space-separated tool names or None
+
+    Returns:
+        List of tool names
+    """
+    if not value:
+        return []
+    return value.split()
+
+
+def load_skill_metadata(content: str) -> SkillMetadata:
+    """Load Level 1 metadata from skill content.
+
+    Parses only the YAML frontmatter to extract essential metadata.
+    This is the most token-efficient way to discover skill capabilities.
+
+    Args:
+        content: Full SKILL.md content string
+
+    Returns:
+        SkillMetadata with essential fields
+
+    Raises:
+        SkillParseError: If content is invalid
+    """
+    frontmatter, _ = _parse_frontmatter(content)
+
+    # Required fields
+    if "name" not in frontmatter:
+        raise SkillParseError("SKILL.md frontmatter must include 'name' field")
+
+    if "description" not in frontmatter:
+        raise SkillParseError("SKILL.md frontmatter must include 'description' field")
+
+    # Extract nested metadata
+    nested_meta = frontmatter.get("metadata", {})
+
+    return SkillMetadata(
+        name=frontmatter["name"],
+        description=frontmatter["description"],
+        license=frontmatter.get("license"),
+        compatibility=frontmatter.get("compatibility"),
+        allowed_tools=_parse_allowed_tools(frontmatter.get("allowed-tools")),
+        category=nested_meta.get("category"),
+        domain=nested_meta.get("domain"),
+        author=nested_meta.get("author"),
+        repository=nested_meta.get("repository"),
+    )
+
+
+def load_skill_full(content: str) -> SkillFull:
+    """Load Level 2 full skill content.
+
+    Parses both frontmatter metadata and the complete body.
+    Use when skill has been selected and full instructions are needed.
+
+    Args:
+        content: Full SKILL.md content string
+
+    Returns:
+        SkillFull with metadata and body
+
+    Raises:
+        SkillParseError: If content is invalid
+    """
+    frontmatter, body = _parse_frontmatter(content)
+    metadata = load_skill_metadata(content)
+
+    return SkillFull(
+        metadata=metadata,
+        body=body,
+    )
+
+
+def load_skill_resource(path: Path) -> str:
+    """Load Level 3 resource file content.
+
+    Loads additional reference files on demand.
+    Use only when specific resource content is needed.
+
+    Args:
+        path: Path to resource file
+
+    Returns:
+        Resource file content
+
+    Raises:
+        SkillNotFoundError: If resource doesn't exist
+    """
+    if not path.exists():
+        raise SkillNotFoundError(f"Resource not found: {path}")
+
+    return path.read_text()
+
+
+class SkillLoader:
+    """Progressive disclosure skill loader.
+
+    Discovers and loads skills from a directory structure:
+    ```
+    skills_dir/
+    ├── skill-name/
+    │   ├── SKILL.md
+    │   └── references/
+    │       ├── rubrics.md
+    │       └── examples.md
+    ```
+
+    Supports three loading levels:
+    - Level 1: load_metadata() - Just YAML frontmatter
+    - Level 2: load_full() - Complete SKILL.md
+    - Level 3: load_resource() - Reference files
+    """
+
+    def __init__(self, skills_dir: Path):
+        """Initialize loader with skills directory.
+
+        Args:
+            skills_dir: Path to directory containing skill subdirectories
+        """
+        self.skills_dir = skills_dir
+        self._metadata_cache: Dict[str, SkillMetadata] = {}
+
+    def list_skills(self) -> List[str]:
+        """List all available skill names.
+
+        Returns:
+            List of skill directory names that contain SKILL.md
+        """
+        if not self.skills_dir.exists():
+            return []
+
+        skills = []
+        for item in self.skills_dir.iterdir():
+            if item.is_dir() and (item / "SKILL.md").exists():
+                skills.append(item.name)
+
+        return sorted(skills)
+
+    def _get_skill_path(self, skill_name: str) -> Path:
+        """Get path to skill directory.
+
+        Args:
+            skill_name: Name of skill
+
+        Returns:
+            Path to skill directory
+
+        Raises:
+            SkillNotFoundError: If skill doesn't exist
+        """
+        skill_path = self.skills_dir / skill_name
+        skill_md = skill_path / "SKILL.md"
+
+        if not skill_md.exists():
+            raise SkillNotFoundError(f"Skill not found: {skill_name}")
+
+        return skill_path
+
+    def load_metadata(self, skill_name: str) -> SkillMetadata:
+        """Load Level 1 metadata for a skill.
+
+        Caches results for performance.
+
+        Args:
+            skill_name: Name of skill to load
+
+        Returns:
+            SkillMetadata with essential fields
+
+        Raises:
+            SkillNotFoundError: If skill doesn't exist
+            SkillParseError: If SKILL.md is invalid
+        """
+        if skill_name in self._metadata_cache:
+            return self._metadata_cache[skill_name]
+
+        skill_path = self._get_skill_path(skill_name)
+        content = (skill_path / "SKILL.md").read_text()
+        metadata = load_skill_metadata(content)
+
+        self._metadata_cache[skill_name] = metadata
+        return metadata
+
+    def load_full(self, skill_name: str) -> SkillFull:
+        """Load Level 2 full content for a skill.
+
+        Args:
+            skill_name: Name of skill to load
+
+        Returns:
+            SkillFull with metadata and body
+
+        Raises:
+            SkillNotFoundError: If skill doesn't exist
+            SkillParseError: If SKILL.md is invalid
+        """
+        skill_path = self._get_skill_path(skill_name)
+        content = (skill_path / "SKILL.md").read_text()
+        return load_skill_full(content)
+
+    def list_resources(self, skill_name: str) -> List[str]:
+        """List available Level 3 resources for a skill.
+
+        Args:
+            skill_name: Name of skill
+
+        Returns:
+            List of resource filenames in references/ directory
+        """
+        skill_path = self._get_skill_path(skill_name)
+        refs_dir = skill_path / "references"
+
+        if not refs_dir.exists():
+            return []
+
+        return sorted([f.name for f in refs_dir.iterdir() if f.is_file()])
+
+    def load_resource(self, skill_name: str, resource_name: str) -> str:
+        """Load Level 3 resource content.
+
+        Args:
+            skill_name: Name of skill
+            resource_name: Filename in references/ directory
+
+        Returns:
+            Resource file content
+
+        Raises:
+            SkillNotFoundError: If skill or resource doesn't exist
+        """
+        skill_path = self._get_skill_path(skill_name)
+        resource_path = skill_path / "references" / resource_name
+
+        return load_skill_resource(resource_path)

--- a/tests/unit/skills/test_loader.py
+++ b/tests/unit/skills/test_loader.py
@@ -1,0 +1,383 @@
+"""
+Tests for progressive disclosure skill loader per ADR-034.
+
+TDD Red Phase: These tests should fail until loader.py is implemented.
+
+Progressive disclosure levels:
+1. Metadata only (~100-200 tokens) - YAML frontmatter
+2. Full SKILL.md content (~500-1000 tokens)
+3. Resources on demand - files from references/ directory
+"""
+
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from llm_council.skills.loader import (
+    SkillLoader,
+    SkillMetadata,
+    SkillNotFoundError,
+    SkillParseError,
+    load_skill_metadata,
+    load_skill_full,
+    load_skill_resource,
+)
+
+
+# Test fixtures
+SAMPLE_SKILL_MD = """---
+name: test-skill
+description: |
+  A test skill for unit testing.
+  Keywords: test, example, demo
+
+license: MIT
+compatibility: "llm-council >= 2.0"
+metadata:
+  category: testing
+  domain: development
+  author: test-author
+
+allowed-tools: "Read Grep Glob mcp:llm-council/test"
+---
+
+# Test Skill
+
+This is the full content of the test skill.
+
+## Usage
+
+Use this skill for testing purposes.
+
+## Example
+
+```bash
+test-skill --verbose
+```
+"""
+
+SAMPLE_SKILL_MINIMAL = """---
+name: minimal-skill
+description: Minimal skill with required fields only.
+---
+
+# Minimal Skill
+
+Basic content.
+"""
+
+
+class TestSkillMetadata:
+    """Tests for SkillMetadata dataclass."""
+
+    def test_metadata_has_required_fields(self):
+        """SkillMetadata should have name and description."""
+        metadata = SkillMetadata(
+            name="test",
+            description="Test description",
+        )
+        assert metadata.name == "test"
+        assert metadata.description == "Test description"
+
+    def test_metadata_has_optional_fields(self):
+        """SkillMetadata should support optional fields."""
+        metadata = SkillMetadata(
+            name="test",
+            description="Test description",
+            license="MIT",
+            compatibility="llm-council >= 2.0",
+            allowed_tools=["Read", "Grep"],
+            category="testing",
+            domain="development",
+            author="test-author",
+        )
+        assert metadata.license == "MIT"
+        assert metadata.compatibility == "llm-council >= 2.0"
+        assert metadata.allowed_tools == ["Read", "Grep"]
+        assert metadata.category == "testing"
+
+    def test_metadata_token_estimate(self):
+        """Metadata should provide token estimate."""
+        metadata = SkillMetadata(
+            name="test-skill",
+            description="A test skill for unit testing.\nKeywords: test, example",
+        )
+        # Rough estimate: ~4 chars per token
+        # Minimal metadata should be small
+        assert 10 <= metadata.estimated_tokens <= 50
+
+
+class TestLoadSkillMetadata:
+    """Tests for Level 1: Metadata extraction."""
+
+    def test_load_metadata_from_string(self):
+        """Should parse YAML frontmatter from skill content."""
+        metadata = load_skill_metadata(SAMPLE_SKILL_MD)
+
+        assert metadata.name == "test-skill"
+        assert "test skill" in metadata.description.lower()
+        assert metadata.license == "MIT"
+
+    def test_load_metadata_extracts_allowed_tools(self):
+        """Should parse allowed-tools into list."""
+        metadata = load_skill_metadata(SAMPLE_SKILL_MD)
+
+        assert "Read" in metadata.allowed_tools
+        assert "Grep" in metadata.allowed_tools
+        assert "mcp:llm-council/test" in metadata.allowed_tools
+
+    def test_load_metadata_extracts_nested_metadata(self):
+        """Should extract nested metadata fields."""
+        metadata = load_skill_metadata(SAMPLE_SKILL_MD)
+
+        assert metadata.category == "testing"
+        assert metadata.domain == "development"
+        assert metadata.author == "test-author"
+
+    def test_load_metadata_handles_minimal_skill(self):
+        """Should handle skill with only required fields."""
+        metadata = load_skill_metadata(SAMPLE_SKILL_MINIMAL)
+
+        assert metadata.name == "minimal-skill"
+        assert "Minimal skill" in metadata.description
+        assert metadata.license is None
+        assert metadata.allowed_tools == []
+
+    def test_load_metadata_raises_on_missing_frontmatter(self):
+        """Should raise error if no YAML frontmatter."""
+        with pytest.raises(SkillParseError) as exc_info:
+            load_skill_metadata("# No frontmatter\n\nJust content.")
+        assert "frontmatter" in str(exc_info.value).lower()
+
+    def test_load_metadata_raises_on_missing_name(self):
+        """Should raise error if name is missing."""
+        invalid_skill = """---
+description: Missing name field.
+---
+# Content
+"""
+        with pytest.raises(SkillParseError) as exc_info:
+            load_skill_metadata(invalid_skill)
+        assert "name" in str(exc_info.value).lower()
+
+
+class TestLoadSkillFull:
+    """Tests for Level 2: Full SKILL.md loading."""
+
+    def test_load_full_returns_complete_content(self):
+        """Should return full skill content including body."""
+        result = load_skill_full(SAMPLE_SKILL_MD)
+
+        assert result.metadata.name == "test-skill"
+        assert "# Test Skill" in result.body
+        assert "## Usage" in result.body
+        assert "## Example" in result.body
+
+    def test_load_full_separates_metadata_and_body(self):
+        """Body should not include YAML frontmatter."""
+        result = load_skill_full(SAMPLE_SKILL_MD)
+
+        assert "---" not in result.body.strip()[:10]  # No frontmatter delimiter at start
+        assert "name:" not in result.body
+
+    def test_load_full_preserves_code_blocks(self):
+        """Should preserve code blocks in body."""
+        result = load_skill_full(SAMPLE_SKILL_MD)
+
+        assert "```bash" in result.body
+        assert "test-skill --verbose" in result.body
+
+    def test_load_full_estimates_body_tokens(self):
+        """Should estimate tokens for full content."""
+        result = load_skill_full(SAMPLE_SKILL_MD)
+
+        # Full content should be more than metadata
+        assert result.estimated_tokens > result.metadata.estimated_tokens
+        assert result.estimated_tokens < 2000  # Reasonable upper bound
+
+
+class TestSkillLoader:
+    """Tests for SkillLoader class."""
+
+    @pytest.fixture
+    def skill_dir(self) -> Path:
+        """Create temporary skills directory with test skills."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skills_path = Path(tmpdir) / ".github" / "skills"
+
+            # Create test-skill
+            test_skill_dir = skills_path / "test-skill"
+            test_skill_dir.mkdir(parents=True)
+            (test_skill_dir / "SKILL.md").write_text(SAMPLE_SKILL_MD)
+
+            # Create references
+            refs_dir = test_skill_dir / "references"
+            refs_dir.mkdir()
+            (refs_dir / "rubrics.md").write_text("# Rubrics\n\nTest rubric content.")
+            (refs_dir / "examples.md").write_text("# Examples\n\nTest examples.")
+
+            # Create minimal-skill
+            minimal_dir = skills_path / "minimal-skill"
+            minimal_dir.mkdir(parents=True)
+            (minimal_dir / "SKILL.md").write_text(SAMPLE_SKILL_MINIMAL)
+
+            yield skills_path
+
+    def test_loader_discovers_skills(self, skill_dir: Path):
+        """Loader should discover all skills in directory."""
+        loader = SkillLoader(skill_dir)
+        skills = loader.list_skills()
+
+        assert "test-skill" in skills
+        assert "minimal-skill" in skills
+
+    def test_loader_loads_metadata_level1(self, skill_dir: Path):
+        """Loader should load Level 1 metadata."""
+        loader = SkillLoader(skill_dir)
+        metadata = loader.load_metadata("test-skill")
+
+        assert metadata.name == "test-skill"
+        assert metadata.category == "testing"
+
+    def test_loader_loads_full_level2(self, skill_dir: Path):
+        """Loader should load Level 2 full content."""
+        loader = SkillLoader(skill_dir)
+        full = loader.load_full("test-skill")
+
+        assert full.metadata.name == "test-skill"
+        assert "# Test Skill" in full.body
+
+    def test_loader_loads_resource_level3(self, skill_dir: Path):
+        """Loader should load Level 3 resources."""
+        loader = SkillLoader(skill_dir)
+        rubrics = loader.load_resource("test-skill", "rubrics.md")
+
+        assert "# Rubrics" in rubrics
+        assert "Test rubric content" in rubrics
+
+    def test_loader_lists_resources(self, skill_dir: Path):
+        """Loader should list available resources."""
+        loader = SkillLoader(skill_dir)
+        resources = loader.list_resources("test-skill")
+
+        assert "rubrics.md" in resources
+        assert "examples.md" in resources
+
+    def test_loader_raises_skill_not_found(self, skill_dir: Path):
+        """Loader should raise error for unknown skill."""
+        loader = SkillLoader(skill_dir)
+
+        with pytest.raises(SkillNotFoundError):
+            loader.load_metadata("nonexistent-skill")
+
+    def test_loader_raises_resource_not_found(self, skill_dir: Path):
+        """Loader should raise error for unknown resource."""
+        loader = SkillLoader(skill_dir)
+
+        with pytest.raises(SkillNotFoundError):
+            loader.load_resource("test-skill", "nonexistent.md")
+
+    def test_loader_handles_skill_without_resources(self, skill_dir: Path):
+        """Loader should handle skills with no references directory."""
+        loader = SkillLoader(skill_dir)
+        resources = loader.list_resources("minimal-skill")
+
+        assert resources == []
+
+    def test_loader_caches_metadata(self, skill_dir: Path):
+        """Loader should cache metadata for performance."""
+        loader = SkillLoader(skill_dir)
+
+        # Load twice
+        meta1 = loader.load_metadata("test-skill")
+        meta2 = loader.load_metadata("test-skill")
+
+        # Should be same object (cached)
+        assert meta1 is meta2
+
+
+class TestLoadSkillResource:
+    """Tests for Level 3: Resource loading."""
+
+    def test_load_resource_from_path(self):
+        """Should load resource file content."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            resource_path = Path(tmpdir) / "test.md"
+            resource_path.write_text("# Test Resource\n\nContent here.")
+
+            content = load_skill_resource(resource_path)
+
+            assert "# Test Resource" in content
+            assert "Content here" in content
+
+    def test_load_resource_raises_on_missing(self):
+        """Should raise error for missing resource."""
+        with pytest.raises(SkillNotFoundError):
+            load_skill_resource(Path("/nonexistent/path.md"))
+
+
+class TestProgressiveDisclosureIntegration:
+    """Integration tests for progressive disclosure workflow."""
+
+    @pytest.fixture
+    def skill_dir(self) -> Path:
+        """Create temporary skills directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skills_path = Path(tmpdir) / ".github" / "skills"
+            test_skill_dir = skills_path / "test-skill"
+            test_skill_dir.mkdir(parents=True)
+            (test_skill_dir / "SKILL.md").write_text(SAMPLE_SKILL_MD)
+
+            refs_dir = test_skill_dir / "references"
+            refs_dir.mkdir()
+            (refs_dir / "detailed.md").write_text("# Detailed\n\n" + "x" * 1000)
+
+            yield skills_path
+
+    def test_progressive_loading_token_efficiency(self, skill_dir: Path):
+        """Progressive loading should be token-efficient."""
+        loader = SkillLoader(skill_dir)
+
+        # Level 1: Just metadata
+        meta = loader.load_metadata("test-skill")
+        level1_tokens = meta.estimated_tokens
+
+        # Level 2: Full content
+        full = loader.load_full("test-skill")
+        level2_tokens = full.estimated_tokens
+
+        # Level 3: With resources
+        resource = loader.load_resource("test-skill", "detailed.md")
+        level3_tokens = level2_tokens + len(resource) // 4  # Rough estimate
+
+        # Each level should add more tokens
+        assert level1_tokens < level2_tokens
+        assert level2_tokens < level3_tokens
+
+        # Level 1 should be minimal
+        assert level1_tokens < 300  # ~100-200 tokens target
+
+    def test_load_all_levels_successively(self, skill_dir: Path):
+        """Should be able to load all levels in sequence."""
+        loader = SkillLoader(skill_dir)
+
+        # Start with metadata discovery
+        skills = loader.list_skills()
+        assert len(skills) > 0
+
+        # Load metadata for first skill
+        skill_name = skills[0]
+        meta = loader.load_metadata(skill_name)
+        assert meta.name == skill_name
+
+        # Decide to load full content
+        full = loader.load_full(skill_name)
+        assert full.body is not None
+
+        # Check for resources
+        resources = loader.list_resources(skill_name)
+        if resources:
+            content = loader.load_resource(skill_name, resources[0])
+            assert len(content) > 0


### PR DESCRIPTION
## Summary
Implements three-level progressive disclosure for agent skills to minimize token usage while providing full skill information on demand.

**Closes:** #280
**Parent Epic:** #262

## Progressive Disclosure Levels

| Level | Content | Target Tokens | Use Case |
|-------|---------|---------------|----------|
| **Level 1** | Metadata only | ~50-200 | Skill discovery/selection |
| **Level 2** | Full SKILL.md | ~500-1000 | Selected skill instructions |
| **Level 3** | Resources | On demand | Reference files when needed |

## Components

### Data Classes
- `SkillMetadata`: Level 1 metadata from YAML frontmatter
- `SkillFull`: Level 2 complete content with body

### Functions
- `load_skill_metadata()`: Parse YAML frontmatter only
- `load_skill_full()`: Parse complete SKILL.md
- `load_skill_resource()`: Load reference files

### SkillLoader Class
- `list_skills()`: Discover available skills
- `load_metadata()`: Level 1 with caching
- `load_full()`: Level 2 content
- `list_resources()`: Available reference files
- `load_resource()`: Level 3 content

## Test Coverage

26 tests covering:
- Metadata parsing and validation
- Full content extraction
- Resource loading
- Error handling (missing skills, invalid YAML)
- Caching behavior
- Progressive loading workflow

## Files Changed
- `src/llm_council/skills/__init__.py` (NEW)
- `src/llm_council/skills/loader.py` (NEW)
- `tests/unit/skills/test_loader.py` (NEW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)