### PR TITLE
Release v0.24.35: April 2026 model refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.35] - 2026-04-23
+
+### Changed
+
+- **April 2026 model refresh** — refreshed tier defaults to incorporate newly-available models:
+  - **Claude Opus 4.6 → 4.7** in `high`, `reasoning`, and `frontier` tier pools + aggregators. Opus 4.7 (GA on OpenRouter since Apr 16, 2026) ships a 13% coding-benchmark lift over 4.6, 3× vision resolution, and a 1M context window. Pricing unchanged per Anthropic.
+  - **Balanced tier aggregator and pool: `gpt-5.3-chat` → `gpt-5.4-mini`** — newer model, 400K context (was 128K), ~57% cheaper input / 68% cheaper output, with reasoning support.
+  - Updated `CouncilConfig.models` default, `TIER_AGGREGATORS`, `_DEFAULT_TIER_MODEL_POOLS`, and `llm_council.yaml`.
+
+### Added
+
+- **Registry entries** in `src/llm_council/models/registry.yaml`:
+  - `anthropic/claude-opus-4.7` (FRONTIER, 1M ctx, $15/$75 per 1M)
+  - `openai/gpt-5.4-mini` (STANDARD, 400K ctx, $0.75/$4.50 per 1M, reasoning)
+  - `openai/gpt-5.4-nano` (ECONOMY, 400K ctx, $0.20/$1.25 per 1M, reasoning)
+  - Older entries retained for backwards compatibility.
+
 ## [0.24.34] - 2026-03-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ council:
       high:
         models:
           - openai/gpt-4o
-          - anthropic/claude-opus-4-6
+          - anthropic/claude-opus-4-7
           - google/gemini-3-pro
         timeout_seconds: 180
 
@@ -463,7 +463,7 @@ The council includes built-in reliability features for long-running operations:
 
 **Progress Feedback**: During deliberation, progress updates show which models have responded and which are still pending:
 ```
-✓ claude-opus-4.6 (1/4) | waiting: gpt-5.1, gemini-3-pro, grok-4
+✓ claude-opus-4.7 (1/4) | waiting: gpt-5.1, gemini-3-pro, grok-4
 ✓ gemini-3-pro (2/4) | waiting: gpt-5.1, grok-4
 ```
 
@@ -1115,7 +1115,7 @@ This implements the "Sovereign Orchestrator" philosophy: the system must functio
 | Provider | Count | Examples |
 |----------|-------|----------|
 | OpenAI | 9 | gpt-4o, gpt-4o-mini, gpt-5.2, gpt-5-mini, o1, o1-preview, o1-mini, o3-mini |
-| Anthropic | 5 | claude-opus-4.6, claude-3-5-sonnet, claude-3-5-haiku |
+| Anthropic | 6 | claude-opus-4.7, claude-opus-4.6, claude-sonnet-4.6, claude-haiku-4.5 |
 | Google | 5 | gemini-3-pro, gemini-2.5-pro, gemini-2.0-flash, gemini-1.5-pro |
 | xAI | 2 | grok-4, grok-4.1-fast |
 | DeepSeek | 2 | deepseek-r1, deepseek-chat |
@@ -1137,7 +1137,7 @@ print(f"Context window: {info.context_window}")  # 128000
 print(f"Quality tier: {info.quality_tier}")      # frontier
 
 # Check capabilities
-window = provider.get_context_window("anthropic/claude-opus-4.6")  # 200000
+window = provider.get_context_window("anthropic/claude-opus-4.7")  # 1000000
 supports = provider.supports_reasoning("openai/o1")  # True
 
 # List all available models

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -30,7 +30,7 @@ council:
       high:
         models:
           - openai/gpt-4o
-          - anthropic/claude-opus-4-6
+          - anthropic/claude-opus-4-7
           - google/gemini-3-pro
         timeout_seconds: 180
 

--- a/llm_council.yaml
+++ b/llm_council.yaml
@@ -30,7 +30,7 @@ council:
       # BALANCED: Good quality with reasonable latency
       balanced:
         models:
-          - openai/gpt-5.3-chat
+          - openai/gpt-5.4-mini
           - anthropic/claude-sonnet-4.6
           - google/gemini-3.1-flash-lite-preview
           - deepseek/deepseek-v3.2
@@ -40,7 +40,7 @@ council:
       high:
         models:
           - openai/gpt-5.4
-          - anthropic/claude-opus-4.6
+          - anthropic/claude-opus-4.7
           - google/gemini-3.1-pro-preview
           - deepseek/deepseek-v3.2-speciale
         timeout_seconds: 180
@@ -49,7 +49,7 @@ council:
       reasoning:
         models:
           - openai/gpt-5.4-pro
-          - anthropic/claude-opus-4.6
+          - anthropic/claude-opus-4.7
           - google/gemini-3.1-pro-preview
           - deepseek/deepseek-v3.2-speciale
         timeout_seconds: 600
@@ -59,7 +59,7 @@ council:
       frontier:
         models:
           - openai/gpt-5.4-pro
-          - anthropic/claude-opus-4.6
+          - anthropic/claude-opus-4.7
           - google/gemini-3.1-pro-preview
           - deepseek/deepseek-v3.2-speciale
         timeout_seconds: 600

--- a/src/llm_council/models/registry.yaml
+++ b/src/llm_council/models/registry.yaml
@@ -36,6 +36,24 @@ models:
     modalities: ["text", "vision"]
     quality_tier: "frontier"
 
+  - id: "openai/gpt-5.4-mini"
+    context_window: 400000
+    pricing:
+      prompt: 0.00075
+      completion: 0.0045
+    supported_parameters: ["temperature", "top_p", "tools", "json_mode", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "standard"
+
+  - id: "openai/gpt-5.4-nano"
+    context_window: 400000
+    pricing:
+      prompt: 0.0002
+      completion: 0.00125
+    supported_parameters: ["temperature", "top_p", "tools", "json_mode", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "economy"
+
   - id: "openai/gpt-5.3-chat"
     context_window: 128000
     pricing:
@@ -144,6 +162,15 @@ models:
       prompt: 0.003
       completion: 0.015
     supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "frontier"
+
+  - id: "anthropic/claude-opus-4.7"
+    context_window: 1000000
+    pricing:
+      prompt: 0.015
+      completion: 0.075
+    supported_parameters: ["temperature", "top_p", "tools"]
     modalities: ["text", "vision"]
     quality_tier: "frontier"
 

--- a/src/llm_council/tier_contract.py
+++ b/src/llm_council/tier_contract.py
@@ -82,26 +82,26 @@ _DEFAULT_TIER_MODEL_POOLS = {
         "deepseek/deepseek-v3.2",
     ],
     "balanced": [
-        "openai/gpt-5.3-chat",
+        "openai/gpt-5.4-mini",
         "anthropic/claude-sonnet-4.6",
         "google/gemini-3.1-flash-lite-preview",
         "deepseek/deepseek-v3.2",
     ],
     "high": [
         "openai/gpt-5.4",
-        "anthropic/claude-opus-4.6",
+        "anthropic/claude-opus-4.7",
         "google/gemini-3.1-pro-preview",
         "deepseek/deepseek-v3.2-speciale",
     ],
     "reasoning": [
         "openai/gpt-5.4-pro",
-        "anthropic/claude-opus-4.6",
+        "anthropic/claude-opus-4.7",
         "google/gemini-3.1-pro-preview",
         "deepseek/deepseek-v3.2-speciale",
     ],
     "frontier": [
         "openai/gpt-5.4-pro",
-        "anthropic/claude-opus-4.6",
+        "anthropic/claude-opus-4.7",
         "google/gemini-3.1-pro-preview",
         "deepseek/deepseek-v3.2-speciale",
     ],
@@ -120,10 +120,10 @@ if TYPE_CHECKING:
 # Warning: Do not use a "mini" model to aggregate reasoning model outputs.
 TIER_AGGREGATORS: Dict[str, str] = {
     "quick": "openai/gpt-5-mini",  # Speed-matched
-    "balanced": "openai/gpt-5.3-chat",  # Quality-matched
+    "balanced": "openai/gpt-5.4-mini",  # Quality-matched
     "high": "openai/gpt-5.4",  # Full capability
-    "reasoning": "anthropic/claude-opus-4.6",  # Can understand reasoning outputs
-    "frontier": "anthropic/claude-opus-4.6",  # Best available for cutting-edge synthesis (ADR-027)
+    "reasoning": "anthropic/claude-opus-4.7",  # Can understand reasoning outputs
+    "frontier": "anthropic/claude-opus-4.7",  # Best available for cutting-edge synthesis (ADR-027)
 }
 
 

--- a/src/llm_council/unified_config.py
+++ b/src/llm_council/unified_config.py
@@ -188,7 +188,7 @@ class TierConfig(BaseModel):
             ),
             "balanced": TierPoolConfig(
                 models=[
-                    "openai/gpt-5.3-chat",
+                    "openai/gpt-5.4-mini",
                     "anthropic/claude-sonnet-4.6",
                     "google/gemini-3.1-flash-lite-preview",
                     "deepseek/deepseek-v3.2",
@@ -198,7 +198,7 @@ class TierConfig(BaseModel):
             "high": TierPoolConfig(
                 models=[
                     "openai/gpt-5.4",
-                    "anthropic/claude-opus-4.6",
+                    "anthropic/claude-opus-4.7",
                     "google/gemini-3.1-pro-preview",
                     "deepseek/deepseek-v3.2-speciale",
                 ],
@@ -207,7 +207,7 @@ class TierConfig(BaseModel):
             "reasoning": TierPoolConfig(
                 models=[
                     "openai/gpt-5.4-pro",
-                    "anthropic/claude-opus-4.6",
+                    "anthropic/claude-opus-4.7",
                     "google/gemini-3.1-pro-preview",
                     "deepseek/deepseek-v3.2-speciale",
                 ],
@@ -217,7 +217,7 @@ class TierConfig(BaseModel):
             "frontier": TierPoolConfig(
                 models=[
                     "openai/gpt-5.4-pro",
-                    "anthropic/claude-opus-4.6",
+                    "anthropic/claude-opus-4.7",
                     "google/gemini-3.1-pro-preview",
                     "deepseek/deepseek-v3.2-speciale",
                 ],
@@ -722,7 +722,7 @@ class CouncilConfig(BaseModel):
         default_factory=lambda: [
             "openai/gpt-5.4",
             "google/gemini-3.1-pro-preview",
-            "anthropic/claude-opus-4.6",
+            "anthropic/claude-opus-4.7",
             "deepseek/deepseek-v3.2-speciale",
         ],
         alias="LLM_COUNCIL_MODELS",


### PR DESCRIPTION
## Release Notes

### Changed
- **Claude Opus 4.6 → 4.7** in `high`, `reasoning`, and `frontier` tier pools + aggregators. Opus 4.7 (GA on OpenRouter since Apr 16, 2026) ships a 13% coding-benchmark lift over 4.6, 3× vision resolution, and a 1M context window. Pricing unchanged per Anthropic.
- **Balanced tier: `gpt-5.3-chat` → `gpt-5.4-mini`** in pool + aggregator — newer model, 400K context (was 128K), ~57% cheaper input / 68% cheaper output, reasoning-capable.
- Updated `CouncilConfig.models` default, `TIER_AGGREGATORS`, `_DEFAULT_TIER_MODEL_POOLS`, `llm_council.yaml`, `README.md`, `docs/getting-started/configuration.md`.

### Added
- Registry entries in `src/llm_council/models/registry.yaml`:
  - `anthropic/claude-opus-4.7` (FRONTIER, 1M ctx, $15/$75 per 1M)
  - `openai/gpt-5.4-mini` (STANDARD, 400K ctx, $0.75/$4.50 per 1M, reasoning)
  - `openai/gpt-5.4-nano` (ECONOMY, 400K ctx, $0.20/$1.25 per 1M, reasoning)

### Not changed
- `quick` tier pool (gpt-5-mini / haiku-4.5 / gemini-3.1-flash-lite / deepseek-v3.2) — still a good price/latency mix.
- DeepSeek (v3.2 / v3.2-speciale remain current; V4 rumored but unreleased).
- Google (no new Gemini since 3.1 Pro/Flash-Lite).
- xAI/Grok intentionally **not** re-added despite Grok 4.20 availability — prior stability issues (v0.24.24 bug) warrant soak-testing before re-introduction.

## Test plan
- [x] Full test suite: 2696 passed, 0 failed (~89s locally)
- [ ] CI: Test / Lint / Type Check / DCO pass
- [ ] Verify sample council consultation with `high` tier hits Opus 4.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)