### PR TITLE
chore(ci): Bump GitHub Actions to Node.js 24 major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: |
@@ -33,7 +33,7 @@ jobs:
           pytest tests/ -v --cov=src --cov-report=xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: github.event_name == 'push'
         with:
           files: coverage.xml
@@ -43,10 +43,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -60,10 +60,10 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/council-gate.yml
+++ b/.github/workflows/council-gate.yml
@@ -32,7 +32,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Need full history for diff
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && steps.check-key.outputs.has_key == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const verdict = '${{ steps.council.outputs.verdict }}';

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,15 +22,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # For git-revision-date plugin if used
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: uv pip install --system mkdocs-material mkdocs
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,21 +14,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       
       - name: Build package
         run: uv build
       
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -37,15 +37,15 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/
@@ -63,7 +63,7 @@ jobs:
       url: https://pypi.org/project/llm-council-mcp/
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/release-security.yml
+++ b/.github/workflows/release-security.yml
@@ -20,15 +20,15 @@ jobs:
     outputs:
       sbom-file: ${{ steps.sbom.outputs.filename }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: |
@@ -43,13 +43,13 @@ jobs:
           echo "filename=$SBOM_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sbom
           path: ${{ steps.sbom.outputs.filename }}
 
       - name: Attach SBOM to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ${{ steps.sbom.outputs.filename }}
 
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download SBOM artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: sbom
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -42,13 +42,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,10 +30,10 @@ jobs:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
           # ADR-035: Use security-extended, not security-and-quality
@@ -41,7 +41,7 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:python"
 
@@ -51,7 +51,7 @@ jobs:
     container:
       image: semgrep/semgrep:1.96.0  # Pinned version
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Semgrep for custom rules and fast pattern matching
       # CodeQL handles deep semantic analysis (avoid duplicates)
@@ -59,7 +59,7 @@ jobs:
         run: semgrep scan --config auto --config .semgrep/ --sarif --output semgrep.sarif . || true
 
       - name: Upload Semgrep results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: semgrep.sarif
@@ -68,7 +68,7 @@ jobs:
     name: Secret Detection
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run Trivy vulnerability scanner
         # Pinned to commit SHA following the March 2026 trivy-action supply chain
@@ -115,7 +115,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM'
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -139,15 +139,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: |
@@ -170,15 +170,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: |
@@ -190,7 +190,7 @@ jobs:
           cyclonedx-py environment -o sbom.json --output-format JSON
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sbom
           path: sbom.json

--- a/.github/workflows/sync-action.yml
+++ b/.github/workflows/sync-action.yml
@@ -33,7 +33,7 @@ jobs:
           echo "Syncing version: $VERSION"
 
       - name: Checkout action repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: amiable-dev/llm-council-action
           token: ${{ secrets.ACTION_REPO_PAT }}

--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate railway.json
         run: |
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Fetch all history for git describe
 
@@ -68,10 +68,10 @@ jobs:
           echo "Raw: ${RAW_VERSION} -> PEP 440: ${VERSION}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: deploy/railway/Dockerfile
@@ -88,7 +88,7 @@ jobs:
     needs: build-docker
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Fetch all history for git describe
 


### PR DESCRIPTION
## Summary

GitHub deprecated Node.js 20 in actions; default switches to Node.js 24 on **2026-06-02**, full removal **2026-09-16**. This bumps all JS-based actions across our workflows to their first Node.js 24-compatible major version, clearing the publish workflow's deprecation warnings.

## Bumps

| Action | From → To | First Node 24 major |
| --- | --- | --- |
| actions/checkout | v4 → v5 | v5 |
| actions/setup-python | v5 → v6 | v6 |
| actions/upload-artifact | v4 → v6 | v6 |
| actions/download-artifact | v4 → v7 | v7 |
| astral-sh/setup-uv | v5 → v7 | v7 |
| github/codeql-action (init/analyze/upload-sarif) | v3 → v4 | v4 |
| actions/github-script | v7 → v8 | v8 |
| codecov/codecov-action | v4 → v5 | v5 (composite) |
| softprops/action-gh-release | v2 → v3 | v3 |
| docker/setup-buildx-action | v3 → v4 | v4 |
| docker/build-push-action | v5 → v7 | v7 |
| actions/deploy-pages | v4 → v5 | v5 |

## Kept on current versions

| Action | Reason |
| --- | --- |
| `gitleaks/gitleaks-action@v2.3.7` | No Node 24 release yet (latest v2.3.9 still Node 20) |
| `actions/dependency-review-action@v4` | Latest v4.9.0 still Node 20; no v5 yet |
| `aquasecurity/trivy-action` | Already SHA-pinned to v0.36.0 in #332 (composite) |
| `snyk/actions/python@0.4.0` | Docker-based, no Node runtime issue |
| `pypa/gh-action-pypi-publish@release/v1` | Composite |
| `actions/upload-pages-artifact@v3` | Composite |
| `actions/attest-build-provenance@v2` | Composite |
| `ossf/scorecard-action@v2.4.0` | Composite |
| `amiable-dev/llm-council-action@v1` | Our own action |

## Compatibility notes

- `upload-artifact@v6` ↔ `download-artifact@v7` share the same `@actions/artifact` package version and are fully interoperable (both introduce Node 24 runtime only; no format change)
- `upload-artifact@v6` requires Actions Runner ≥ `2.327.1` (GitHub-hosted runners already on 2.333.x)
- `setup-uv@v7` keeps itself auto-updated on our hosted runners per its install instructions

## Test plan
- [ ] All required checks pass on this PR (Test, Lint, Type Check, CodeQL, Semgrep, Secret Detection, Dependency Review, DCO)
- [ ] After merge, verify Layer 3 jobs on master push succeed (Trivy, SonarCloud, Snyk, SBOM)
- [ ] Verify next release cycle (PyPI publish workflow) runs without Node 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)