### PR TITLE
chore(ci): Bump SonarSource/sonarqube-scan-action v6 → v7

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -130,7 +130,7 @@ jobs:
           fetch-depth: 0
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 


### PR DESCRIPTION
Follow-up to #334 — I missed this one. SonarSource released v7 on 2026-04-01, which switches the runtime to Node.js 24. v6 is still Node.js 20 and was still raising the deprecation warning on the post-merge Security Scanning run.

Only remaining Node 20 warning after this merges will be `gitleaks/gitleaks-action@v2.3.7`, which has no Node 24 release yet.

## Test plan
- [ ] CI green
- [ ] Post-merge Security Scanning on master has no Node 20 warning for sonarqube-scan-action

🤖 Generated with [Claude Code](https://claude.com/claude-code)