### PR TITLE
fix(extras): [mcp] now includes fastapi/uvicorn via transitive [http]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,12 @@ dependencies = [
 # HTTP server dependencies - install with: pip install "llm-council-core[http]"
 http = ["fastapi>=0.100.0", "uvicorn>=0.20.0"]
 # MCP server dependencies - install with: pip install "llm-council-core[mcp]"
-mcp = ["mcp>=1.22.0"]
+# Transitive on [http] because llm_council.mcp_server imports
+# llm_council.verification.api, which requires fastapi/uvicorn.
+mcp = [
+    "llm-council-core[http]",
+    "mcp>=1.22.0,<1.27",
+]
 # Secure key storage via system keychain - install with: pip install "llm-council-core[secure]"
 secure = ["keyring>=23.0.0"]
 # Ollama local LLM support via LiteLLM - install with: pip install "llm-council-core[ollama]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ dependencies = [
 http = ["fastapi>=0.100.0", "uvicorn>=0.20.0"]
 # MCP server dependencies - install with: pip install "llm-council-core[mcp]"
 # Transitive on [http] because llm_council.mcp_server imports
-# llm_council.verification.api, which requires fastapi/uvicorn.
+# llm_council.verification.api, which imports fastapi; [http] also includes
+# uvicorn for running the HTTP server.
 mcp = [
     "llm-council-core[http]",
     "mcp>=1.22.0,<1.27",

--- a/src/llm_council/cli.py
+++ b/src/llm_council/cli.py
@@ -237,8 +237,8 @@ def serve_mcp():
     """
     try:
         from llm_council.mcp_server import mcp
-    except ImportError:
-        print("Error: MCP dependencies not installed.", file=sys.stderr)
+    except ImportError as e:
+        print(f"Error importing MCP server: {e}", file=sys.stderr)
         print("\nTo use the MCP server, install with:", file=sys.stderr)
         print("    pip install 'llm-council-core[mcp]'", file=sys.stderr)
         print("\nFor library-only usage, import directly:", file=sys.stderr)

--- a/uv.lock
+++ b/uv.lock
@@ -1429,7 +1429,9 @@ http = [
     { name = "uvicorn" },
 ]
 mcp = [
+    { name = "fastapi" },
     { name = "mcp" },
+    { name = "uvicorn" },
 ]
 ollama = [
     { name = "litellm" },
@@ -1442,11 +1444,12 @@ secure = [
 requires-dist = [
     { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.100.0" },
     { name = "fastapi", marker = "extra == 'http'", specifier = ">=0.100.0" },
+    { name = "fastapi", marker = "extra == 'mcp'", specifier = ">=0.100.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "keyring", marker = "extra == 'secure'", specifier = ">=23.0.0" },
     { name = "litellm", marker = "extra == 'ollama'", specifier = ">=1.50.0" },
-    { name = "mcp", marker = "extra == 'all'", specifier = ">=1.22.0" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.22.0" },
+    { name = "mcp", marker = "extra == 'all'", specifier = ">=1.22.0,<1.27" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.22.0,<1.27" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
@@ -1461,6 +1464,7 @@ requires-dist = [
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'dev'", specifier = ">=2.0.0" },
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.20.0" },
     { name = "uvicorn", marker = "extra == 'http'", specifier = ">=0.20.0" },
+    { name = "uvicorn", marker = "extra == 'mcp'", specifier = ">=0.20.0" },
     { name = "vcrpy", marker = "extra == 'dev'", specifier = ">=6.0.0" },
 ]
 provides-extras = ["all", "dev", "docs", "http", "mcp", "ollama", "secure"]


### PR DESCRIPTION
## Summary

Fixes #344 — `[mcp]` extra omits `fastapi`/`uvicorn` (transitively required by `mcp_server.py`), `mcp>=1.22.0` is loose enough to resolve to the API-incompatible 1.27, and `serve_mcp()` masks the real `ImportError` behind a generic "MCP dependencies not installed" message.

## Changes

- **`pyproject.toml`** — `[mcp]` now transitively depends on `[http]` (fastapi + uvicorn). Follows the existing `[all] = ["llm-council-core[http,mcp]"]` transitive-extras pattern. Also adds `mcp<1.27` upper bound.
- **`src/llm_council/cli.py`** — `serve_mcp()` surfaces the real `ImportError` (e.g. `No module named 'fastapi'`) in addition to the install hint.
- **`uv.lock`** — regenerated for the new constraints.

## Test plan

- [x] `uv lock` resolves cleanly with the new constraints (local)
- [ ] CI: `uv run pytest tests/ -v`
- [ ] CI: `uv run ruff check src/ tests/`
- [ ] CI: `uv run mypy src/llm_council --ignore-missing-imports`
- [ ] Manual reproduction: a fresh `uv tool install 'llm-council-core[mcp,secure]'` from this branch produces a working `llm-council` (no ImportError)

## Notes

`serve_http()` has the same misleading-error-message pattern (cli.py ~line 225). Not touched here to keep this PR scoped to #344; worth a small follow-up PR for symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)