### PR TITLE
docs(mcp): Document reasoning tier and MCP_TIMEOUT for consult_council

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -34,6 +34,53 @@ Use the MCP server for AI assistants like Claude Code or Claude Desktop:
 claude mcp add llm-council --scope user -- llm-council
 ```
 
+#### Configuring MCP Client Timeouts
+
+The council's `high` and `reasoning` tiers can take 3–10 minutes when frontier
+reasoning models review large inputs (e.g. multi-thousand-line ADRs). MCP
+clients have their own transport-layer timeout that is **independent of the
+server's tier budget**. If the client times out first, you'll see "MCP layer
+timeout" errors even though the council is still working — see
+[ADR-012](https://github.com/amiable-dev/llm-council/blob/master/docs/adr/ADR-012-mcp-server-reliability.md)
+and issue [#327](https://github.com/amiable-dev/llm-council/issues/327) for
+the underlying constraint.
+
+Set `MCP_TIMEOUT` (milliseconds) on the **client** to at least the tier's
+server budget:
+
+| Tier        | Server budget | Minimum client `MCP_TIMEOUT` |
+|-------------|---------------|-----------------------------|
+| `quick`     | ~30s          | `60000` (1 min)             |
+| `balanced`  | ~90s          | `120000` (2 min)            |
+| `high`      | ~180s         | `300000` (5 min)            |
+| `reasoning` | ~600s         | `900000` (15 min)           |
+
+In Claude Code, set it per-server in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "llm-council": {
+      "type": "stdio",
+      "command": "llm-council",
+      "args": [],
+      "env": {
+        "MCP_TIMEOUT": "900000"
+      }
+    }
+  }
+}
+```
+
+Or set it globally as a shell env var before launching the client:
+
+```bash
+export MCP_TIMEOUT=900000
+```
+
+This is the only fix for "consult_council times out at high tier" — the
+server is running fine, the client is hanging up early.
+
 ### Python SDK (For Custom Applications)
 
 Use the Python SDK for custom integrations:

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -147,7 +147,17 @@ async def consult_council(
 
     Args:
         query: The question to ask the council.
-        confidence: Response quality level - "quick" (2 models, ~10s), "balanced" (3 models, ~25s), or "high" (full council, ~45s).
+        confidence: Tier for model selection and timeout budgets. One of:
+            - "quick"     - 2 fast models, ~30s server budget (per-model 20s)
+            - "balanced"  - 3 models, ~90s server budget (per-model 45s)
+            - "high"      - full council, ~180s server budget (per-model 90s) [default]
+            - "reasoning" - full council using slow reasoning models, ~600s server budget (per-model 300s)
+            Unknown values silently fall back to "high".
+            Note: "high" and "reasoning" can exceed typical MCP client transport
+            timeouts (Claude Code default ~60s). Set MCP_TIMEOUT (milliseconds)
+            in your client config to at least the tier's server budget when
+            using these tiers — otherwise the client will cut the connection
+            before the council finishes deliberating.
         include_details: If True, includes individual model responses and rankings.
         verdict_type: Type of verdict to render (ADR-025b Jury Mode):
             - "synthesis": Default behavior, unstructured natural language synthesis


### PR DESCRIPTION
## Summary

- `consult_council` docstring now lists all four runnable tiers (`quick`/`balanced`/`high`/`reasoning`) with real server budgets, replacing stale pre-ADR-012 estimates
- Adds a note in the docstring about the client-side `MCP_TIMEOUT` requirement for `high`/`reasoning` so LLM callers don't conclude high tier is broken
- New \"Configuring MCP Client Timeouts\" section in `docs/integrations/index.md` with tier→`MCP_TIMEOUT` mapping and a concrete `.mcp.json` env block

## Why

A different Claude Code instance reported that `consult_council` (a) didn't allow reasoning tier and (b) timed out at the MCP layer on high tier. Investigation:

- **(a)** is a docstring lie. The runtime has accepted `\"reasoning\"` since 4a4234d (Dec 2025); the schema is plain `string` with no enum; the docstring is the only signal an LLM caller gets, and it only listed quick/balanced/high. `verify` and the bundled skills already document reasoning correctly — only `consult_council` was out of sync.
- **(b)** is the well-documented client-side MCP transport timeout race. ADR-012 §419 explicitly chose not to fix this server-side, and issue #327 has hard evidence (Stage 1 took 652s at high tier on a large input). The only fix is on the client.

Use case: the requirement is council review with reasoning models on multi-thousand-line ADRs. Both the docstring fix and the `MCP_TIMEOUT` guidance are needed for that to work end-to-end.

No runtime behavior change — pure docstring + markdown.

## Test plan

- [x] CI passes (lint/typecheck — no test impact since no code changes)
- [ ] Spot-check rendered docs in Docusaurus preview
- [ ] After release: confirm a fresh MCP client sees `\"reasoning\"` listed in the consult_council tool description

🤖 Generated with [Claude Code](https://claude.com/claude-code)