### PR TITLE
Release v0.24.43: fix dead health-probe model + refresh tier pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.43] - 2026-06-02
+
+### Fixed
+
+- **Health check no longer reports a spurious "error" from a retired probe model** — `council_health_check` (and the OpenRouter / Requesty / direct gateway `health_check()` methods) probed connectivity with a hardcoded `google/gemini-2.0-flash-001`, which has since been retired from OpenRouter and now 404s. The probe failure surfaced as a health-check `error` / `ready: false` even when the council itself was perfectly healthy. The probe model is now a single shared constant `DEFAULT_HEALTH_CHECK_MODEL` in `gateway/base.py` (set to the current, cheap, GA `google/gemini-2.5-flash-lite`) referenced by all four call sites, so the next retirement is a one-line update instead of five scattered literals. The direct gateway's native-API probe ids were refreshed too (`claude-3-5-haiku-20241022` → `claude-haiku-4-5`, `gemini-2.0-flash-001` → `gemini-2.5-flash-lite`).
+- **Broken model in the `high` / `reasoning` / `frontier` tier pools** — those pools (and their code-level defaults in `tier_contract.py` / `unified_config.py`) referenced `deepseek/deepseek-v3.2-speciale`, which does not exist on OpenRouter and would fail at request time. Replaced with current DeepSeek models (`deepseek-v4-pro` for high/frontier, the reasoning-specialised `deepseek-r1` for reasoning).
+
+### Changed
+
+- **Tier model pools refreshed against the live OpenRouter catalogue (2026-06-02)** — every tier pool model was cross-checked against `https://openrouter.ai/api/v1/models`; all 20 pool entries plus the health probe now resolve both in the bundled registry and live on OpenRouter. Changes: `quick`/`balanced` move from the `gemini-3.1-flash-lite-preview` preview to the GA `gemini-3.1-flash-lite`; `high`/`reasoning`/`frontier` bump Anthropic from `claude-opus-4.7` to the newest `claude-opus-4.8` (same price); `frontier` bumps OpenAI to `gpt-5.5-pro`. Tier aggregators and the default council model list were updated to match. Registry (`models/registry.yaml`) bumped to v1.3 with `gpt-5.5-pro`, `claude-opus-4.8`, `gemini-3.1-flash-lite` (GA), `gemini-2.5-flash-lite`, and `deepseek-v4-pro` added; retired `gemini-2.0-flash-001` and non-existent `deepseek-v3.2-speciale` removed; stale `claude-opus-4.7` pricing corrected to live values.
+
 ## [0.24.42] - 2026-05-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,845 +1,145 @@
-# CLAUDE.md - Technical Notes for LLM Council
+# CLAUDE.md — Technical Notes for LLM Council
 
-This file contains technical details, architectural decisions, and important implementation notes for future development sessions.
+Durable architecture, design rationale, and gotchas for future sessions. This file is a **map and a rationale**, not an API reference — for function signatures, read the source (they go stale here). When you change behavior that contradicts a note below, update the note.
 
 ## Project Overview
 
-LLM Council is a 3-stage deliberation system where multiple LLMs collaboratively answer user questions. The key innovation is anonymized peer review in Stage 2, preventing models from playing favorites.
+LLM Council is a 3-stage deliberation system where multiple LLMs collaboratively answer a question. The core innovation: **anonymized peer review** in Stage 2 (models rank "Response A/B/C…", not each other by name) so they can't play favorites.
 
-## Architecture
+It is a single Python package (`src/llm_council/`) exposing a CLI, an HTTP/REST server, and an MCP server. There is **no separate frontend or `backend/` directory** — older docs referencing `backend.main`, `frontend/src/`, `main.py`, or `storage.py` describe a retired layout.
 
-### Backend Structure (`backend/`)
+## Running & Developing
 
-**`tier_contract.py`** - ADR-022 Tier Contract
-- `TierContract`: Frozen dataclass defining tier execution parameters
-  - `tier`: Confidence level (quick|balanced|high|reasoning)
-  - `deadline_ms`, `per_model_timeout_ms`: Timeout configuration
-  - `token_budget`, `max_attempts`: Resource limits
-  - `requires_peer_review`, `requires_verifier`: Stage flags
-  - `allowed_models`, `aggregator_model`: Model configuration
-  - `override_policy`: Escalation rules
-- `create_tier_contract(tier, task_domain)`: Factory function to create contracts
-  - **ADR-026**: Now accepts optional `task_domain` parameter for dynamic selection
-  - Uses `select_tier_models()` when `LLM_COUNCIL_MODEL_INTELLIGENCE=true`
-- `TIER_AGGREGATORS`: Speed-matched aggregator models per tier
-- `DEFAULT_TIER_CONTRACTS`: Pre-built contracts for all tiers
+- Install / setup: `make setup` (deps + `.env`), or `make install` (deps only).
+- Run the HTTP API: `llm-council serve [--host H] [--port 8000]` (default port **8000**). Entry point is `llm_council.cli:main`; the FastAPI app lives in `src/llm_council/http_server.py`.
+- Other CLI subcommands: `setup-key` (store API key in keychain, ADR-013), `bias-report` (cross-session bias analysis, ADR-018), `install-skills`, `gate`.
+- Quality gates: `make test` / `make test-fast` / `make test-cov`, `make lint` (ruff), `make typecheck` (mypy), `make check` (lint+typecheck), `make fix`. ~120 test files in `tests/`.
+- `tests/test_openrouter.py` verifies OpenRouter connectivity and that a model identifier resolves before you add it to the council.
+- **Relative imports**: modules import siblings as `from .unified_config import …`. Keep imports relative within the package.
+- ADRs live in `docs/adr/`. Most subsystems below cite the ADR that introduced them — read it for design context.
 
-**`metadata/`** - ADR-026 Model Intelligence Layer
-- Provides model metadata abstraction for the Model Intelligence Layer
-- Supports offline operation (StaticRegistryProvider) and dynamic metadata (DynamicMetadataProvider)
+## Architecture: the L1→L4 layer model (ADR-024)
 
-- **`types.py`**: Core types
-  - `ModelInfo`: Frozen dataclass with id, context_window, pricing, modalities, quality_tier
-  - `QualityTier`: Enum (FRONTIER, STANDARD, ECONOMY, LOCAL)
-  - `Modality`: Enum (TEXT, VISION, AUDIO, etc.)
-  - `ModelStatus`: Enum (AVAILABLE, DEPRECATED, PREVIEW, BETA) - ADR-028
-- **`protocol.py`**: `MetadataProvider` Protocol (interface)
-  - `get_model_info()`, `get_context_window()`, `get_pricing()`
-  - `supports_reasoning()`, `list_available_models()`
-- **`static_registry.py`**: `StaticRegistryProvider` (31 models from YAML)
-  - Offline-safe provider using bundled registry + LiteLLM fallback
-  - Registry at `src/llm_council/models/registry.yaml`
-- **`dynamic_provider.py`**: `DynamicMetadataProvider` (ADR-026 Phase 1)
-  - Fetches metadata from OpenRouter API with TTL caching
-  - Falls back to StaticRegistryProvider when cache empty or offline
-- **`cache.py`**: TTL caching infrastructure
-  - `TTLCache`: Thread-safe cache with LRU eviction
-  - `ModelIntelligenceCache`: Composite (registry 1hr, availability 5min TTL)
-- **`openrouter_client.py`**: Async OpenRouter API client
-  - `fetch_models()`: Fetches model metadata from OpenRouter
-  - `transform_api_model()`: Transforms API response to ModelInfo
-- **`selection.py`**: Tier selection algorithm (ADR-026 Phase 1)
-  - `TIER_WEIGHTS`: Per-tier weight matrices (quick→latency, reasoning→quality)
-  - `QUALITY_TIER_SCORES`: QualityTier → float mapping (ADR-030 benchmark-justified):
-    - FRONTIER: 0.95 (MMLU 87-90%)
-    - STANDARD: 0.85 (MMLU 80-86%, +0.10 from 0.75)
-    - ECONOMY: 0.70 (MMLU 70-79%, +0.15 from 0.55)
-    - LOCAL: 0.50 (MMLU 55-80%, +0.10 from 0.40)
-  - `COST_REFERENCE_HIGH`: Reference price for cost normalization (0.015 per 1K tokens)
-  - `ModelCandidate`: Dataclass for model scoring
-  - `apply_anti_herding_penalty()`: Penalizes models with >30% traffic
-  - `select_with_diversity()`: Enforces provider diversity (min 2 providers)
-  - `select_tier_models()`: Main entry point for dynamic selection
-  - **Metadata Integration Functions** (ADR-026 Phase 1 "Hollow" Fix):
-    - `_get_provider_safe()`: Get provider without crashing (returns None on failure)
-    - `_get_quality_score_from_metadata()`: Real QualityTier lookup (not regex)
-    - `_get_cost_score_from_metadata()`: Real pricing data (not regex)
-    - `_meets_context_requirement()`: Real context window filtering (not always True)
-  - **Circuit Breaker Integration** (ADR-030):
-    - `_is_circuit_breaker_enabled()`: Check if circuit breaker is enabled (env > config > default)
-    - `_is_circuit_breaker_open(model_id)`: Check if model's circuit is open
-    - `select_tier_models()` filters out models with open circuit breakers
-- **`scoring.py`**: Cost scoring algorithms (ADR-030)
-  - `MIN_PRICE`: Floor to avoid log(0) ($0.0001)
-  - `CostScaleAlgorithm`: Literal["linear", "log_ratio", "exponential"]
-  - `get_cost_score_log_ratio()`: Log-ratio scoring for exponential price differences
-  - `get_cost_score_exponential()`: Exponential decay scoring
-  - `get_cost_score_with_config()`: Uses algorithm from config/env var
-  - `QUALITY_TIER_BENCHMARK_SOURCES`: Citation URLs for quality tier justification
-- **`offline.py`**: Offline mode detection
-  - `is_offline_mode()`: Checks `LLM_COUNCIL_OFFLINE` env var
-- **`registry.py`**: ADR-028 Model Registry (Background Registry Pattern)
-  - `ModelRegistry`: Thread-safe singleton cache with asyncio.Lock
-  - `RegistryEntry`: Cached model info with timestamp
-  - `get_registry()`: Singleton factory
-  - `refresh_registry()`: Background refresh with stale-while-revalidate
-  - `get_candidates()`: Read-only access for request-time filtering
-  - `get_health_status()`: Health check for observability
-- **`worker.py`**: ADR-028 Background Discovery Worker
-  - `run_discovery_worker()`: Periodic registry refresh task
-  - Exponential backoff on failures
-  - Graceful shutdown via asyncio.Event
-- **`discovery.py`**: ADR-028 Request-Time Discovery
-  - `discover_tier_candidates()`: In-memory filtering from cached registry
-  - `_model_qualifies_for_tier()`: Tier-specific qualification logic
-  - `KNOWN_REASONING_FAMILIES`: Set of reasoning model families
-  - `_merge_deduplicate()`: Merge dynamic and static candidates
-  - `emit_discovery_fallback()`: Emit fallback events
-- **`startup.py`**: ADR-028 Application Lifecycle Hooks
-  - `start_discovery_worker()`: Start worker at app startup
-  - `stop_discovery_worker()`: Graceful shutdown
-  - `get_worker_status()`: Health check for worker state
-- **`__init__.py`**: `get_provider()` singleton factory
-  - Returns `StaticRegistryProvider` by default
-  - Returns `DynamicMetadataProvider` when `LLM_COUNCIL_MODEL_INTELLIGENCE=true`
-  - Offline mode (`LLM_COUNCIL_OFFLINE=true`) forces static provider
-  - ADR-028 exports: `get_registry`, `discover_tier_candidates`, lifecycle hooks
+Requests flow through four layers with formal boundary contracts in `layer_contracts.py`:
 
-**Environment Variables (ADR-026):**
-- `LLM_COUNCIL_MODEL_INTELLIGENCE=true`: Enable dynamic model selection
-- `LLM_COUNCIL_OFFLINE=true`: Force offline mode (static provider only)
+- **L1 Tier** (`tier_contract.py`, ADR-022) — picks a confidence tier (`quick|balanced|high|reasoning`, plus `frontier`) and its `TierContract` (timeouts, token budget, peer-review/verifier flags, allowed/aggregator models, escalation policy).
+- **L2 Triage** (`triage/`, ADR-020) — domain classification, wildcard specialist selection, per-model prompt optimization (e.g. Claude XML), complexity heuristics.
+- **L3 Council** (`council.py`) — the 3-stage deliberation core.
+- **L4 Gateway** (`gateway/`, `gateway_adapter.py`, ADR-023/030) — provider calls, circuit breaking.
 
-**Environment Variables (ADR-028 Discovery):**
-- `LLM_COUNCIL_DISCOVERY_ENABLED=true`: Enable background discovery
-- `LLM_COUNCIL_DISCOVERY_INTERVAL=300`: Refresh interval in seconds
-- `LLM_COUNCIL_DISCOVERY_MIN_CANDIDATES=3`: Minimum candidates before fallback
+**Principles (ADR-024):** layer sovereignty (each layer owns its decision), explicit/auditable escalation, failure isolation (gateway failures don't cascade into tier changes), constraint propagation downward, observability by default. Every boundary crossing validates and emits a `LayerEvent` (`emit_layer_event()`); `observability/` bridges those events to StatsD/Prometheus (ADR-030).
 
-**`performance/`** - ADR-026 Phase 3: Internal Performance Tracking
-- Tracks model performance from actual council sessions
-- Builds Internal Performance Index for quality scoring in model selection
+## Module map (`src/llm_council/`)
 
-- **`types.py`**: Core types
-  - `ModelSessionMetric`: Per-session per-model performance data (session_id, model_id, latency_ms, borda_score, parse_success)
-  - `ModelPerformanceIndex`: Aggregated performance (mean_borda_score, p50/p95_latency_ms, parse_success_rate, confidence_level)
-- **`store.py`**: JSONL persistence (follows bias_persistence.py pattern)
-  - `append_performance_records()`: Atomic append to JSONL file
-  - `read_performance_records()`: Read with max_days and model_id filtering
-- **`tracker.py`**: Main tracker class
-  - `InternalPerformanceTracker`: Aggregates metrics with exponential decay
-  - `record_session()`: Record metrics from completed council session
-  - `get_model_index()`: Get aggregated ModelPerformanceIndex
-  - `get_quality_score()`: Get 0-100 normalized score for selection.py
-- **`integration.py`**: Council integration
-  - `persist_session_performance_data()`: Extract and persist session metrics
-  - `get_tracker()`: Singleton factory for tracker
-- **`__init__.py`**: Module exports
+Council core
+- `council.py` — `stage1_collect_responses`, `stage2_collect_rankings` (anonymizes → `label_to_model`, parses rankings), `calculate_aggregate_rankings` (Borda), `stage3_synthesize_final`. Shadow-vote integration for frontier tier (ADR-027).
+- `openrouter.py` — `query_model` / `query_models_parallel`; returns `{content, reasoning_details?}`; returns `None` on failure (graceful degradation).
+- `http_server.py`, `mcp_server.py`, `cli.py` — the three entry surfaces. `skills/` — bundled skills (`install-skills`).
 
-**Performance Tracking Environment Variables:**
-- `LLM_COUNCIL_PERFORMANCE_TRACKING`: Enable/disable (default: true)
-- `LLM_COUNCIL_PERFORMANCE_STORE`: Custom store path
+Tiering & model selection
+- `tier_contract.py` (ADR-022), `unified_config.py` (ADR-024, see below).
+- `metadata/` (ADR-026/028) — model metadata abstraction. `StaticRegistryProvider` (offline, bundled `models/registry.yaml`, ~31 models / 8 providers) and `DynamicMetadataProvider` (OpenRouter API + TTL cache). Background discovery worker + request-time discovery (ADR-028). `intersection.py` resolves tier membership for multi-tier models (e.g. o1-preview).
+- `triage/` (ADR-020), `reasoning/` (ADR-026 Phase 2 — effort levels), `performance/` (ADR-026 Phase 3 — internal performance index from real sessions).
 
-**Confidence Levels (sample size thresholds):**
-- INSUFFICIENT: <10 samples
-- PRELIMINARY: 10-30 samples
-- MODERATE: 30-100 samples
-- HIGH: 100+ samples
+Frontier tier lifecycle (ADR-027/029)
+- `voting.py` — `VotingAuthority` (FULL / ADVISORY / EXCLUDED). Frontier tier defaults to **ADVISORY (Shadow Mode)**: votes logged + evaluated but zero weight in consensus.
+- `audition/` (ADR-029) — cold-start state machine SHADOW → PROBATION → EVALUATION → FULL (+ QUARANTINE). New models earn voting weight by volume before counting.
+- `graduation.py` — promote frontier → high (≥30 days, ≥100 sessions, <2% errors, ≥75th pct).
+- `cost_ceiling.py` — frontier capped at 5× high-tier avg cost. `frontier_fallback.py` — hard fallback frontier → high on timeout/rate-limit/API error.
 
-**`unified_config.py`** - ADR-024 Unified YAML Configuration
-- Single source of truth consolidating ADR-020, ADR-022, ADR-023, ADR-026 settings
-- Pydantic-based schema with validation
-- **Main Classes**:
-  - `UnifiedConfig`: Root configuration with tiers, triage, gateways, model_intelligence, evaluation
-  - `TierConfig`: Tier pools, defaults, escalation settings
-  - `TriageConfig`: Wildcard, prompt optimization, fast path settings
-  - `GatewayConfig`: Default gateway, providers, model routing, fallback chain
-  - `ModelIntelligenceConfig` (ADR-026): Dynamic model selection settings
-    - `enabled`: Whether dynamic selection is active (default: false)
-    - `refresh`: Cache TTL settings (registry_ttl, availability_ttl)
-    - `selection`: Selection algorithm settings (min_providers, default_count)
-    - `anti_herding`: Traffic concentration prevention (enabled, threshold, penalty)
-  - `EvaluationConfig` (ADR-031): Evaluation-time settings for scoring, safety, and bias
-    - `rubric`: RubricConfig (enabled, weights with validation)
-    - `safety`: SafetyConfig (enabled, score_cap)
-    - `bias`: BiasConfig (audit_enabled, persistence_enabled, thresholds, store_path, consent_level)
-    - `scoring` (ADR-030): Cost scoring algorithm configuration
-      - `cost_scale`: "linear" | "log_ratio" | "exponential" (default: "log_ratio")
-      - `cost_reference_high`: Reference expensive price (default: 0.015)
-    - `circuit_breaker` (ADR-030): Per-model circuit breaker configuration
-      - `enabled`: Enable circuit breaker (default: true)
-      - `failure_threshold`: Failure rate to trip (default: 0.25)
-      - `min_requests`: Min requests before evaluation (default: 5)
-      - `window_seconds`: Sliding window size (default: 600)
-      - `cooldown_seconds`: Cooldown when open (default: 1800)
-      - `half_open_max_requests`: Probe requests (default: 3)
-      - `half_open_success_threshold`: Success rate to close (default: 0.67)
-    - `audition` (ADR-029): Model audition configuration
-      - `enabled`: Enable audition mechanism (default: true)
-      - `max_audition_seats`: Max audition models per session (default: 1)
-      - `shadow`/`probation`/`evaluation`/`quarantine`: Phase-specific settings
-- **Key Functions**:
-  - `load_config(path)`: Load from YAML file with validation
-  - `get_effective_config()`: Get config with env var overrides applied
-  - `get_config()`, `reload_config()`: Global configuration management
-- **Configuration Priority**: YAML file > Environment variables > Defaults
-- **YAML File Locations** (searched in order):
-  1. `LLM_COUNCIL_CONFIG` environment variable
-  2. `./llm_council.yaml` (current directory)
-  3. `~/.config/llm-council/llm_council.yaml`
-- **Environment Variable Substitution**: Supports `${VAR_NAME}` syntax in YAML
-- **EvaluationConfig Environment Variables** (ADR-031):
-  - `RUBRIC_SCORING_ENABLED`: Enable rubric-based scoring
-  - `SAFETY_GATE_ENABLED`: Enable safety gate
-  - `BIAS_AUDIT_ENABLED`: Enable per-session bias auditing
-  - `BIAS_PERSISTENCE_ENABLED`: Enable cross-session bias persistence
+Evaluation & scoring
+- `rubric.py` (ADR-016) — multi-dimensional scoring (accuracy/relevance/completeness/conciseness/clarity). **Accuracy acts as a ceiling** (`calculate_weighted_score_with_accuracy_ceiling`): accuracy <5 caps at 4.0, 5–6 caps at 7.0, ≥7 uncapped — prevents confident-but-wrong answers ranking well. Falls back to holistic parsing if rubric JSON won't parse.
+- `safety_gate.py` (ADR-016) — caps score on harmful-pattern detection; context-aware exclusions for educational/defensive content.
+- `evaluation.py`, `quality/`, `verdict.py`, `dissent.py` — additional evaluation/quality surfaces.
+- `gateway/` (ADR-030) — `EnhancedCircuitBreaker` (sliding-window failure rate, default 25% over 10-min window, 30-min cooldown, half-open probes) + per-model registry that emits `L4_CIRCUIT_BREAKER_OPEN/CLOSE`. `scoring.py` — cost-scoring algorithms (linear/log_ratio/exponential).
 
-**`layer_contracts.py`** - ADR-024 Layer Interface Contracts
-- Formalizes L1→L2→L3→L4 layer boundaries with validation and observability
-- **Re-exports all layer interface types**:
-  - L1: `TierContract`, `create_tier_contract`
-  - L2: `TriageResult`, `TriageRequest`, `DomainCategory`, `WildcardConfig`
-  - L4: `GatewayRequest`, `GatewayResponse`, `CanonicalMessage`, `ContentBlock`
-- **Validation Functions**:
-  - `validate_tier_contract()`, `validate_triage_result()`, `validate_gateway_request()`
-  - `validate_l1_to_l2_boundary()`, `validate_l2_to_l3_boundary()`, `validate_l3_to_l4_boundary()`
-- **Observability Hooks**:
-  - `LayerEventType`: Enum with L1/L2/L3/L4/Discovery event types
-  - `LayerEvent`: Dataclass with event_type, data, timestamp
-  - `emit_layer_event()`, `get_layer_events()`, `clear_layer_events()`
-- **Discovery Events (ADR-028)**:
-  - `DISCOVERY_REFRESH_STARTED`: Emitted when registry refresh begins
-  - `DISCOVERY_REFRESH_COMPLETE`: Emitted on successful refresh with duration_ms
-  - `DISCOVERY_REFRESH_FAILED`: Emitted on refresh failure with error details
-  - `DISCOVERY_FALLBACK_TRIGGERED`: Emitted when static fallback is used
-  - `DISCOVERY_STALE_SERVE`: Emitted when serving stale data after failures
-- **Circuit Breaker Events (ADR-030)**:
-  - `L4_CIRCUIT_BREAKER_OPEN`: Emitted when circuit trips (model_id, failure_rate, cooldown_seconds)
-  - `L4_CIRCUIT_BREAKER_CLOSE`: Emitted when circuit closes after recovery (model_id, from_state)
-- **Boundary Crossing Helpers** (validate + emit event):
-  - `cross_l1_to_l2(contract, query)` - L1→L2 with L1_TIER_SELECTED event
-  - `cross_l2_to_l3(result, tier_contract)` - L2→L3 with L2_TRIAGE_COMPLETE event
-  - `cross_l3_to_l4(request)` - L3→L4 with L4_GATEWAY_REQUEST event
-- **Architectural Principles** (per ADR-024):
-  - Layer Sovereignty: Each layer owns its decision
-  - Explicit Escalation: All escalations logged and auditable
-  - Failure Isolation: Gateway failures don't cascade to tier changes
-  - Constraint Propagation: Tier constraints flow down
-  - Observability by Default: Every layer emits events
+Bias (ADR-015/018)
+- `bias_audit.py` (ADR-015) — per-session indicators: length↔score correlation (pure-Python Pearson), reviewer calibration, position bias. **These are anomaly indicators, not statistically robust proof** — with N=4–5 models there are only 4–5 data points (≥30 needed for significance), and a single ordering can't separate position effects from quality.
+- `bias_persistence.py` (ADR-018 P1) — JSONL store, `ConsentLevel` (OFF→RESEARCH). `bias_aggregation.py` (ADR-018 P2-3) — cross-session pooled correlation w/ CIs (Fisher-z), confidence tiers, temporal trends, anomaly flagging. Surfaced via `llm-council bias-report`.
 
-**`gateway/circuit_breaker.py`** - ADR-023/ADR-030 Circuit Breaker Implementation
-- Prevents cascading failures by temporarily blocking requests to failing models
-- **`CircuitState`**: Enum (CLOSED, OPEN, HALF_OPEN)
-- **`CircuitBreaker`**: Basic circuit breaker with absolute failure count (ADR-023)
-- **`EnhancedCircuitBreakerConfig`** (ADR-030):
-  - `failure_threshold`: 0.25 (25% failure rate)
-  - `min_requests`: 5 (minimum before evaluation)
-  - `window_seconds`: 600 (10 minute sliding window)
-  - `cooldown_seconds`: 1800 (30 minute cooldown)
-  - `half_open_max_requests`: 3 (probe requests)
-  - `half_open_success_threshold`: 0.67 (2/3 success to close)
-- **`EnhancedCircuitBreaker`** (ADR-030):
-  - Sliding window failure tracking with timestamp-based pruning
-  - `failure_rate()`: Current failure rate in window
-  - `request_count_in_window()`: Total requests in window
-  - `failure_count_in_window()`: Failed requests in window
-  - `allow_request()`: Check if request allowed (handles OPEN→HALF_OPEN transition)
-  - `record_success()` / `record_failure()`: Track request outcomes
+Observability & telemetry
+- `observability/` (ADR-030 metrics export — StatsD/Prometheus/NoOp), `telemetry.py` / `telemetry_client.py`, `webhooks/`.
 
-**`gateway/circuit_breaker_registry.py`** - ADR-030 Per-Model Circuit Breaker Registry
-- Thread-safe global registry for per-model circuit breakers
-- **Key Functions**:
-  - `get_circuit_breaker(model_id, config)`: Get or create breaker for model
-  - `check_circuit_breaker(model_id)`: Returns (allowed, reason) tuple
-  - `record_model_result(model_id, success)`: Record result with automatic event emission
-  - `get_all_breakers()`: Return all registered breakers (for monitoring)
-  - `_reset_registry()`: Clear registry (for testing)
-- **Event Emission**: Automatically emits L4_CIRCUIT_BREAKER_OPEN/CLOSE events on state transitions
+Verification (ADR-034/040/041) — `verification/api.py`
+- `run_verification()` wraps `_run_verification_pipeline()` (stages 1–3) in `asyncio.wait_for()` with a global deadline = `tier_contract.deadline_ms/1000 × 1.5` (`VERIFICATION_TIMEOUT_MULTIPLIER`).
+- **Waterfall time budget (ADR-040):** stage1 = 50% of remaining, stage2 = 70% of what's left, stage3 = the rest; each capped by `tier_timeout["per_model"]`.
+- **Durable partial state:** `partial_state` is updated after each stage and survives `CancelledError`, so a timeout still returns `completed_stages`. `VerifyResponse` carries `timeout_fired`, `completed_stages`, and (ADR-041) `timing` / `input_metrics`.
+- **Per-tier input caps** `TIER_MAX_CHARS` (quick 15K, balanced 30K, high/reasoning 50K). Per-file truncation (#342) is surfaced as an `expansion_warnings` entry rather than silently dropped; `reasoning`/`high` can read a full 50K file.
+- Performance tracker is wired on success only, wrapped in try/except so telemetry never fails verification.
 
-**`observability/`** - ADR-030 Metrics Export
-- Bridges internal LayerEvents to external metrics backends (Prometheus, StatsD)
-- **`metrics_adapter.py`**: Main adapter implementation
-  - `MetricsBackend`: Protocol for metrics backends (emit_counter, emit_gauge, emit_histogram)
-  - `NoOpBackend`: No-operation backend when metrics disabled
-  - `StatsDBackend`: UDP-based StatsD backend with DogStatsD tag support
-  - `PrometheusBackend`: In-memory Prometheus metrics with text format export
-  - `MetricsAdapter`: Translates LayerEvents to metrics
-    - Handles `L4_CIRCUIT_BREAKER_OPEN` → counter + failure_rate gauge
-    - Handles `L4_CIRCUIT_BREAKER_CLOSE` → counter with from_state tag
-  - `get_metrics_adapter()`: Factory function (uses config for backend selection)
-  - `subscribe_metrics_adapter()`: Subscribe to receive LayerEvents
-  - `unsubscribe_metrics_adapter()`: Unsubscribe from events
-  - `_notify_adapters()`: Internal hook called by `emit_layer_event()`
-- **Configuration** (in `unified_config.py`):
-  - `MetricsConfig`: enabled, backend, statsd_host, statsd_port, statsd_prefix, prometheus_port
-  - Defaults: disabled, backend="none", localhost:8125 for StatsD, port 9090 for Prometheus
-- **Environment Variables**:
-  - `LLM_COUNCIL_METRICS_ENABLED`: Enable/disable metrics export (default: false)
-  - `LLM_COUNCIL_METRICS_BACKEND`: Backend type (none, statsd, prometheus)
-  - `LLM_COUNCIL_STATSD_HOST`: StatsD server host
-  - `LLM_COUNCIL_STATSD_PORT`: StatsD server port
+## Key design decisions
 
-**`voting.py`** - ADR-027 Shadow Mode Voting Authority
-- Implements voting authority levels for the council's tier system
-- Frontier tier models operate in Shadow Mode by default
-- **`VotingAuthority` Enum**:
-  - `FULL`: Vote counts in consensus calculation (weight = 1.0)
-  - `ADVISORY`: Vote logged/evaluated but has zero weight (Shadow Mode)
-  - `EXCLUDED`: Model not included in deliberation
-- **`TIER_VOTING_AUTHORITY`**: Default authority by tier
-  - quick/balanced/high/reasoning: `VotingAuthority.FULL`
-  - frontier: `VotingAuthority.ADVISORY` (Shadow Mode by default)
-- **Key Functions**:
-  - `get_vote_weight(authority)`: Returns 1.0 for FULL, 0.0 for ADVISORY/EXCLUDED
-  - `get_model_voting_authority(model_id, tier, override)`: Get authority for model
-  - `calculate_shadow_agreement(consensus_winner, shadow_votes)`: Calculate agreement ratio
-- **Shadow Mode Purpose**: Prevents experimental/preview models from affecting production consensus while still logging their votes for evaluation
+**Stage 2 prompt format** — strict, to stay parseable: (1) evaluate each response individually, (2) emit a `FINAL RANKING:` header, (3) numbered list (`1. Response C`, `2. Response A`, …), (4) nothing after the ranking. `parse_ranking_from_text()` handles numbered and plain forms; fallback regex extracts any `Response X` in order if a model misbehaves.
 
-**`graduation.py`** - ADR-027 Frontier Graduation Criteria
-- Determines when a frontier model is ready for promotion to high tier
-- **`GraduationCriteria`**: Frozen dataclass with ADR-027 defaults
-  - `min_age_days`: 30 (days of evaluation)
-  - `min_completed_sessions`: 100 (council sessions)
-  - `max_error_rate`: 0.02 (< 2% errors)
-  - `min_quality_percentile`: 0.75 (>= 75th percentile)
-- **`ModelStats`**: Tracked performance statistics for evaluation
-- **`should_graduate(stats, criteria)`**: Returns (passed, failures) tuple
-- **`get_graduation_candidates(tier)`**: Get all potential graduation candidates
-
-**`cost_ceiling.py`** - ADR-027 Cost Ceiling Protection
-- Prevents runaway costs for frontier tier models
-- **`FRONTIER_COST_MULTIPLIER`**: Default 5.0x multiplier
-- **`apply_cost_ceiling(model_id, model_cost, tier, high_tier_avg_cost)`**:
-  - Returns (allowed, reason) tuple
-  - Frontier models capped at 5x high-tier average cost
-  - Non-frontier tiers bypass check
-- **`check_model_cost_ceiling()`**: Convenience wrapper
-
-**`frontier_fallback.py`** - ADR-027 Hard Fallback
-- Automatic fallback from frontier tier to high tier on failure
-- **`RateLimitError`**, **`APIError`**: Exception classes
-- **`FallbackResult`**: Dataclass with response + fallback metadata
-- **`execute_with_fallback(query, frontier_model, fallback_tier="high")`**:
-  - Tries frontier model first
-  - Falls back on timeout/rate limit/API error
-  - Logs warning on fallback
-- **`execute_with_fallback_detailed()`**: Same as above but returns FallbackResult with metadata
-  - Emits `FRONTIER_FALLBACK_TRIGGERED` event on fallback
-- **`emit_fallback_event(frontier_model, fallback_model, reason)`**: Emit fallback event
-- **`should_use_fallback_wrapper(tier_contract)`**: Returns True for frontier tier only
-- **`get_fallback_tier_from_config()`**: Get fallback tier from unified config
-- **`DEFAULT_FRONTIER_TIMEOUT`**: 300 seconds
-
-**`audition/`** - ADR-029 Model Audition Mechanism
-- Implements volume-based audition for newly discovered models
-- Solves the cold start problem: new models progress through states before voting
-- **State Machine**: SHADOW → PROBATION → EVALUATION → FULL (+ QUARANTINE for failures)
-- **`types.py`**: Core types
-  - `AuditionState`: Enum (SHADOW, PROBATION, EVALUATION, FULL, QUARANTINE)
-  - `AuditionStatus`: Dataclass tracking model progress (session_count, first_seen, consecutive_failures, quality_percentile)
-  - `AuditionCriteria`: Frozen dataclass with graduation thresholds
-  - `evaluate_state_transition()`: Determine if model should change states
-  - `record_session_result()`: Update status after session
-- **`tracker.py`**: Main tracker class
-  - `AuditionTracker`: In-memory cache + JSONL persistence
-  - `get_status(model_id)`: Get current audition status
-  - `record_session(model_id, success, criteria)`: Record session and check transitions
-  - `update_quality_percentile(model_id, percentile)`: Update quality score
-  - `check_transitions(criteria)`: Evaluate all models for state changes
-  - `get_audition_tracker()`: Singleton factory
-- **`selection.py`**: Selection weighting
-  - Weight progression: SHADOW/PROBATION=30%, EVALUATION=30-100%, FULL=100%, QUARANTINE=0%
-  - `get_selection_weight(status)`: Returns weight factor (0-1)
-  - `select_with_audition(candidates, tracker, count, max_audition_seats)`: Apply weights + seat limits
-  - `is_auditioning_model(status)`: Check if in audition state
-- **`voting.py`**: Voting integration
-  - `STATE_VOTING_AUTHORITY`: Maps AuditionState to VotingAuthority
-  - SHADOW/PROBATION/EVALUATION → ADVISORY (non-binding votes)
-  - FULL → FULL (binding votes), QUARANTINE → EXCLUDED
-  - `get_audition_voting_authority(model_id, tracker)`: Get authority for model
-- **`store.py`**: JSONL persistence
-  - `append_audition_record()`: Atomic append to JSONL
-  - `read_audition_records()`: Read with optional model_id filter
-- **Graduation Criteria** (per ADR-029):
-  - SHADOW → PROBATION: 10 sessions + 3 days
-  - PROBATION → EVALUATION: 25 sessions + 7 days
-  - EVALUATION → FULL: 50 sessions + quality ≥ 75th percentile
-  - Quarantine: consecutive failures exceed threshold (SHADOW: 3, PROBATION: 5)
-- **Environment Variables**:
-  - `LLM_COUNCIL_AUDITION_ENABLED`: Enable/disable audition (default: true)
-  - `LLM_COUNCIL_AUDITION_MAX_SEATS`: Max audition models per session (default: 1)
-  - `LLM_COUNCIL_AUDITION_SHADOW_SESSIONS`: Min sessions for SHADOW exit (default: 10)
-  - `LLM_COUNCIL_AUDITION_EVAL_SESSIONS`: Min sessions for EVALUATION exit (default: 50)
-- **Observability Events**:
-  - `AUDITION_STATE_TRANSITION`: Model changed state
-  - `AUDITION_MODEL_SELECTED`: Auditioning model selected for council
-  - `AUDITION_FAILURE_RECORDED`: Session failure recorded
-  - `AUDITION_QUARANTINE_TRIGGERED`: Model entered quarantine
-  - `AUDITION_GRADUATION_COMPLETE`: Model graduated to FULL
-
-**`triage/`** - ADR-020 Query Triage Layer
-- **`types.py`**: Core types for triage
-  - `TriageResult`: resolved_models, optimized_prompts, fast_path, escalation fields
-  - `TriageRequest`: query with optional tier_contract and domain_hint
-  - `WildcardConfig`: specialist pools, fallback model, diversity constraints
-  - `DomainCategory`: CODE, REASONING, CREATIVE, MULTILINGUAL, GENERAL
-  - `DEFAULT_SPECIALIST_POOLS`: Per-domain model recommendations
-- **`wildcard.py`**: Domain-specialized model selection
-  - `classify_query_domain()`: Keyword-based domain classification
-  - `select_wildcard()`: Select specialist from pool with diversity constraints
-- **`prompt_optimizer.py`**: Per-model prompt adaptation
-  - `PromptOptimizer`: Applies provider-specific formatting (Claude XML, etc.)
-  - `get_model_provider()`: Extract provider from model ID
-- **`complexity.py`**: Complexity classification (placeholder)
-  - `HeuristicComplexityClassifier`: Keyword/length-based heuristics
-  - `NotDiamondClassifier`: Placeholder for future integration
-  - `classify_complexity()`: Entry point for complexity classification
-- **`__init__.py`**: Exports `run_triage()` entry point
-- Configuration: `WILDCARD_ENABLED`, `PROMPT_OPTIMIZATION_ENABLED`
-
-**`openrouter.py`**
-- `query_model()`: Single async model query
-- `query_models_parallel()`: Parallel queries using `asyncio.gather()`
-- Returns dict with 'content' and optional 'reasoning_details'
-- Graceful degradation: returns None on failure, continues with successful responses
-
-**`council.py`** - The Core Logic
-- `stage1_collect_responses()`: Parallel queries to all council models
-- `stage2_collect_rankings()`:
-  - Anonymizes responses as "Response A, B, C, etc."
-  - Creates `label_to_model` mapping for de-anonymization
-  - Prompts models to evaluate and rank (with strict format requirements)
-  - Returns tuple: (rankings_list, label_to_model_dict)
-  - Each ranking includes both raw text and `parsed_ranking` list
-  - **ADR-016**: When `RUBRIC_SCORING_ENABLED=true`, uses multi-dimensional rubric prompt
-- `stage3_synthesize_final()`: Chairman synthesizes from all responses + rankings
-- `parse_ranking_from_text()`: Extracts "FINAL RANKING:" section, handles both numbered lists and plain format
-- `calculate_aggregate_rankings()`: Computes average rank position across all peer evaluations
-  - **ADR-027**: Accepts optional `voting_authorities` dict mapping reviewer IDs to VotingAuthority
-  - **ADR-027**: Accepts optional `return_shadow_votes` bool to include shadow vote metadata
-  - ADVISORY votes (Shadow Mode) are tracked but have zero weight in rankings
-- **ADR-027 Shadow Vote Integration**:
-  - `should_track_shadow_votes(tier_contract)`: Returns True for frontier tier only
-  - `emit_shadow_vote_events(shadow_votes, consensus_winner)`: Emits FRONTIER_SHADOW_VOTE events
-  - Automatically enabled in `run_council_with_fallback` for frontier tier
-
-**`rubric.py`** - ADR-016 Structured Rubric Scoring
-- `RubricScore`: Dataclass for multi-dimensional scores (accuracy, relevance, completeness, conciseness, clarity)
-- `calculate_weighted_score()`: Weighted average from dimension scores
-- `calculate_weighted_score_with_accuracy_ceiling()`: Weighted score with accuracy acting as ceiling
-  - Accuracy < 5: caps at 4.0 ("significant errors or worse" per scoring anchors)
-  - Accuracy 5-6: caps at 7.0 ("mixed accuracy")
-  - Accuracy ≥ 7: no ceiling ("mostly accurate or better")
-  - **Rationale**: Prevents confident lies from ranking well; thresholds map to scoring anchor definitions
-- `parse_rubric_evaluation()`: Extracts rubric JSON from model response, handles code blocks
-- `validate_weights()`: Ensures weights sum to 1.0 and include all dimensions
-- **Fallback**: If rubric parsing fails, falls back to holistic scoring via `parse_ranking_from_text()`
-- **Scoring Anchors**: Defined in ADR-016 with behavioral examples for each score level (1-10)
-
-**`safety_gate.py`** - ADR-016 Safety Gate
-- `SafetyCheckResult`: Dataclass with passed, reason, flagged_patterns
-- `check_response_safety()`: Scans response for harmful patterns
-- `apply_safety_gate_to_score()`: Caps score if safety check fails
-- **Patterns detected**: dangerous_instructions, weapon_making, malware_hacking, self_harm, pii_exposure
-- **Context-aware**: Exclusion contexts allow educational/defensive content
-- Configuration in `unified_config.py`: `scoring.safety_gate_enabled`
-
-**`bias_audit.py`** - ADR-015 Per-Session Bias Indicators
-- `BiasAuditResult`: Dataclass containing all bias metrics
-- `calculate_length_correlation()`: Pure Python Pearson correlation (no scipy/numpy)
-- `audit_reviewer_calibration()`: Detects harsh/generous reviewers (mean ± 1 std from median)
-- `calculate_position_bias()`: Detects position effects in scoring
-- `derive_position_mapping()`: Converts `label_to_model` → position indices
-  - Supports enhanced format (v0.3.0+): Uses `display_index` directly
-  - Supports legacy format: Derives from label letter (A → 0, B → 1)
-- `run_bias_audit()`: Main entry point, runs all bias checks and returns overall risk assessment
-- `extract_scores_from_stage2()`: Converts Stage 2 results to format needed for bias audit
-- **Configuration** (ADR-031): Uses `get_config().evaluation.bias.*` from unified_config
-  - `audit_enabled`, `length_correlation_threshold`, `position_variance_threshold`
-
-**Statistical Limitations**: Per-session bias auditing has inherent limitations with small sample sizes:
-- With N=4-5 models, length correlation has only 4-5 data points (minimum 30+ needed for significance)
-- Position bias from a single ordering cannot distinguish position effects from quality differences
-- Reviewer calibration is relative to the current session only, not across sessions
-- These metrics are **indicators for extreme anomalies**, not statistically robust proof of systematic bias
-
-**`bias_persistence.py`** - ADR-018 Phase 1: Data Persistence
-- `BiasMetricRecord`: Dataclass for individual bias measurements (schema version 1.1.0)
-- `ConsentLevel`: Enum for privacy consent levels (OFF=0, LOCAL_ONLY=1, ANONYMOUS=2, ENHANCED=3, RESEARCH=4)
-- `hash_query_if_enabled()`: HMAC hash for query grouping (RESEARCH consent only)
-- `append_bias_records()`: Atomic JSONL append
-- `read_bias_records()`: Read with filtering (max_sessions, max_days, since)
-- `create_bias_records_from_session()`: Convert Stage 2 results to records
-- `persist_session_bias_data()`: High-level integration point for council.py
-- **Configuration** (ADR-031): Uses helper functions accessing `get_config().evaluation.bias.*`
-  - `_get_bias_persistence_enabled()`, `_get_bias_store_path()`, `_get_bias_consent_level()`
-
-**`bias_aggregation.py`** - ADR-018 Phase 2-3: Cross-Session Analysis
-- `StatisticalConfidence`: Enum for confidence tiers (INSUFFICIENT, PRELIMINARY, MODERATE, HIGH)
-- `fisher_z_transform()` / `inverse_fisher_z()`: Fisher z-transformation for correlation CIs
-- `determine_confidence_level()`: Map sample size to confidence tier
-- `pooled_correlation_with_ci()`: Pooled length-score correlation with 95% CI
-- `aggregate_reviewer_profiles()`: Per-reviewer mean, std, harshness z-score
-- `aggregate_position_bias()`: Variance of position means
-- `run_aggregated_bias_audit()`: Main entry point for cross-session analysis
-- `generate_bias_report_text()` / `generate_bias_report_json()`: CLI report generation
-- `detect_temporal_trends()`: Phase 3 - rolling window trend detection
-- `detect_anomalies()`: Phase 3 - outlier session flagging
-
-**CLI (`cli.py`) - bias-report command**
-```bash
-llm-council bias-report [--input FILE] [--sessions N] [--days N] [--format text|json] [--verbose]
-```
-
-**`metadata/`** - ADR-026 Model Metadata Provider
-- **`types.py`**: Core data structures
-  - `ModelInfo`: Frozen dataclass with id, context_window, pricing, supported_parameters, modalities, quality_tier, is_preview, supports_reasoning
-  - `QualityTier`: Enum (FRONTIER, STANDARD, ECONOMY, LOCAL)
-  - `Modality`: Enum (TEXT, VISION, AUDIO)
-- **`intersection.py`**: ADR-027 Tier intersection logic
-  - `resolve_tier_intersection(tier, model_info, allow_preview)`: Determine if model qualifies for tier
-  - Handles models belonging to multiple tiers (e.g., o1-preview is both reasoning and frontier)
-  - Precedence rules: frontier includes previews, reasoning excludes previews by default
-- **`protocol.py`**: Abstract protocol definition
-  - `MetadataProvider`: `@runtime_checkable` Protocol with 5 methods
-    - `get_model_info(model_id)` → Optional[ModelInfo]
-    - `get_context_window(model_id)` → int (default 4096)
-    - `get_pricing(model_id)` → Dict[str, float]
-    - `supports_reasoning(model_id)` → bool
-    - `list_available_models()` → List[str]
-- **`static_registry.py`**: Offline-safe provider
-  - `StaticRegistryProvider`: Implements MetadataProvider
-  - Priority chain: local registry > LiteLLM > 4096 default
-  - Loads bundled `models/registry.yaml` (31 models)
-- **`litellm_adapter.py`**: LiteLLM metadata extraction
-  - Lazy import prevents startup failures
-  - Model ID normalization (openai/gpt-4o → gpt-4o)
-- **`offline.py`**: Offline mode management
-  - `is_offline_mode()`: Checks `LLM_COUNCIL_OFFLINE` env var
-  - `check_offline_mode_startup()`: Logs INFO about offline mode
-  - Truthy values: "true", "1", "yes", "on"
-- **`__init__.py`**: Module exports and factory
-  - `get_provider()`: Returns singleton StaticRegistryProvider
-  - `reload_provider()`: Refreshes cached instance (for testing)
-  - Exports: ModelInfo, QualityTier, Modality, MetadataProvider
-
-**`reasoning/`** - ADR-026 Phase 2 Reasoning Parameter Optimization
-- **`types.py`**: Core reasoning types
-  - `ReasoningEffort`: Enum (MINIMAL, LOW, MEDIUM, HIGH, XHIGH)
-  - `EFFORT_RATIOS`: Effort to ratio mapping (0.10, 0.20, 0.50, 0.80, 0.95)
-  - `ReasoningConfig`: Frozen dataclass with `for_tier()` factory method
-  - `should_apply_reasoning(stage, config)`: Check if reasoning applies to stage
-- **`tracker.py`**: Usage tracking
-  - `ReasoningUsage`: Per-model usage dataclass
-  - `AggregatedUsage`: Cross-model aggregation
-  - `extract_reasoning_usage()`: Parse OpenRouter response
-  - `aggregate_reasoning_usage()`: Combine multiple usages
-- **`__init__.py`**: Module exports
-
-**Reasoning Effort Levels:**
-- MINIMAL (10%): quick tier, creative tasks
-- LOW (20%): balanced tier
-- MEDIUM (50%): high tier, coding tasks
-- HIGH (80%): reasoning tier, math tasks
-- XHIGH (95%): explicit opt-in only
-
-**Stage Configuration:**
-- `stage1: true` (primary responses - default ON)
-- `stage2: false` (peer reviews - default OFF)
-- `stage3: true` (synthesis - default ON)
-
-**Offline Mode** - ADR-026 "Sovereign Orchestrator" Philosophy
-```bash
-# Force offline operation - all core operations work without external calls
-export LLM_COUNCIL_OFFLINE=true
-```
-
-When offline:
-1. Uses StaticRegistryProvider exclusively
-2. Disables external metadata/routing calls
-3. Logs INFO about limited/stale metadata
-4. All core council operations succeed
-
-**Bundled Registry** (`src/llm_council/models/registry.yaml`)
-- 31 models from 8 providers
-- OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, Ollama
-- Includes reasoning models (o1, o3-mini, deepseek-r1)
-- Local models have LOCAL quality tier and $0 pricing
-
-**Enhanced `label_to_model` Format (v0.3.0+)**
-Per council recommendation for robustness, anonymization now uses explicit position indices:
+**Anonymization / `label_to_model`** — models see `Response A/B/…`; the backend keeps the mapping. Enhanced format (v0.3.0+) uses explicit indices to avoid string-parsing fragility:
 ```python
-# Enhanced format (eliminates string parsing fragility)
 {"Response A": {"model": "openai/gpt-4", "display_index": 0}, ...}
-
-# INVARIANT: Labels are assigned in lexicographic order (A=0, B=1, etc.)
+# INVARIANT: labels assigned in lexicographic order (A=0, B=1, …)
 ```
+De-anonymization is for display only. Metadata (`label_to_model`, `aggregate_rankings`) is returned via the API but **not persisted**.
 
-**`storage.py`**
-- JSON-based conversation storage in `data/conversations/`
-- Each conversation: `{id, created_at, messages[]}`
-- Assistant messages contain: `{role, stage1, stage2, stage3}`
-- Note: metadata (label_to_model, aggregate_rankings) is NOT persisted to storage, only returned via API
+**Error handling** — continue with whatever responses succeed; never fail the whole request on a single model failure; only surface an error if *all* models fail.
 
-**`main.py`**
-- FastAPI app with CORS enabled for localhost:5173 and localhost:3000
-- POST `/api/conversations/{id}/message` returns metadata in addition to stages
-- Metadata includes: label_to_model mapping and aggregate_rankings
+**Offline mode ("Sovereign Orchestrator", ADR-026)** — `LLM_COUNCIL_OFFLINE=true` forces `StaticRegistryProvider`, disables external metadata/routing, and still completes all core council operations on stale/limited metadata.
 
-### Frontend Structure (`frontend/src/`)
+## Configuration (`unified_config.py`, ADR-024)
 
-**`App.jsx`**
-- Main orchestration: manages conversations list and current conversation
-- Handles message sending and metadata storage
-- Important: metadata is stored in the UI state for display but not persisted to backend JSON
+Single Pydantic source of truth consolidating ADR-020/022/023/026/030/031. Priority: **YAML file > env vars > defaults**. YAML searched at `$LLM_COUNCIL_CONFIG` → `./llm_council.yaml` → `~/.config/llm-council/llm_council.yaml`. Supports `${VAR}` substitution. Sections: `tiers`, `triage`, `gateways`, `model_intelligence`, `evaluation` (rubric/safety/bias/scoring/circuit_breaker/audition), `metrics`. Models (council + chairman) are configured in `llm_council.yaml`.
 
-**`components/ChatInterface.jsx`**
-- Multiline textarea (3 rows, resizable)
-- Enter to send, Shift+Enter for new line
-- User messages wrapped in markdown-content class for padding
+### Environment variable index
+| Var | Effect |
+|---|---|
+| `LLM_COUNCIL_MODELS` | Override council members |
+| `LLM_COUNCIL_MODEL_INTELLIGENCE=true` | Enable dynamic model selection (ADR-026) |
+| `LLM_COUNCIL_OFFLINE=true` | Force offline / static provider |
+| `LLM_COUNCIL_DISCOVERY_ENABLED` / `_INTERVAL` (300) / `_MIN_CANDIDATES` (3) | Background discovery (ADR-028) |
+| `LLM_COUNCIL_PERFORMANCE_TRACKING` (true) / `_STORE` | Internal performance index (ADR-026 P3) |
+| `LLM_COUNCIL_AUDITION_ENABLED` (true) / `_MAX_SEATS` (1) / `_SHADOW_SESSIONS` (10) / `_EVAL_SESSIONS` (50) | Audition (ADR-029) |
+| `LLM_COUNCIL_METRICS_ENABLED` / `_BACKEND` (none\|statsd\|prometheus) / `LLM_COUNCIL_STATSD_HOST` / `_PORT` | Metrics export (ADR-030) |
+| `RUBRIC_SCORING_ENABLED` / `SAFETY_GATE_ENABLED` / `BIAS_AUDIT_ENABLED` / `BIAS_PERSISTENCE_ENABLED` | Evaluation toggles (ADR-031) |
+| `WILDCARD_ENABLED` / `PROMPT_OPTIMIZATION_ENABLED` | Triage features (ADR-020) |
 
-**`components/Stage1.jsx`**
-- Tab view of individual model responses
-- ReactMarkdown rendering with markdown-content wrapper
+**Reasoning effort levels** (`reasoning/`): MINIMAL 10% (quick/creative), LOW 20% (balanced), MEDIUM 50% (high/coding), HIGH 80% (reasoning/math), XHIGH 95% (opt-in). Applied per stage: stage1 on, stage2 off, stage3 on by default.
 
-**`components/Stage2.jsx`**
-- **Critical Feature**: Tab view showing RAW evaluation text from each model
-- De-anonymization happens CLIENT-SIDE for display (models receive anonymous labels)
-- Shows "Extracted Ranking" below each evaluation so users can validate parsing
-- Aggregate rankings shown with average position and vote count
-- Explanatory text clarifies that boldface model names are for readability only
+**Performance/bias confidence tiers** (sample size): INSUFFICIENT <10, PRELIMINARY 10–30, MODERATE 30–100, HIGH 100+.
 
-**`components/Stage3.jsx`**
-- Final synthesized answer from chairman
-- Green-tinted background (#f0fff0) to highlight conclusion
+## Data flow
 
-**Styling (`*.css`)**
-- Light mode theme (not dark mode)
-- Primary color: #4a90e2 (blue)
-- Global markdown styling in `index.css` with `.markdown-content` class
-- 12px padding on all markdown content to prevent cluttered appearance
-
-## Key Design Decisions
-
-### Stage 2 Prompt Format
-The Stage 2 prompt is very specific to ensure parseable output:
 ```
-1. Evaluate each response individually first
-2. Provide "FINAL RANKING:" header
-3. Numbered list format: "1. Response C", "2. Response A", etc.
-4. No additional text after ranking section
+Query
+ → Stage 1: parallel queries → [responses]
+ → Stage 1.5 (optional): style normalization
+ → Stage 2: anonymize → parallel ranking queries → [evaluations + parsed rankings]
+ → Aggregate rankings (Borda)
+ → Bias audit (if enabled)
+ → Stage 3: chairman synthesis with full context
+ → {stage1, stage2, stage3, metadata}
 ```
+The flow is async/parallel wherever possible to minimize latency.
 
-This strict format allows reliable parsing while still getting thoughtful evaluations.
+## Gotchas
 
-### De-anonymization Strategy
-- Models receive: "Response A", "Response B", etc.
-- Backend creates mapping: `{"Response A": "openai/gpt-5.1", ...}`
-- Frontend displays model names in **bold** for readability
-- Users see explanation that original evaluation used anonymous labels
-- This prevents bias while maintaining transparency
-
-### Error Handling Philosophy
-- Continue with successful responses if some models fail (graceful degradation)
-- Never fail the entire request due to single model failure
-- Log errors but don't expose to user unless all models fail
-
-### UI/UX Transparency
-- All raw outputs are inspectable via tabs
-- Parsed rankings shown below raw text for validation
-- Users can verify system's interpretation of model outputs
-- This builds trust and allows debugging of edge cases
-
-## Important Implementation Details
-
-### Relative Imports
-All backend modules use relative imports (e.g., `from .unified_config import ...`) not absolute imports. This is critical for Python's module system to work correctly when running as `python -m backend.main`.
-
-### Port Configuration
-- Backend: 8001 (changed from 8000 to avoid conflict)
-- Frontend: 5173 (Vite default)
-- Update both `backend/main.py` and `frontend/src/api.js` if changing
-
-### Markdown Rendering
-All ReactMarkdown components must be wrapped in `<div className="markdown-content">` for proper spacing. This class is defined globally in `index.css`.
-
-### Model Configuration
-Models are configured in `llm_council.yaml` and loaded via `unified_config.py`. Chairman can be same or different from council members. Configuration can be overridden via environment variables (e.g., `LLM_COUNCIL_MODELS`).
-
-## Common Gotchas
-
-1. **Module Import Errors**: Always run backend as `python -m backend.main` from project root, not from backend directory
-2. **CORS Issues**: Frontend must match allowed origins in `main.py` CORS middleware
-3. **Ranking Parse Failures**: If models don't follow format, fallback regex extracts any "Response X" patterns in order
-4. **Missing Metadata**: Metadata is ephemeral (not persisted), only available in API responses
-
-## Future Enhancement Ideas
-
-- Configurable council/chairman via UI instead of config file
-- Streaming responses instead of batch loading
-- Export conversations to markdown/PDF
-- Model performance analytics over time
-- Custom ranking criteria (not just accuracy/insight)
-- Support for reasoning models (o1, etc.) with special handling
-
-## Testing Notes
-
-Use `test_openrouter.py` to verify API connectivity and test different model identifiers before adding to council. The script tests both streaming and non-streaming modes.
+1. Keep package-internal imports relative (`from .x import …`).
+2. Ranking parse failures fall back to permissive `Response X` regex extraction.
+3. Metadata (`label_to_model`, `aggregate_rankings`) is ephemeral — API response only, never written to storage.
+4. Per-session bias metrics are extreme-anomaly indicators, not significance tests (see bias note above).
 
 ## Release Workflow
 
-**Branch Protection**: The repository has branch protection rules requiring PRs and CI checks. **Never push directly to master** - all changes must go through PRs, even for releases.
+**Branch protection:** PRs + passing CI are required. **Never push directly to `master`**, even for releases.
 
-### 1. Ensure Starting from Latest Master
-```bash
-git checkout master
-git pull origin master
-```
+1. `git checkout master && git pull origin master`
+2. `git checkout -b release/v0.X.0`
+3. Update `CHANGELOG.md` (Keep a Changelog: Added / Changed / Fixed / Removed).
+4. `git commit --signoff -m "chore(release): Prepare v0.X.0 release"` then push the branch.
+5. Open PR: `gh pr create --title "Release v0.X.0" --body "…"`.
+6. Wait for required checks: **Test, Lint, Type Check, DCO** (DCO needs `--signoff`). Do not merge until green.
+7. `gh pr merge --squash --delete-branch`.
+8. **After merge**, tag from updated master: `git tag -a v0.X.0 -m "…" && git push origin v0.X.0` — this triggers `publish.yml` (build → test wheel → publish to PyPI).
+9. Verify: `gh run list --workflow=publish.yml --limit=1`, then `pip index versions llm-council-core`.
 
-### 2. Create Release Branch
-```bash
-git checkout -b release/v0.X.0
-```
+**Versioning:** git tags via `hatch-vcs`/setuptools-scm; `src/llm_council/_version.py` is auto-generated + gitignored. SemVer (MAJOR breaking / MINOR feature / PATCH fix).
 
-### 3. Update CHANGELOG.md
-Add release notes following [Keep a Changelog](https://keepachangelog.com/) format:
-- **Added**: New features
-- **Changed**: Changes to existing functionality
-- **Fixed**: Bug fixes
-- **Removed**: Removed features
+## Future enhancement ideas
 
-### 4. Commit and Push Branch
-```bash
-git add CHANGELOG.md
-git commit --signoff -m "chore(release): Prepare v0.X.0 release"
-git push -u origin release/v0.X.0
-```
-
-### 5. Open Pull Request
-```bash
-gh pr create --title "Release v0.X.0" --body "## Release Notes
-
-[changelog excerpt]
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)"
-```
-
-### 6. Wait for CI
-Let GitHub Actions run tests and checks. **Do not merge until all required checks pass.**
-
-Required checks:
-- `Test` - Unit and integration tests
-- `Lint` - Code style checks
-- `Type Check` - Static type analysis
-- `DCO` - Developer Certificate of Origin (requires `--signoff`)
-
-### 7. Merge PR
-After CI passes, merge via GitHub UI or CLI:
-```bash
-gh pr merge --squash --delete-branch
-```
-
-### 8. Tag the Release (After Merge)
-**Only after PR is merged**, create and push the version tag:
-```bash
-git checkout master
-git pull origin master
-git tag -a v0.X.0 -m "v0.X.0 - Brief description"
-git push origin v0.X.0
-```
-
-This triggers the `publish.yml` workflow which automatically:
-- Builds the package
-- Tests installation from wheel
-- Publishes to PyPI
-
-### 9. Verify Publication
-```bash
-# Check workflow status
-gh run list --workflow=publish.yml --limit=1
-
-# Verify on PyPI (after ~2 minutes)
-pip index versions llm-council-core
-```
-
-### Versioning
-
-- **Version source**: Git tags via `setuptools-scm` (configured in `pyproject.toml`)
-- **Version file**: `src/llm_council/_version.py` is auto-generated and gitignored
-- **Semantic versioning**: MAJOR.MINOR.PATCH
-  - MAJOR: Breaking API changes
-  - MINOR: New features, backward compatible
-  - PATCH: Bug fixes only
-
-### Why PRs Matter for OSS
-- Runs CI checks before merge (tests, linting)
-- Provides audit trail for contributors
-- Models the workflow expected from contributors
-- Allows async review if needed
-
-### Enforcing Branch Protection
-To prevent accidental direct pushes (even by admins), enable in GitHub:
-**Settings → Branches → Branch protection rules → master → "Do not allow bypassing the above settings"**
-
-## Verification API (ADR-034/ADR-040)
-
-**`verification/api.py`** - Verification endpoint and pipeline
-- `run_verification()`: Core verification logic with global timeout guardrail
-- `_run_verification_pipeline()`: Inner pipeline (stages 1-3) wrapped by `asyncio.wait_for()`
-- `_build_preflight_info()`: Pre-flight complexity estimation for progress reporting
-- **ADR-040 Constants**:
-  - `VERIFICATION_TIMEOUT_MULTIPLIER = 1.5`: Global deadline = `tier_contract.deadline_ms/1000 * 1.5`
-  - `TIER_MAX_CHARS`: Per-tier input size limits (quick: 15K, balanced: 30K, high/reasoning: 50K)
-- **Per-file size limits (#342)**:
-  - `_fetch_file_at_commit_async(snapshot_id, path, max_file_chars=None)` — `max_file_chars` controls per-call streaming cap; defaults to legacy `MAX_FILE_CHARS=15000` only when None.
-  - `_fetch_files_for_verification_async_with_metadata(snapshot_id, paths, tier="balanced")` — derives `per_file_budget = per_batch_budget = TIER_MAX_CHARS[tier]`. At `reasoning`/`high` tier, a single 50K file is fully readable; under the legacy hardcoded 15K cap, big ADRs were silently amputated.
-  - Per-file truncation surfaces as a structured `expansion_warnings` entry on `VerifyResponse`: `"file '<path>' truncated at N chars (<tier> tier per-file budget)"`. The previous code dropped the `truncated` boolean on the floor.
-- **VerifyResponse Fields (ADR-040)**:
-  - `timeout_fired: bool`: True if global deadline was exceeded
-  - `completed_stages: List[str]`: Stages completed before timeout (e.g. `["stage1", "stage2"]`)
-- **VerifyResponse Fields (ADR-041)**:
-  - `timing: Optional[Dict]`: Per-stage and total timing (`stage1_elapsed_ms`, `stage2_elapsed_ms`, `stage3_elapsed_ms`, `total_elapsed_ms`, `global_deadline_ms`, `budget_utilization`)
-  - `input_metrics: Optional[Dict]`: Input size metrics (`content_chars`, `tier_max_chars`, `num_models`, `num_reviewers`, `tier`)
-- **Waterfall Time Budgeting (ADR-040 Option A)**:
-  - Stage 1: 50% of remaining global deadline
-  - Stage 2: 70% of remaining after Stage 1
-  - Stage 3: all remaining time
-  - Each capped by `tier_timeout["per_model"]` to prevent single-stage overrun
-- **Durable Partial State (ADR-040 Option A)**:
-  - `partial_state` dict passed to pipeline, updated after each stage completes
-  - Survives `asyncio.CancelledError` from `wait_for` timeout
-  - Timeout handler reads `partial_state["completed_stages"]` for partial result
-  - ADR-041: Also stores `stage_timings`, `model_statuses`, `aggregate_rankings` for telemetry
-- **Performance Tracker Wiring (ADR-041)**:
-  - `persist_session_performance_data()` called after successful pipeline completion
-  - Converts `aggregate_rankings` list to dict keyed by model_id
-  - Wrapped in try/except — telemetry failures never fail verification
-  - Not called on timeout path (incomplete data)
-- **stage2/stage3 Timeout Params (ADR-040)**:
-  - `stage2_collect_rankings()` now accepts `timeout`, `models`, `on_progress` params
-  - When `on_progress` provided: uses `asyncio.as_completed` + `query_model` for per-model progress
-  - When `on_progress` is None: uses `query_models_parallel` (backward compat)
-  - `stage3_synthesize_final()` now accepts `timeout` param
-  - Both default to 120.0s for backward compatibility at other call sites
-
-## Data Flow Summary
-
-```
-User Query
-    ↓
-Stage 1: Parallel queries → [individual responses]
-    ↓
-Stage 1.5 (optional): Style normalization
-    ↓
-Stage 2: Anonymize → Parallel ranking queries → [evaluations + parsed rankings]
-    ↓
-Aggregate Rankings Calculation → [sorted by Borda score]
-    ↓
-Bias Audit (if enabled): Per-session indicators (length correlation, reviewer calibration, position bias)
-    ↓
-Stage 3: Chairman synthesis with full context
-    ↓
-Return: {stage1, stage2, stage3, metadata (including bias_audit if enabled)}
-    ↓
-Frontend: Display with tabs + validation UI
-```
-
-The entire flow is async/parallel where possible to minimize latency.
+Streaming responses; conversation export (md/PDF); model performance analytics over time; configurable council/chairman at runtime; custom ranking criteria.

--- a/llm_council.yaml
+++ b/llm_council.yaml
@@ -23,7 +23,7 @@ council:
         models:
           - openai/gpt-5-mini
           - anthropic/claude-haiku-4.5
-          - google/gemini-3.1-flash-lite-preview
+          - google/gemini-3.1-flash-lite
           - deepseek/deepseek-v3.2
         timeout_seconds: 30
 
@@ -32,7 +32,7 @@ council:
         models:
           - openai/gpt-5.4-mini
           - anthropic/claude-sonnet-4.6
-          - google/gemini-3.1-flash-lite-preview
+          - google/gemini-3.1-flash-lite
           - deepseek/deepseek-v3.2
         timeout_seconds: 90
 
@@ -40,28 +40,28 @@ council:
       high:
         models:
           - openai/gpt-5.4
-          - anthropic/claude-opus-4.7
+          - anthropic/claude-opus-4.8
           - google/gemini-3.1-pro-preview
-          - deepseek/deepseek-v3.2-speciale
+          - deepseek/deepseek-v4-pro
         timeout_seconds: 180
 
       # REASONING: Deep reasoning with extended thinking
       reasoning:
         models:
           - openai/gpt-5.4-pro
-          - anthropic/claude-opus-4.7
+          - anthropic/claude-opus-4.8
           - google/gemini-3.1-pro-preview
-          - deepseek/deepseek-v3.2-speciale
+          - deepseek/deepseek-r1
         timeout_seconds: 600
 
       # FRONTIER: Cutting-edge/preview models (may be unstable)
       # Use for testing latest capabilities before promoting to 'high'
       frontier:
         models:
-          - openai/gpt-5.4-pro
-          - anthropic/claude-opus-4.7
+          - openai/gpt-5.5-pro
+          - anthropic/claude-opus-4.8
           - google/gemini-3.1-pro-preview
-          - deepseek/deepseek-v3.2-speciale
+          - deepseek/deepseek-v4-pro
         timeout_seconds: 600
         # Frontier-specific: accept higher latency/cost for newest models
         allow_preview: true

--- a/src/llm_council/gateway/base.py
+++ b/src/llm_council/gateway/base.py
@@ -12,6 +12,12 @@ from typing import Any, AsyncIterator, Dict, List, Optional
 
 from .types import GatewayRequest, GatewayResponse
 
+# Default model for gateway connectivity probes (health_check). Must be a
+# current, cheap, generally-available model. Update here when it is retired —
+# a 404 from a retired probe model otherwise surfaces as a spurious health-check
+# "error" even when the council itself is healthy (ADR-012).
+DEFAULT_HEALTH_CHECK_MODEL = "google/gemini-2.5-flash-lite"
+
 
 class HealthStatus(Enum):
     """Health status for a gateway router."""

--- a/src/llm_council/gateway/direct.py
+++ b/src/llm_council/gateway/direct.py
@@ -595,9 +595,9 @@ class DirectGateway(BaseRouter):
                     provider=provider,
                     model="gpt-4o-mini"
                     if provider == "openai"
-                    else "claude-3-5-haiku-20241022"
+                    else "claude-haiku-4-5"
                     if provider == "anthropic"
-                    else "gemini-2.0-flash-001",
+                    else "gemini-2.5-flash-lite",
                     messages=[{"role": "user", "content": "ping"}],
                     timeout=10.0,
                 )

--- a/src/llm_council/gateway/openrouter.py
+++ b/src/llm_council/gateway/openrouter.py
@@ -28,6 +28,7 @@ def _get_openrouter_api_key() -> str:
 OPENROUTER_API_KEY = _get_openrouter_api_key()
 
 from .base import (
+    DEFAULT_HEALTH_CHECK_MODEL,
     BaseRouter,
     HealthStatus,
     RouterCapabilities,
@@ -350,7 +351,7 @@ class OpenRouterGateway(BaseRouter):
         """
         # Use a fast, cheap model for health check
         result = await self._query_openrouter(
-            model="google/gemini-2.0-flash-001",
+            model=DEFAULT_HEALTH_CHECK_MODEL,
             messages=[{"role": "user", "content": "ping"}],
             timeout=10.0,
         )

--- a/src/llm_council/gateway/requesty.py
+++ b/src/llm_council/gateway/requesty.py
@@ -15,6 +15,7 @@ from typing import AsyncIterator, Dict, Any, List, Optional
 import httpx
 
 from .base import (
+    DEFAULT_HEALTH_CHECK_MODEL,
     BaseRouter,
     HealthStatus,
     RouterCapabilities,
@@ -339,7 +340,7 @@ class RequestyGateway(BaseRouter):
         """
         # Use a fast, cheap model for health check
         result = await self._query_requesty(
-            model="google/gemini-2.0-flash-001",
+            model=DEFAULT_HEALTH_CHECK_MODEL,
             messages=[{"role": "user", "content": "ping"}],
             timeout=10.0,
         )

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -40,6 +40,7 @@ from llm_council.verification.transcript import (
 from llm_council.unified_config import get_config, get_api_key
 from llm_council.tier_contract import create_tier_contract
 from llm_council.openrouter import query_model_with_status, STATUS_OK
+from llm_council.gateway.base import DEFAULT_HEALTH_CHECK_MODEL
 
 
 def _get_council_models() -> list:
@@ -346,7 +347,7 @@ async def council_health_check() -> str:
         try:
             start = time.time()
             response = await query_model_with_status(
-                "google/gemini-2.0-flash-001",  # Fast and cheap
+                DEFAULT_HEALTH_CHECK_MODEL,  # Fast, cheap, GA probe model
                 [{"role": "user", "content": "ping"}],
                 timeout=10.0,
             )
@@ -355,7 +356,7 @@ async def council_health_check() -> str:
             checks["api_connectivity"] = {
                 "status": response["status"],
                 "latency_ms": latency_ms,
-                "test_model": "google/gemini-2.0-flash-001",
+                "test_model": DEFAULT_HEALTH_CHECK_MODEL,
             }
 
             if response["status"] == STATUS_OK:

--- a/src/llm_council/models/registry.yaml
+++ b/src/llm_council/models/registry.yaml
@@ -11,13 +11,22 @@
 #   modalities: List of input modalities (text, vision, audio)
 #   quality_tier: frontier | standard | economy | local
 
-version: "1.2"
-updated: "2026-03-06"
+version: "1.3"
+updated: "2026-06-02"
 
 models:
   # ============================================================================
-  # OpenAI Models (13)
+  # OpenAI Models (14)
   # ============================================================================
+  - id: "openai/gpt-5.5-pro"
+    context_window: 1050000
+    pricing:
+      prompt: 0.03
+      completion: 0.18
+    supported_parameters: ["temperature", "top_p", "tools", "json_mode", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "frontier"
+
   - id: "openai/gpt-5.4-pro"
     context_window: 1050000
     pricing:
@@ -154,7 +163,7 @@ models:
     quality_tier: "standard"
 
   # ============================================================================
-  # Anthropic Models (8)
+  # Anthropic Models (9)
   # ============================================================================
   - id: "anthropic/claude-sonnet-4.6"
     context_window: 1000000
@@ -165,11 +174,20 @@ models:
     modalities: ["text", "vision"]
     quality_tier: "frontier"
 
+  - id: "anthropic/claude-opus-4.8"
+    context_window: 1000000
+    pricing:
+      prompt: 0.005
+      completion: 0.025
+    supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "frontier"
+
   - id: "anthropic/claude-opus-4.7"
     context_window: 1000000
     pricing:
-      prompt: 0.015
-      completion: 0.075
+      prompt: 0.005
+      completion: 0.025
     supported_parameters: ["temperature", "top_p", "tools"]
     modalities: ["text", "vision"]
     quality_tier: "frontier"
@@ -238,7 +256,7 @@ models:
     quality_tier: "standard"
 
   # ============================================================================
-  # Google Models (8)
+  # Google Models (9)
   # ============================================================================
   - id: "google/gemini-3.1-pro-preview"
     context_window: 1040000
@@ -248,6 +266,15 @@ models:
     supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
     modalities: ["text", "vision"]
     quality_tier: "frontier"
+
+  - id: "google/gemini-3.1-flash-lite"
+    context_window: 1048576
+    pricing:
+      prompt: 0.00025
+      completion: 0.0015
+    supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "economy"
 
   - id: "google/gemini-3.1-flash-lite-preview"
     context_window: 1040000
@@ -285,8 +312,8 @@ models:
     modalities: ["text", "vision"]
     quality_tier: "frontier"
 
-  - id: "google/gemini-2.0-flash-001"
-    context_window: 1000000
+  - id: "google/gemini-2.5-flash-lite"
+    context_window: 1048576
     pricing:
       prompt: 0.0001
       completion: 0.0004
@@ -315,14 +342,14 @@ models:
   # ============================================================================
   # DeepSeek Models (4)
   # ============================================================================
-  - id: "deepseek/deepseek-v3.2-speciale"
-    context_window: 163000
+  - id: "deepseek/deepseek-v4-pro"
+    context_window: 1048576
     pricing:
-      prompt: 0.0004
-      completion: 0.0012
+      prompt: 0.00043
+      completion: 0.00087
     supported_parameters: ["temperature", "top_p", "reasoning"]
     modalities: ["text"]
-    quality_tier: "standard"
+    quality_tier: "frontier"
 
   - id: "deepseek/deepseek-v3.2"
     context_window: 163000

--- a/src/llm_council/tier_contract.py
+++ b/src/llm_council/tier_contract.py
@@ -78,32 +78,32 @@ _DEFAULT_TIER_MODEL_POOLS = {
     "quick": [
         "openai/gpt-5-mini",
         "anthropic/claude-haiku-4.5",
-        "google/gemini-3.1-flash-lite-preview",
+        "google/gemini-3.1-flash-lite",
         "deepseek/deepseek-v3.2",
     ],
     "balanced": [
         "openai/gpt-5.4-mini",
         "anthropic/claude-sonnet-4.6",
-        "google/gemini-3.1-flash-lite-preview",
+        "google/gemini-3.1-flash-lite",
         "deepseek/deepseek-v3.2",
     ],
     "high": [
         "openai/gpt-5.4",
-        "anthropic/claude-opus-4.7",
+        "anthropic/claude-opus-4.8",
         "google/gemini-3.1-pro-preview",
-        "deepseek/deepseek-v3.2-speciale",
+        "deepseek/deepseek-v4-pro",
     ],
     "reasoning": [
         "openai/gpt-5.4-pro",
-        "anthropic/claude-opus-4.7",
+        "anthropic/claude-opus-4.8",
         "google/gemini-3.1-pro-preview",
-        "deepseek/deepseek-v3.2-speciale",
+        "deepseek/deepseek-r1",
     ],
     "frontier": [
-        "openai/gpt-5.4-pro",
-        "anthropic/claude-opus-4.7",
+        "openai/gpt-5.5-pro",
+        "anthropic/claude-opus-4.8",
         "google/gemini-3.1-pro-preview",
-        "deepseek/deepseek-v3.2-speciale",
+        "deepseek/deepseek-v4-pro",
     ],
 }
 
@@ -122,8 +122,8 @@ TIER_AGGREGATORS: Dict[str, str] = {
     "quick": "openai/gpt-5-mini",  # Speed-matched
     "balanced": "openai/gpt-5.4-mini",  # Quality-matched
     "high": "openai/gpt-5.4",  # Full capability
-    "reasoning": "anthropic/claude-opus-4.7",  # Can understand reasoning outputs
-    "frontier": "anthropic/claude-opus-4.7",  # Best available for cutting-edge synthesis (ADR-027)
+    "reasoning": "anthropic/claude-opus-4.8",  # Can understand reasoning outputs
+    "frontier": "anthropic/claude-opus-4.8",  # Best available for cutting-edge synthesis (ADR-027)
 }
 
 

--- a/src/llm_council/unified_config.py
+++ b/src/llm_council/unified_config.py
@@ -14,7 +14,7 @@ Example YAML configuration (llm_council.yaml):
         default: high
         pools:
           quick:
-            models: [openai/gpt-4o-mini, anthropic/claude-3-5-haiku-20241022]
+            models: [openai/gpt-5-mini, anthropic/claude-haiku-4.5]
             timeout_seconds: 30
       triage:
         enabled: false
@@ -180,7 +180,7 @@ class TierConfig(BaseModel):
                 models=[
                     "openai/gpt-5-mini",
                     "anthropic/claude-haiku-4.5",
-                    "google/gemini-3.1-flash-lite-preview",
+                    "google/gemini-3.1-flash-lite",
                     "deepseek/deepseek-v3.2",
                 ],
                 timeout_seconds=30,
@@ -190,7 +190,7 @@ class TierConfig(BaseModel):
                 models=[
                     "openai/gpt-5.4-mini",
                     "anthropic/claude-sonnet-4.6",
-                    "google/gemini-3.1-flash-lite-preview",
+                    "google/gemini-3.1-flash-lite",
                     "deepseek/deepseek-v3.2",
                 ],
                 timeout_seconds=90,
@@ -198,28 +198,28 @@ class TierConfig(BaseModel):
             "high": TierPoolConfig(
                 models=[
                     "openai/gpt-5.4",
-                    "anthropic/claude-opus-4.7",
+                    "anthropic/claude-opus-4.8",
                     "google/gemini-3.1-pro-preview",
-                    "deepseek/deepseek-v3.2-speciale",
+                    "deepseek/deepseek-v4-pro",
                 ],
                 timeout_seconds=180,
             ),
             "reasoning": TierPoolConfig(
                 models=[
                     "openai/gpt-5.4-pro",
-                    "anthropic/claude-opus-4.7",
+                    "anthropic/claude-opus-4.8",
                     "google/gemini-3.1-pro-preview",
-                    "deepseek/deepseek-v3.2-speciale",
+                    "deepseek/deepseek-r1",
                 ],
                 timeout_seconds=600,
             ),
             # ADR-027: Frontier tier for cutting-edge/preview models
             "frontier": TierPoolConfig(
                 models=[
-                    "openai/gpt-5.4-pro",
-                    "anthropic/claude-opus-4.7",
+                    "openai/gpt-5.5-pro",
+                    "anthropic/claude-opus-4.8",
                     "google/gemini-3.1-pro-preview",
-                    "deepseek/deepseek-v3.2-speciale",
+                    "deepseek/deepseek-v4-pro",
                 ],
                 timeout_seconds=600,
             ),
@@ -722,8 +722,8 @@ class CouncilConfig(BaseModel):
         default_factory=lambda: [
             "openai/gpt-5.4",
             "google/gemini-3.1-pro-preview",
-            "anthropic/claude-opus-4.7",
-            "deepseek/deepseek-v3.2-speciale",
+            "anthropic/claude-opus-4.8",
+            "deepseek/deepseek-v4-pro",
         ],
         alias="LLM_COUNCIL_MODELS",
     )


### PR DESCRIPTION
## Summary

Two model-currency fixes, plus an opportunistic CLAUDE.md cleanup. Targeted for release **v0.24.42**.

### 1. Health check "error" was just a retired probe model (item 1)
`council_health_check` and the OpenRouter/Requesty/direct gateway `health_check()` methods probed connectivity with a hardcoded `google/gemini-2.0-flash-001`, which has been **retired from OpenRouter and now 404s**. That surfaced as a health-check `error` / `ready: false` even when the council was healthy.

- Centralised the probe as `DEFAULT_HEALTH_CHECK_MODEL` in `gateway/base.py` → `google/gemini-2.5-flash-lite` (current, cheap, GA). All four call sites now reference the one constant, so the next retirement is a one-line change.
- Refreshed the direct gateway's native-API probe ids (`claude-3-5-haiku-20241022` → `claude-haiku-4-5`, `gemini-2.0-flash-001` → `gemini-2.5-flash-lite`).

### 2. Are the tiered models current? — refreshed against live OpenRouter (item 2)
Cross-checked **every** tier-pool model against `https://openrouter.ai/api/v1/models` (342 models, fetched 2026-06-02). Found `deepseek/deepseek-v3.2-speciale` (used in `high`/`reasoning`/`frontier`) **does not exist** and would fail at request time. Refreshed pools + their code-level defaults (`tier_contract.py`, `unified_config.py`) and the bundled registry:

| Tier | Before | After |
|------|--------|-------|
| quick / balanced (Google) | `gemini-3.1-flash-lite-preview` | `gemini-3.1-flash-lite` (GA) |
| high / reasoning / frontier (Anthropic) | `claude-opus-4.7` | `claude-opus-4.8` (newest, same price) |
| high / frontier (DeepSeek) | `deepseek-v3.2-speciale` ❌ | `deepseek-v4-pro` |
| reasoning (DeepSeek) | `deepseek-v3.2-speciale` ❌ | `deepseek-r1` (reasoning-specialised) |
| frontier (OpenAI) | `gpt-5.4-pro` | `gpt-5.5-pro` (newest) |

All 20 pool entries + the health probe now resolve **both** in the bundled registry and live on OpenRouter (verified programmatically). Registry bumped to v1.3; stale `claude-opus-4.7` pricing also corrected to live values.

> **Reviewer note / judgment calls:** these are *proposals* — easy to tune here. The notable cost bump is `frontier` → `gpt-5.5-pro` ($30/1M in). `high`/`reasoning`/`frontier` keep `gemini-3.1-pro-preview` (still the only preview-tier Gemini 3.1 Pro). Happy to hold any tier at a cheaper/GA option.

### Plus: CLAUDE.md optimization (separate commit)
The doc described a retired `backend/` + `frontend/` web-app layout (no longer present), with a wrong run command and port, and ~600 lines of staling per-function listings. Replaced with an accurate ADR-keyed module map + durable design notes (845 → 145 lines).

## Testing
- Full suite: **2825 passed, 1 skipped** (`uv run --extra dev --extra all pytest`)
- `ruff check` clean on all changed files
- Programmatic check: every tier-pool model + probe resolves in registry ∩ live OpenRouter; retired ids fully removed
- Pre-existing mypy errors in `tier_contract.py` (lines 279-285) are unrelated to this change (confirmed present with edits stashed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)