### PR TITLE
fix(mcp): report real API-key source in health check (keychain vs unknown)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`council_health_check` now reports the real API-key source** — `key_source` showed `"unknown"` whenever the key came from the macOS Keychain (ADR-013), because `mcp_server._get_key_source()` only checked the `OPENROUTER_API_KEY` env var. It now delegates to `unified_config.get_key_source()`, which tracks the actual resolution path, so a keychain-resolved key reports `"keychain"` (env still reports `"environment"`). Cosmetic only — key resolution itself already worked.
+
 ## [0.24.43] - 2026-06-02
 
 ### Fixed

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -37,7 +37,11 @@ from llm_council.verification.transcript import (
 )
 
 # ADR-032: Migrated to unified_config
-from llm_council.unified_config import get_config, get_api_key
+from llm_council.unified_config import (
+    get_config,
+    get_api_key,
+    get_key_source as _config_get_key_source,
+)
 from llm_council.tier_contract import create_tier_contract
 from llm_council.openrouter import query_model_with_status, STATUS_OK
 from llm_council.gateway.base import DEFAULT_HEALTH_CHECK_MODEL
@@ -75,13 +79,16 @@ def _get_tier_timeout(tier: str) -> dict:
 
 
 def _get_key_source() -> str:
-    """Determine the source of the API key."""
-    import os
+    """Report where the OpenRouter API key was resolved from (ADR-013).
 
-    if os.environ.get("OPENROUTER_API_KEY"):
-        return "environment"
-    # Could add keychain detection here
-    return "unknown"
+    Delegates to unified_config's source tracking, which distinguishes
+    "environment", "keychain", "config_file", etc. — instead of only
+    detecting the env var and otherwise reporting "unknown". Re-resolving
+    here makes the reported source deterministic for the OpenRouter key
+    regardless of intervening resolutions for other providers.
+    """
+    get_api_key("openrouter")
+    return _config_get_key_source()
 
 
 # Module-level function for backwards compatibility with tests


### PR DESCRIPTION
## Summary

Cosmetic fix surfaced while restoring the local MCP server's keychain key after the v0.24.43 upgrade: `council_health_check` reported `"key_source": "unknown"` even though the key was correctly resolved from the macOS Keychain.

`mcp_server._get_key_source()` only inspected the `OPENROUTER_API_KEY` env var and returned `"unknown"` otherwise. It now delegates to `unified_config.get_key_source()`, which already tracks the actual ADR-013 resolution path.

| Key source | Before | After |
|------------|--------|-------|
| macOS Keychain | `"unknown"` | `"keychain"` |
| Env var | `"environment"` | `"environment"` |

**Resolution itself always worked** — this only fixes the reported label in the health check.

## Testing
- `tests/test_secure_key_handling.py` — 22 passed
- MCP / health / key_source tests — 31 passed
- `ruff check` clean

## Release note
No dedicated release — intended to ride the **next substantive release** (entry sits under `## [Unreleased]` in CHANGELOG). The change only reaches a running MCP server after that release is published and the local tool is reinstalled as `[mcp,secure]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)