### PR TITLE
fix(verify): handle None/empty synthesis in verdict extraction (NoneType crash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`verify` no longer crashes when the chairman synthesis is empty/None** — `extract_verdict_from_synthesis` and `extract_blocking_issues` read the synthesis via `stage3_result.get("response", "")`, but the `"response"` key is normally present with a `None` value (e.g. a reasoning-only model returning null content, or a partial/timed-out stage 3), so the `""` default never applied. `None.upper()` / `re.finditer(pattern, None)` then raised `AttributeError: 'NoneType' object has no attribute 'upper'` (surfaced to MCP callers as a generic crash), instead of degrading to an `"unclear"` verdict the way a *missing* key already did. Both extractors now coalesce a missing/None synthesis to `""`. Regression tests added in `tests/unit/verification/test_verdict_extractor.py`.
+
 ## [0.24.43] - 2026-06-02
 
 ### Fixed

--- a/src/llm_council/verification/verdict_extractor.py
+++ b/src/llm_council/verification/verdict_extractor.py
@@ -48,7 +48,12 @@ def extract_verdict_from_synthesis(
         - verdict: "pass", "fail", or "unclear"
         - base_confidence: 0.0-1.0 based on signal strength
     """
-    response = stage3_result.get("response", "")
+    # Coalesce a missing/None synthesis to "" so an empty, failed, or partial
+    # stage 3 (e.g. a reasoning-only model returning null content, or a
+    # timed-out synthesis) degrades to an "unclear" verdict instead of raising
+    # AttributeError. `.get("response", "")` is insufficient: the key is usually
+    # present with a None value, so the "" default never applies.
+    response = (stage3_result or {}).get("response") or ""
     response_upper = response.upper()
 
     # Check for explicit verdict markers
@@ -267,7 +272,10 @@ def extract_blocking_issues(
     Returns:
         List of blocking issue dictionaries with severity, description, location
     """
-    response = stage3_result.get("response", "")
+    # Same None-coalescing as extract_verdict_from_synthesis: a None synthesis
+    # would otherwise make re.finditer() raise on a non-string. Treat empty/None
+    # as "no blocking issues found".
+    response = (stage3_result or {}).get("response") or ""
     issues: List[Dict[str, Any]] = []
 
     # Look for critical/major/minor issue patterns

--- a/tests/unit/verification/test_verdict_extractor.py
+++ b/tests/unit/verification/test_verdict_extractor.py
@@ -1,0 +1,51 @@
+"""Regression tests for verdict extraction robustness (ADR-034).
+
+A reasoning-only model returning null content, or a partial/timed-out stage 3,
+yields a synthesis whose ``response`` is ``None`` (the key is present with a
+None value, so ``.get("response", "")`` returns None — not ""). The verdict
+extractors must degrade to an "unclear"/empty result instead of raising
+``AttributeError: 'NoneType' object has no attribute ...``.
+"""
+
+import pytest
+
+from llm_council.verification.verdict_extractor import (
+    extract_blocking_issues,
+    extract_verdict_from_synthesis,
+)
+
+
+class TestExtractVerdictFromSynthesisHandlesNone:
+    def test_response_is_none_returns_unclear(self):
+        # Chairman returned null content (reasoning-only model / empty synthesis)
+        verdict, confidence = extract_verdict_from_synthesis({"response": None})
+        assert verdict == "unclear"
+        assert 0.0 <= confidence <= 1.0
+
+    def test_response_key_absent_returns_unclear(self):
+        verdict, _ = extract_verdict_from_synthesis({})
+        assert verdict == "unclear"
+
+    def test_stage3_result_is_none_returns_unclear(self):
+        # Whole synthesis failed/missing
+        verdict, _ = extract_verdict_from_synthesis(None)
+        assert verdict == "unclear"
+
+    def test_normal_pass_still_works(self):
+        verdict, _ = extract_verdict_from_synthesis(
+            {"response": "The implementation is APPROVED and correct."}
+        )
+        assert verdict == "pass"
+
+
+class TestExtractBlockingIssuesHandlesNone:
+    @pytest.mark.parametrize("stage3", [{"response": None}, {}, None])
+    def test_none_or_missing_synthesis_yields_no_issues(self, stage3):
+        assert extract_blocking_issues(stage3) == []
+
+    def test_issues_still_extracted_from_text(self):
+        issues = extract_blocking_issues(
+            {"response": "CRITICAL: null deref in foo.py:10"}
+        )
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "critical"


### PR DESCRIPTION
## Summary

Investigated a downstream (Conductor) session whose **high-tier `verify` crashed** with `'NoneType' object has no attribute …`. Root-caused to verdict extraction, not infra.

`extract_verdict_from_synthesis()` and `extract_blocking_issues()` read the chairman synthesis with `stage3_result.get("response", "")`. But the `"response"` key is normally **present with a `None` value** when the synthesis is empty/failed/partial — a reasoning-only model returning null `content`, or a timed-out stage 3. So the `""` default never applied, and:

- `None.upper()` → `AttributeError` (verdict extractor)
- `re.finditer(pattern, None)` → `TypeError` (blocking-issues extractor)

…instead of degrading to an `"unclear"` verdict the way a *missing* key already did.

### Fix
Both extractors now coalesce a missing/None synthesis to `""`: `(stage3_result or {}).get("response") or ""`.

### Reproduction (before fix)
```python
extract_verdict_from_synthesis({"response": None})
# AttributeError: 'NoneType' object has no attribute 'upper'
```
After: returns `("unclear", …)`.

## Why it started showing up
v0.24.43's tier refresh added reasoning-only models (`deepseek-v4-pro`, `deepseek-r1`) to the high/reasoning/frontier pools; these return `content=None`, making null-content synthesis far more likely to hit this latent hole.

## Scope ruled out (grounding)
- Not any of llm-council's own `.replace`/`.upper` calls elsewhere — verified installed bytes == released source.
- ADR-036 quality metrics tolerate `None` content (separately reproduced — no crash).
- The wider `response.get("content", "")` pattern (~8 sites) has the same None-coalescing weakness; most consumers tolerate it today, but it's worth a follow-up sweep.

## Testing
- New `tests/unit/verification/test_verdict_extractor.py` — 8 passed
- Full verification suite — 261 passed
- `ruff` clean

## Note
Two problems were reported in that session; **this PR fixes only the crash.** The other — `balanced` timing out — is environmental (frontier/reasoning model latency exceeding the tier deadline), not a code bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)