### PR TITLE
Release v0.24.44: fix verify NoneType crash + real key_source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.44] - 2026-06-02
+
+### Fixed
+
+- **`verify` no longer crashes when the chairman synthesis is empty/None** — `extract_verdict_from_synthesis` and `extract_blocking_issues` read the synthesis via `stage3_result.get("response", "")`, but the `"response"` key is normally present with a `None` value (e.g. a reasoning-only model returning null content, or a partial/timed-out stage 3), so the `""` default never applied. `None.upper()` / `re.finditer(pattern, None)` then raised `AttributeError: 'NoneType' object has no attribute 'upper'` (surfaced to MCP callers as a generic crash), instead of degrading to an `"unclear"` verdict the way a *missing* key already did. Both extractors now coalesce a missing/None synthesis to `""`. Regression tests added in `tests/unit/verification/test_verdict_extractor.py`.
+- **`council_health_check` now reports the real API-key source** — `key_source` showed `"unknown"` whenever the key came from the macOS Keychain (ADR-013), because `mcp_server._get_key_source()` only checked the `OPENROUTER_API_KEY` env var. It now delegates to `unified_config.get_key_source()`, which tracks the actual resolution path, so a keychain-resolved key reports `"keychain"` (env still reports `"environment"`). Cosmetic only — key resolution itself already worked.
+
 ## [0.24.43] - 2026-06-02
 
 ### Fixed

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -37,7 +37,11 @@ from llm_council.verification.transcript import (
 )
 
 # ADR-032: Migrated to unified_config
-from llm_council.unified_config import get_config, get_api_key
+from llm_council.unified_config import (
+    get_config,
+    get_api_key,
+    get_key_source as _config_get_key_source,
+)
 from llm_council.tier_contract import create_tier_contract
 from llm_council.openrouter import query_model_with_status, STATUS_OK
 from llm_council.gateway.base import DEFAULT_HEALTH_CHECK_MODEL
@@ -75,13 +79,16 @@ def _get_tier_timeout(tier: str) -> dict:
 
 
 def _get_key_source() -> str:
-    """Determine the source of the API key."""
-    import os
+    """Report where the OpenRouter API key was resolved from (ADR-013).
 
-    if os.environ.get("OPENROUTER_API_KEY"):
-        return "environment"
-    # Could add keychain detection here
-    return "unknown"
+    Delegates to unified_config's source tracking, which distinguishes
+    "environment", "keychain", "config_file", etc. — instead of only
+    detecting the env var and otherwise reporting "unknown". Re-resolving
+    here makes the reported source deterministic for the OpenRouter key
+    regardless of intervening resolutions for other providers.
+    """
+    get_api_key("openrouter")
+    return _config_get_key_source()
 
 
 # Module-level function for backwards compatibility with tests

--- a/src/llm_council/verification/verdict_extractor.py
+++ b/src/llm_council/verification/verdict_extractor.py
@@ -48,7 +48,12 @@ def extract_verdict_from_synthesis(
         - verdict: "pass", "fail", or "unclear"
         - base_confidence: 0.0-1.0 based on signal strength
     """
-    response = stage3_result.get("response", "")
+    # Coalesce a missing/None synthesis to "" so an empty, failed, or partial
+    # stage 3 (e.g. a reasoning-only model returning null content, or a
+    # timed-out synthesis) degrades to an "unclear" verdict instead of raising
+    # AttributeError. `.get("response", "")` is insufficient: the key is usually
+    # present with a None value, so the "" default never applies.
+    response = (stage3_result or {}).get("response") or ""
     response_upper = response.upper()
 
     # Check for explicit verdict markers
@@ -267,7 +272,10 @@ def extract_blocking_issues(
     Returns:
         List of blocking issue dictionaries with severity, description, location
     """
-    response = stage3_result.get("response", "")
+    # Same None-coalescing as extract_verdict_from_synthesis: a None synthesis
+    # would otherwise make re.finditer() raise on a non-string. Treat empty/None
+    # as "no blocking issues found".
+    response = (stage3_result or {}).get("response") or ""
     issues: List[Dict[str, Any]] = []
 
     # Look for critical/major/minor issue patterns

--- a/tests/unit/verification/test_verdict_extractor.py
+++ b/tests/unit/verification/test_verdict_extractor.py
@@ -1,0 +1,51 @@
+"""Regression tests for verdict extraction robustness (ADR-034).
+
+A reasoning-only model returning null content, or a partial/timed-out stage 3,
+yields a synthesis whose ``response`` is ``None`` (the key is present with a
+None value, so ``.get("response", "")`` returns None — not ""). The verdict
+extractors must degrade to an "unclear"/empty result instead of raising
+``AttributeError: 'NoneType' object has no attribute ...``.
+"""
+
+import pytest
+
+from llm_council.verification.verdict_extractor import (
+    extract_blocking_issues,
+    extract_verdict_from_synthesis,
+)
+
+
+class TestExtractVerdictFromSynthesisHandlesNone:
+    def test_response_is_none_returns_unclear(self):
+        # Chairman returned null content (reasoning-only model / empty synthesis)
+        verdict, confidence = extract_verdict_from_synthesis({"response": None})
+        assert verdict == "unclear"
+        assert 0.0 <= confidence <= 1.0
+
+    def test_response_key_absent_returns_unclear(self):
+        verdict, _ = extract_verdict_from_synthesis({})
+        assert verdict == "unclear"
+
+    def test_stage3_result_is_none_returns_unclear(self):
+        # Whole synthesis failed/missing
+        verdict, _ = extract_verdict_from_synthesis(None)
+        assert verdict == "unclear"
+
+    def test_normal_pass_still_works(self):
+        verdict, _ = extract_verdict_from_synthesis(
+            {"response": "The implementation is APPROVED and correct."}
+        )
+        assert verdict == "pass"
+
+
+class TestExtractBlockingIssuesHandlesNone:
+    @pytest.mark.parametrize("stage3", [{"response": None}, {}, None])
+    def test_none_or_missing_synthesis_yields_no_issues(self, stage3):
+        assert extract_blocking_issues(stage3) == []
+
+    def test_issues_still_extracted_from_text(self):
+        issues = extract_blocking_issues(
+            {"response": "CRITICAL: null deref in foo.py:10"}
+        )
+        assert len(issues) == 1
+        assert issues[0]["severity"] == "critical"


### PR DESCRIPTION
## Summary

Fast-track patch release bundling two fixes (supersedes #351 and #352, which are folded in here).

### 1. `verify` NoneType crash (the urgent one)
High-tier `verify` crashed with `'NoneType' object has no attribute …` when the chairman synthesis came back empty/None (reasoning-only model returning null content, or a partial/timed-out stage 3). `extract_verdict_from_synthesis` / `extract_blocking_issues` used `stage3_result.get("response", "")`, but the key is present-with-`None`, so the `""` default never applied → `None.upper()` / `re.finditer(pattern, None)` raised. Now both coalesce to `""` and degrade to an `"unclear"` verdict (matching the already-graceful missing-key path).

Reproduced and covered: `tests/unit/verification/test_verdict_extractor.py` (8 cases).

### 2. `council_health_check` key_source (cosmetic)
Reported `"unknown"` for keychain-resolved keys; now delegates to `unified_config.get_key_source()` → reports `"keychain"`.

## Testing
- Full suite: **2833 passed, 1 skipped**
- `ruff` clean

## Notes
- The verify fix turns a crash into a correct `"unclear"` verdict on empty synthesis — it does **not** speed up slow models. A separately-reported `balanced` timeout in the field was environmental (model latency vs tier deadline), not a code bug.
- After merge + tag, the local MCP tool must be reinstalled as `llm-council-core[mcp,secure]==0.24.44` (the `[secure]` extra is required for keychain resolution) and the server reconnected.

Closes #351, #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)