### PR TITLE
chore(adr-011): epic setup + refreshed ADRs for cost accounting

### DIFF
--- a/.epic-loop/config.yaml
+++ b/.epic-loop/config.yaml
@@ -8,13 +8,17 @@ project:
   short_name: "council"
   repo: "amiable-dev/llm-council"        # EPIC=N resolves against this repo
 
-# Pre-push gates mirror the required CI checks (Test / Lint / Type Check) so a
-# red CI (state F) is caught locally first. Scoped via only_if_changed: ADR- and
-# docs-only PRs skip build/test entirely and pay nothing. `make test-fast` here
-# keeps the loop snappy; CI still runs the full `make test` suite as the backstop.
+# Pre-push gates mirror the ACTUAL blocking CI checks so a red CI (state F) is
+# caught locally first. Note: CI's type-check step is advisory
+# (`mypy … || echo "…non-blocking"`) and the repo carries pre-existing mypy
+# debt, so `make check` would wrongly block the loop on baseline errors CI
+# tolerates. We gate on ruff (the blocking Lint job) + tests; mypy stays a
+# manual due-diligence check on changed code. Scoped via only_if_changed so
+# docs/ADR-only PRs skip build/test and pay nothing. `make test-fast` keeps the
+# loop snappy; CI runs the full `make test` suite as the backstop.
 pre_push_gates:
-  - name: lint-typecheck
-    command: make check          # ruff + mypy
+  - name: lint
+    command: make lint           # ruff check src/ tests/ — the blocking CI gate
     only_if_changed:
       - "src/**"
       - "tests/**"

--- a/.epic-loop/config.yaml
+++ b/.epic-loop/config.yaml
@@ -1,0 +1,51 @@
+# .epic-loop/config.yaml — per-repo bindings for /epic-loop and /adr-epic.
+# Schema: .claude/skills/epic-loop/references/config-schema.md
+# Tuned for llm-council (Python package: CLI + HTTP + MCP server).
+version: 1
+
+project:
+  name: "llm-council"
+  short_name: "council"
+  repo: "amiable-dev/llm-council"        # EPIC=N resolves against this repo
+
+# Pre-push gates mirror the required CI checks (Test / Lint / Type Check) so a
+# red CI (state F) is caught locally first. Scoped via only_if_changed: ADR- and
+# docs-only PRs skip build/test entirely and pay nothing. `make test-fast` here
+# keeps the loop snappy; CI still runs the full `make test` suite as the backstop.
+pre_push_gates:
+  - name: lint-typecheck
+    command: make check          # ruff + mypy
+    only_if_changed:
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+  - name: tests-fast
+    command: make test-fast
+    only_if_changed:
+      - "src/**"
+      - "tests/**"
+
+language_test_guards: []
+gui_paths: []
+
+# slop-detector (already installed, pinned) runs collect-only over src/ and is
+# fed to Council as informational evidence — not a hard gate.
+quality_signals:
+  enabled: true
+  scan_target: "src"
+  trigger_paths:
+    - "src/**"
+  scanner_version_pin: "3.7.3"
+
+council:
+  default_tier: balanced
+  confidence_threshold: 0.7
+  on_budget_exceeded: manual_coverage
+
+# No Copilot reviewer authors PRs in this repo → skip the B0–B3 ladder and go
+# straight to the mandatory Council gate. Flip to `copilot` if that changes.
+review: none
+
+cadence_floor:
+  max_merges_per_hour: 2
+  scope: closes_clause

--- a/.epic-loop/config.yaml
+++ b/.epic-loop/config.yaml
@@ -50,6 +50,12 @@ council:
 # straight to the mandatory Council gate. Flip to `copilot` if that changes.
 review: none
 
+# Raised to 5/hr (from 2) for autonomous multi-phase execution of epic #359.
+# Safe here because child merges never publish: setuptools-scm derives the
+# version from git tags and publish.yml triggers on tag push only, so merging
+# phase PRs to master does NOT release. Versioning is deferred to ONE release
+# at epic completion (minor, or major if breaking), per the impact of the whole
+# epic — see epic #359 and [[council-release-once-per-epic]].
 cadence_floor:
-  max_merges_per_hour: 2
+  max_merges_per_hour: 5
   scope: closes_clause

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,9 @@ site/
 .mcp.json
 .council/
 .council/
+
+# slop-detector: governance config (contains codebase complexity surface — keep private)
+.epic-loop/*
+!.epic-loop/config.yaml
+.slopconfig.yaml
+.clawpatch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Cost and token accounting (ADR-011, Phase 1)** — the council now captures and reports USD cost alongside tokens. A per-gateway `CostResolver` (`gateway/cost_resolver.py`) stamps `cost_usd` + a `cost_source` provenance tag onto every call — `provider` ground-truth for OpenRouter/Requesty (capturing the previously-discarded inline `usage.cost`), `registry_estimate` from `registry.yaml` pricing for Direct APIs, and `local_zero` for Ollama — so an estimate is never presented as a bill. `metadata["usage"]` now carries `{by_stage, by_model, total}` with `cost_usd`/`cached_tokens` (per-model uses reviewer-primary attribution), exposed as a typed, OpenAPI-documented `usage` field on the HTTP `CouncilResponse` and as a progressive-disclosure **Cost & Tokens** summary in MCP `consult_council` (one line by default; full per-model/per-stage breakdown only under `include_details`). The MCP fallback path (`run_council_with_fallback`) now aggregates usage into metadata too (previously absent — the MCP surface had no token data). Cost accounting is soft-fail and never breaks a council run. Surfacing token/cost in `VerifyResponse` is deferred to a follow-up (verification telemetry, ADR-041).
+
 ## [0.24.45] - 2026-06-16
 
 Verify-gate robustness pass, from a real epic-loop session that "kept reporting council timeouts." Investigation of the live transcripts and `.council/logs` found the council server healthy — the pain was four distinct verify-layer defects conflated as "timeouts". All four are fixed here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,11 @@ Evaluation & scoring
 - `evaluation.py`, `quality/`, `verdict.py`, `dissent.py` — additional evaluation/quality surfaces.
 - `gateway/` (ADR-030) — `EnhancedCircuitBreaker` (sliding-window failure rate, default 25% over 10-min window, 30-min cooldown, half-open probes) + per-model registry that emits `L4_CIRCUIT_BREAKER_OPEN/CLOSE`. `scoring.py` — cost-scoring algorithms (linear/log_ratio/exponential).
 
+Cost & token accounting (ADR-011, Phase 1)
+- `gateway/cost_resolver.py` — `CostResolver` stamps `cost_usd` + `cost_source` on each call: **provider** ground-truth for OpenRouter/Requesty (inline `usage.cost`, previously discarded), **registry_estimate** for Direct APIs (`registry.yaml` pricing × tokens), **local_zero** for Ollama. `registry_pricing_lookup` bridges to `metadata.get_provider().get_pricing`.
+- `openrouter.py` `query_model` now captures `cost`/`cached_tokens`; `council.py` aggregates per-stage **and** per-model (`_add_cost_to_usage` → `_build_usage_summary`, shared by both entry points) into `metadata["usage"] = {by_stage, by_model, total}` — each carries `cost_usd`/`cached_tokens`. **Never presents an estimate as a bill** (`cost_source` distinguishes). Cost accounting never fails a run (soft-fail).
+- `cost_summary.py` `format_cost_summary` renders usage with **progressive disclosure**: one dense line by default, full per-model/per-stage breakdown only under `include_details`. Surfaced in MCP `consult_council` ("Cost & Tokens") and as a typed `usage` field on the HTTP `CouncilResponse`. Releases: one version bump per epic, not per PR (git-tag/setuptools-scm; `publish.yml` triggers on tag only).
+
 Bias (ADR-015/018)
 - `bias_audit.py` (ADR-015) — per-session indicators: length↔score correlation (pure-Python Pearson), reviewer calibration, position bias. **These are anomaly indicators, not statistically robust proof** — with N=4–5 models there are only 4–5 data points (≥30 needed for significance), and a single ordering can't separate position effects from quality.
 - `bias_persistence.py` (ADR-018 P1) — JSONL store, `ConsentLevel` (OFF→RESEARCH). `bias_aggregation.py` (ADR-018 P2-3) — cross-session pooled correlation w/ CIs (Fisher-z), confidence tiers, temporal trends, anomaly flagging. Surfaced via `llm-council bias-report`.

--- a/README.md
+++ b/README.md
@@ -317,7 +317,10 @@ llm-council
 
 ### `consult_council`
 
-Ask the LLM council a question and get synthesized guidance.
+Ask the LLM council a question and get synthesized guidance. Every response
+includes a one-line **Cost & Tokens** summary (total tokens, plus USD cost when
+the provider reports it); pass `include_details=true` for the full
+per-model/per-stage breakdown.
 
 **Arguments:**
 - `query` (string, required): The question to ask the council
@@ -326,7 +329,7 @@ Ask the LLM council a question and get synthesized guidance.
   - `"balanced"`: Mid-tier models (GPT-4o, Sonnet), ~90 seconds - good balance of speed and quality
   - `"high"`: Full council (Opus, GPT-4o), ~180 seconds - comprehensive deliberation
   - `"reasoning"`: Deep thinking models (GPT-5.2, o1, DeepSeek-R1), ~600 seconds - complex reasoning
-- `include_details` (boolean, optional): Include individual model responses and rankings (default: false)
+- `include_details` (boolean, optional): Include individual model responses, rankings, and the full per-model/per-stage **Cost & Tokens** breakdown (default: false)
 - `verdict_type` (string, optional): Type of verdict to render (default: "synthesis")
   - `"synthesis"`: Free-form natural language synthesis
   - `"binary"`: Go/no-go decision (approved/rejected) with confidence score

--- a/docs/adr/ADR-011-cost-tracking.md
+++ b/docs/adr/ADR-011-cost-tracking.md
@@ -1,424 +1,211 @@
-# ADR-011: Cost Tracking and Prediction System
+# ADR-011: Cost and Token Accounting
 
-**Status:** Proposed
-**Date:** 2024-12-12
-**Deciders:** LLM Council
-**Technical Story:** Design comprehensive cost tracking, prediction, and budget controls for the council system
+**Status:** Accepted 2026-07-01
+**Date:** 2026-07-01 (refreshed from Proposed draft 2024-12-12)
+**Decision Makers:** Chris Joseph, LLM Council
+**Related:** ADR-009 (open-core boundary), ADR-024 (L1→L4 layers), ADR-030 (metrics export), ADR-041 (verification telemetry), ADR-022/ADR-026 (tier/model selection), ADR-027 (frontier cost ceiling)
 
-## Context and Problem Statement
+---
 
-The council system uses multiple LLM calls per query (3-10 models × 3 stages), making costs unpredictable. Users need:
+> **Revision note (2026-07-01):** This ADR was drafted in 2024 as a Proposed design and never implemented. It is refreshed here to reflect three developments since: (1) OpenRouter now returns authoritative per-request USD cost inline on every response, (2) OpenTelemetry has standardized GenAI token/cost metric names, and (3) PostHog LLM Analytics is available as a dashboard sink. These collapse most of the original "PricingService" and "cloud dashboard" scope. The layer-ownership model (ADR-024) — absent in the original — is now the organizing principle.
 
-1. **Pre-submission estimates**: Know costs before running a query
-2. **Post-submission breakdowns**: Understand where money went
-3. **Budget controls**: Prevent surprise charges
-4. **Optimization guidance**: Reduce costs without sacrificing quality
+## Context
 
-### Current State
-- Token counts tracked per stage (stage1, stage1.5, stage2, stage3)
-- OpenRouter provides usage: `{prompt_tokens, completion_tokens, total_tokens}`
-- No cost calculation or prediction
-- No budget enforcement
+A council query fans out to 3–10 models across 3 stages, so cost is both significant and hard to predict. Users need: pre-submission estimates, post-submission breakdowns, optional budget controls, and — most importantly as token prices rise — data to **optimize token spend against output quality**.
 
-### Key Challenge: Peer Review Cost Growth
-Stage 2 (peer review) input size grows as O(N × M) where:
-- N = number of models
-- M = average Stage 1 response length
+### Verified current state (2026-07-01)
 
-With 5 models generating 500 tokens each, each reviewer sees ~2500+ input tokens.
+Token accounting is ~80% plumbed but the cheap, high-value pieces are missing:
+
+- **Tokens are captured** at every gateway as `UsageInfo{prompt_tokens, completion_tokens, total_tokens}` (`gateway/types.py:43`) and aggregated **per stage** in `council.py:2071` → returned inside `metadata["usage"]` (`by_stage` + grand `total`, `council.py:2244`).
+- **Tokens are NOT attributed per model** — only per stage. You cannot see which model burned the budget.
+- **Tokens are buried** — they live inside an untyped `metadata: Dict[str, Any]` (`http_server.py:139`), are absent from the OpenAPI schema, and the MCP `consult_council` tool returns latency but no tokens/cost (`mcp_server.py:304`). `VerifyResponse` carries `timing`/`input_metrics` (ADR-041) but no token/cost fields.
+- **USD cost is never computed.** No `tokens × price` exists anywhere. `cost_ceiling.py` only *filters* candidate models; `metadata/scoring.py` only *scores* models for selection. Registry pricing (`models/registry.yaml`, `pricing.prompt`/`pricing.completion` per 1K tokens) sits unused for accounting.
+- **The provider's own cost is discarded** — `openrouter.py:138` extracts `usage` but drops the `cost` field OpenRouter returns.
+
+### The peer-review cost driver
+
+Stage 2 input grows O(N × M) (N models × M avg Stage-1 length): 5 models × ~500 tokens each means every reviewer ingests ~2500+ input tokens. Peer review is typically the largest single cost bucket, which is why per-stage attribution matters.
 
 ## Decision Drivers
 
-* **Accuracy**: Cost predictions should be within 20% of actuals
-* **Reliability**: Never fail a query due to pricing lookup issues
-* **User Safety**: Prevent runaway costs before they happen
-* **Transparency**: Users understand exactly how costs are calculated
-* **Extensibility**: Support future providers beyond OpenRouter
+- **Transparency** — users see exactly how much a query cost and where it went.
+- **Optimization** — expose cost *per unit of quality* so model/tier selection can be tuned.
+- **Accuracy** — prefer provider ground-truth cost over local estimation.
+- **Reliability** — accounting must never fail a query (soft-fail like all telemetry, per ADR-041).
+- **No overloading** — cost is a horizontal concern; it must not become a hidden input to layer decisions (ADR-024 sovereignty).
 
-## Design Questions & Decisions
+## Decision
 
-### 1. Pricing Data Source
+Treat cost/token accounting as a **horizontal observability concern** (like metrics/logging), not a new layer and not an input to routing decisions. It threads through the existing L1→L4 model (ADR-024) at four well-defined points and surfaces at the edges.
 
-**Question:** How to get and cache model pricing data?
+### 1. Cost data source — provider ground-truth first, registry fallback
 
-**Options Considered:**
-| Approach | Pros | Cons |
-|----------|------|------|
-| Hardcoded only | Simple, no dependencies | Stale quickly, maintenance burden |
-| Dynamic API only | Always current | API failures break pricing |
-| **Hybrid (chosen)** | Resilient, current when available | Slightly more complex |
+The original design centered on a `PricingService` that fetches and caches OpenRouter prices. That is now largely unnecessary for **post-query** accounting:
 
-**Decision: Hybrid approach with cached dynamic fetching + hardcoded fallback**
+- **Primary (OpenRouter path):** capture the authoritative cost the provider already returns. Every OpenRouter response now includes `usage.cost` plus `usage.cost_details{upstream_inference_cost, cache_discount}` and `cached_tokens`. This is the exact amount billed — no estimation, and it correctly accounts for prompt caching (a real optimization lever). Extend `UsageInfo` with `cost_usd: float | None` and populate it at `gateway/openrouter.py:311` from the response; drop nothing.
+- **Fallback (direct/Ollama and other gateways that don't return cost, and all pre-query estimation):** compute from the pricing table that already exists in `models/registry.yaml` (`pricing.prompt`/`pricing.completion`, per 1K tokens). No hardcoded dict, no new fetch service — read the registry the metadata layer already loads.
 
-```python
-class PricingService:
-    def __init__(self):
-        self.cache_ttl = 3600  # 1 hour
-        self.fallback_prices = {
-            # Per million tokens
-            "openai/gpt-4o": {"input": 2.50, "output": 10.00},
-            "anthropic/claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
-            "google/gemini-1.5-pro": {"input": 1.25, "output": 5.00},
-        }
-        self._cache = {}
+So `PricingService` shrinks to a thin helper: "use `usage.cost` if the gateway supplied it, else `(prompt·p_in + completion·p_out)/1000` from the registry." Ground-truth where available, deterministic fallback otherwise.
 
-    async def get_price(self, model_id: str) -> dict:
-        if self._is_cache_valid(model_id):
-            return self._cache[model_id]
+**Cost is not OpenRouter-only.** The gateway layer (ADR-023) already routes across four providers, and their cost fidelity differs. A single `CostResolver` at L4 applies the right strategy per gateway and stamps each `UsageInfo` with a `cost_source` so accuracy provenance is explicit — a computed estimate is never presented as a bill:
 
-        try:
-            price = await self._fetch_from_openrouter(model_id)
-            self._update_cache(model_id, price)
-            return price
-        except APIError:
-            return self.fallback_prices.get(model_id)
-```
+| Gateway | Providers | `cost_source` | Basis |
+|---|---|---|---|
+| OpenRouter | 100+ models | `provider` | `usage.cost` (+ `cost_details`, `cached_tokens`) — the billed amount |
+| Requesty | 300+ models | `provider` if returned, else `registry_estimate` | router-reported when present |
+| Direct | Anthropic, OpenAI, Google (native APIs) | `registry_estimate` | `registry.yaml` pricing × tokens (native APIs return tokens only) |
+| Ollama | local models | `local_zero` | self-hosted; no marginal API cost |
 
-**Rationale:**
-- OpenRouter prices change frequently (new models, price drops)
-- API failures shouldn't break cost tracking
-- Cached prices provide sub-millisecond lookups during query execution
-- Fallback ensures graceful degradation
+This is exactly the reconciliation model ADR-023 §5 (`UnifiedCostRecord.pricing_source`) left open; ADR-011 fulfills it. When both a router-reported and a registry-computed figure exist, log the delta to keep the pricing table honest. BYOK subtlety: on OpenRouter, `cost_details.upstream_inference_cost` is populated **only** for BYOK requests — so BYOK users get *more* granular cost detail, worth surfacing. BYOK credential handling itself is unchanged (ADR-023/ADR-013: request-scoped ContextVar → env → keychain → config).
 
-### 2. Token Estimation for Cost Prediction
+### 2. Where accounting attaches in the layer model (ADR-024)
 
-**Question:** How to estimate completion tokens before a query runs?
+| Layer | Responsibility | Concrete change |
+|---|---|---|
+| **L4 Gateway** (capture) | Record `cost_usd` + `cost_source` + `cached_tokens` on the response via the `CostResolver` (§1). **Data only, no decisions.** | Add the three fields to `UsageInfo` (`gateway/types.py:43`); populate per-gateway (ground-truth in `openrouter.py`/`requesty.py`, registry estimate in `direct.py`, zero in `ollama.py`). |
+| **L3 Council** (aggregate) | Sum tokens **and** cost, adding the missing **per-model** dimension alongside per-stage. | Extend `total_usage` (`council.py:2071`) and grand total to carry `cost_usd`; add a `by_model` map. Home for the `CostSummary`/`TokenUsage` DTOs. |
+| **Edges** (surface) | Make it visible to callers. | Typed `usage`/`cost` block on `CouncilResponse` (`http_server.py:139`); token/cost fields in `VerifyResponse.input_metrics` (ADR-041's existing home, `verification/api.py`); a cost section in MCP `consult_council` output. |
+| **Observability** (emit) | Push to metrics backends and dashboards. | Emit via the existing `MetricsAdapter` (ADR-030) using OTel names (below); optionally sink to PostHog LLM Analytics. |
 
-**Options Considered:**
-| Approach | Pros | Cons |
-|----------|------|------|
-| Simple multiplier | Easy | Ignores model/stage variance |
-| Trained ML predictor | Accurate | Complex, data-hungry |
-| **Historical percentiles (chosen)** | Accurate, simple | Needs bootstrap data |
+**Sovereignty guardrail:** L1 (tier) and L2 (triage) must **not** silently read cost to gate or escalate. The only place cost influences control flow is the *explicit, opt-in* budget check in §4, which emits an auditable `LayerEvent`. This preserves ADR-024's "explicit/auditable escalation" and "failure isolation" principles.
 
-**Decision: Model-specific historical percentiles with stage multipliers**
+### 3. Observability — adopt OpenTelemetry GenAI semantic conventions
 
-```python
-class CostPredictor:
-    def __init__(self):
-        # Per (model, stage) completion token statistics
-        self.completion_stats = {
-            "openai/gpt-4o": {
-                "initial_response": {"p50": 450, "p75": 680, "p95": 1200},
-                "peer_review": {"p50": 580, "p75": 850, "p95": 1400},
-                "synthesis": {"p50": 400, "p75": 600, "p95": 1000},
-            },
-            # ... other models
-        }
+Rather than invent metric names, adopt the now-standard OTel GenAI conventions so Datadog/Grafana/PostHog ingest them with zero custom mapping:
 
-    def estimate_query_cost(
-        self,
-        prompt_tokens: int,
-        models: list[str],
-        confidence: str = "p75"  # p50, p75, p95
-    ) -> CostEstimate:
-        """
-        Estimate total cost for a council query.
+- `gen_ai.client.token.usage` — histogram of token counts, tagged `gen_ai.token.type` = `input|output`, `gen_ai.request.model`, and `gen_ai.operation.name` = the council stage.
+- A cost counter/gauge (`llm_council.cost.usd`) tagged by model and stage, until a GenAI-standard cost metric stabilizes (the token conventions are standardized; cost is still emerging).
 
-        Returns low/expected/high range based on historical data.
-        """
-        estimates = []
+These flow through the existing `emit_layer_event()` → `MetricsAdapter` path (`observability/metrics_adapter.py`); `LayerEvent.data` already accepts arbitrary fields, so no structural change is needed. PostHog LLM Analytics (already integrated in tooling) serves as the historical-dashboard sink — this **replaces** the original ADR's "paid cloud tier / PostgreSQL dashboards," which we no longer need to build.
 
-        for stage in ["initial_response", "peer_review", "synthesis"]:
-            stage_models = self._models_for_stage(stage, models)
-            stage_prompt = self._estimate_stage_prompt(stage, prompt_tokens)
+### 4. Budget enforcement — opt-in, tiered, auditable (unchanged in spirit)
 
-            for model in stage_models:
-                completion = self.completion_stats[model][stage][confidence]
-                price = self.pricing.get_price(model)
+Retained from the original design, but explicitly framed as opt-in and auditable:
 
-                cost = (
-                    (stage_prompt * price["input"]) +
-                    (completion * price["output"])
-                ) / 1_000_000
+- Modes: `STRICT` (reject if high estimate exceeds), `BALANCED` (reject if expected exceeds, warn if high exceeds), `PERMISSIVE` (warn only). Default off; when enabled, `BALANCED`.
+- **Never abort mid-completion** (wastes spent tokens); check only between stages and return partial results gracefully — consistent with the verification pipeline's durable-partial-state behavior (ADR-040).
+- Every reject/warn emits a `LayerEvent` so the decision is visible, never a silent tier change.
+- Pre-query estimation uses the percentile predictor (§5), the only place estimation (vs. ground truth) is used.
 
-                estimates.append(StageCostEstimate(stage, model, cost))
+### 5. Pre-query estimation (Phase 2 only)
 
-        total = sum(e.cost for e in estimates)
-        return CostEstimate(
-            low=total * 0.6,      # p25 equivalent
-            expected=total,       # chosen confidence
-            high=total * 1.5,     # p95 buffer
-            breakdown=estimates
-        )
+Post-query needs no estimation — we have actuals (provider cost or registry math). Estimation is only needed *before* a run, for the budget gate and for showing an expected range. Keep the model×stage historical-percentile predictor from the original draft (p50/p75/p95 completion tokens, EMA-updated from actuals), sourcing per-model history from the **performance index** the `performance/` module already persists (ADR-026 P3 / ADR-041). This avoids a second data store.
 
-    def update_stats(self, model: str, stage: str, actual_tokens: int):
-        """Update statistics after each completion (exponential moving average)."""
-        alpha = 0.1
-        current = self.completion_stats[model][stage]["p50"]
-        self.completion_stats[model][stage]["p50"] = (
-            alpha * actual_tokens + (1 - alpha) * current
-        )
-```
+### 6. Optimization: cost-per-quality (the "part b" payoff)
 
-**Rationale:**
-- Different models have different verbosity (Claude verbose, GPT concise)
-- Different stages have different output patterns (reviews longer than synthesis)
-- Percentiles let users choose risk tolerance
-- EMA updates improve accuracy over time without complex ML
+Transparency alone doesn't optimize spend. To optimize token-vs-output we add a **cost dimension to the performance index**: extend `ModelSessionMetric` and `ModelPerformanceIndex` (`performance/types.py`) with `cost_usd`, giving a **Borda-per-dollar** (quality-per-cost) signal per model. That signal then feeds cost-aware model/tier selection in L1/L2 (ADR-022/ADR-026) — the one place cost legitimately enters routing, and only via the explicit, audited selection path, never silently. This is deliberately sequenced last: it depends on Phase 1 data existing.
 
-### 3. Budget Enforcement Strategy
+### 7. Output surfaces — progressive disclosure
 
-**Question:** How to handle spending limits?
+Cost/token data must reach humans and the *calling LLM* without flooding either. The calling model's context window is a scarce resource, so the governing principle is **progressive disclosure**: a single dense summary line by default, full per-model/per-stage breakdown only on request.
 
-**Options Considered:**
-| Approach | Pros | Cons |
-|----------|------|------|
-| Hard reject | Safe | Frustrating UX, estimates uncertain |
-| Warn only | User-friendly | Can exceed budget |
-| Abort mid-query | Real-time control | Wastes spent tokens |
-| **Tiered (chosen)** | Flexible, safe | More complex |
+| Surface | Consumer | Default (always) | On request | Notes |
+|---|---|---|---|---|
+| MCP `consult_council` | Claude Code / Cursor chat | One line: `~8.5k tokens · ~$0.021 · high tier` | Per-model + per-stage table behind existing `include_details=true` | **Prerequisite:** `run_council_with_fallback()` does not currently aggregate usage into `metadata` (unlike `run_full_council()`); fix first, else MCP has no token data at all |
+| MCP `verify` / CLI `gate` | LLM chat + CI | One row in the metrics table | `### Cost & Tokens` section | Single change in `verification/formatting.py:format_verification_result()` serves both |
+| HTTP council endpoint | SDK / programmatic | Typed `usage` block always present | — | Promote `metadata["usage"]` from `Dict[str, Any]` to a documented Pydantic model so OpenAPI + generated clients expose it |
+| HTTP stream (SSE) | live UIs | incremental usage per `stage.complete` event | — | enables a live cost ticker |
+| CLI `cost-report` (new) | human analyst | compact summary | `--verbose`, `--days`, `--min-cost`, `--format text\|json\|csv` | Clones the `bias-report` framework (`bias_aggregation.py` text/JSON/CSV + ASCII bars) reading the same performance-index store |
 
-**Decision: Tiered enforcement with configurable strictness**
+Two distinct consumption modes: **per-query transparency** (inline summary, rendered in the chat/response) and **cross-session reporting** (the `cost-report` CLI). They share DTOs but not surfaces.
+
+### 8. Tooling integration — one emitter, example templates
+
+The observability metrics (§3) double as the integration point for external LLM-cost tooling. **Build one vendor-neutral OTLP exporter, not N per-vendor adapters.**
+
+- **Single OTLP `gen_ai.*` exporter.** Because the metric names follow OTel GenAI conventions, one exporter feeds PostHog, Datadog, Grafana, Langfuse, Honeycomb, and Traceloop with zero per-vendor mapping.
+- **PostHog LLM Analytics** (the primary named target) accepts this two ways: (a) native `$ai_generation` events — PostHog auto-computes cost at ingestion from `$ai_provider` + `$ai_model` + token counts, using **OpenRouter pricing as its primary source** (the same reference this ADR uses, so figures reconcile across the stack); or (b) OTLP `gen_ai.*` spans over its OTLP endpoint (Bearer-token auth), auto-converted to `$ai_generation`. Where we hold provider ground-truth (OpenRouter path), we send precalculated cost props (`$ai_input_cost_usd`, …) which PostHog uses verbatim; for `registry_estimate` sources we send tokens + model + provider and let PostHog compute, or send `$ai_*_token_price` custom pricing for exotic/BYOK models.
+- **Deployable examples.** The repo ships no observability templates today (single-service `docker-compose.yml`, no Grafana/Prometheus assets). Add `examples/observability/`: a compose overlay wiring an OTel Collector → PostHog **and** Prometheus/Grafana; one Grafana dashboard JSON (cost/tokens by model/stage/tier, plus cost-per-quality once Phase 3 lands); and a PostHog config snippet. "Top N" resolves to three sinks — PostHog, Prometheus/Grafana, generic OTLP — covered by the one emitter.
+- **BYO-backend boundary.** We emit standards-compliant signals; we do not bundle a datastore or hosted dashboard. Consistent with the open-core boundary (ADR-009).
+
+## Response schema
 
 ```python
-class BudgetEnforcer:
-    class Mode(Enum):
-        STRICT = "strict"      # Reject if p75 estimate exceeds
-        BALANCED = "balanced"  # Reject if p50 exceeds, warn if p75 exceeds
-        PERMISSIVE = "permissive"  # Warn only, never reject upfront
-
-    def pre_query_check(
-        self,
-        estimate: CostEstimate,
-        budget_remaining: float,
-        mode: Mode = Mode.BALANCED
-    ) -> BudgetDecision:
-        if mode == Mode.STRICT:
-            if estimate.high > budget_remaining:
-                return BudgetDecision.REJECT, self._suggest_cheaper(estimate)
-
-        elif mode == Mode.BALANCED:
-            if estimate.expected > budget_remaining:
-                return BudgetDecision.REJECT, "Likely to exceed budget"
-            elif estimate.high > budget_remaining:
-                return BudgetDecision.WARN, f"May exceed (${estimate.expected:.2f} expected, up to ${estimate.high:.2f})"
-
-        elif mode == Mode.PERMISSIVE:
-            if estimate.expected > budget_remaining:
-                return BudgetDecision.WARN, "Likely to exceed budget"
-
-        return BudgetDecision.ALLOW, None
-
-    def mid_query_check(
-        self,
-        spent_so_far: float,
-        remaining_stages: list[str],
-        budget_remaining: float
-    ) -> BudgetDecision:
-        """Check between stages - abort gracefully if over budget."""
-        if spent_so_far > budget_remaining:
-            return BudgetDecision.ABORT_GRACEFULLY, "Budget exceeded. Returning partial results."
-        return BudgetDecision.CONTINUE, None
-```
-
-**Critical UX considerations:**
-- **Never abort mid-completion**: Wastes tokens, creates broken responses
-- **Check between stages**: Can return partial results gracefully
-- **Suggest alternatives**: "Removing GPT-4 reduces estimate to $0.28"
-
-### 4. Cost Attribution in Peer Review
-
-**Question:** In Stage 2, each model reviews all others. How to attribute costs?
-
-**Options Considered:**
-| Approach | Pros | Cons |
-|----------|------|------|
-| Split among reviewed | Intuitive | Masks reviewer verbosity |
-| **Reviewer only (chosen)** | Actionable, causal | Less intuitive |
-| Both views | Complete | Complex |
-
-**Decision: Primary attribution to reviewer, with cross-reference tagging**
-
-```python
-@dataclass
-class CostAttribution:
-    stage: str
-    model: str
-    tokens_in: int
-    tokens_out: int
-    cost: float
-    reviewing_models: list[str] | None = None  # For peer review stage
-
-    @property
-    def cost_per_review_target(self) -> float | None:
-        """Secondary view: split cost among reviewed responses."""
-        if self.reviewing_models:
-            return self.cost / len(self.reviewing_models)
-        return None
-```
-
-**Rationale:**
-- **Causality**: The reviewer's verbosity determines cost
-- **Actionability**: "Claude's reviews cost 2x GPT's" → adjust reviewer selection
-- **Simplicity**: Primary attribution is straightforward
-- **Flexibility**: Can still compute "cost to be reviewed" analytically
-
-**Example output:**
-```json
-{
-  "model_costs": {
-    "openai/gpt-4o": {
-      "direct_cost": 0.0234,
-      "cost_as_review_target": 0.0156,
-      "breakdown": {
-        "initial_response": 0.0089,
-        "peer_review": 0.0102,
-        "synthesis": 0.0043
-      }
-    }
-  },
-  "stage_costs": {
-    "initial_response": 0.0312,
-    "peer_review": 0.0847,
-    "synthesis": 0.0098
-  }
-}
-```
-
-### 5. Where Cost Tracking Lives
-
-**Question:** Core library, optional module, or cloud-only?
-
-**Decision: Core library with pluggable interfaces**
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                     OPEN SOURCE CORE                            │
-├─────────────────────────────────────────────────────────────────┤
-│  llm_council/                                                   │
-│  └── cost_tracking/                                             │
-│      ├── __init__.py                                            │
-│      ├── types.py          # CostEstimate, Attribution DTOs     │
-│      ├── calculator.py     # Pure token→cost math               │
-│      ├── predictor.py      # Estimation algorithms              │
-│      ├── enforcer.py       # Budget enforcement                 │
-│      └── interfaces.py     # Abstract PricingProvider           │
-│                                                                 │
-│  llm_council/cost_tracking/backends/                            │
-│  ├── memory_storage.py     # In-memory (default)                │
-│  ├── sqlite_storage.py     # Local persistence                  │
-│  └── static_pricing.py     # Bundled fallback prices            │
-└─────────────────────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────────┐
-│                    PAID CLOUD TIER                              │
-├─────────────────────────────────────────────────────────────────┤
-│  • PostgreSQL storage backend                                   │
-│  • Real-time OpenRouter pricing sync                            │
-│  • Cross-organization prediction models                         │
-│  • Budget alerts, dashboards, admin controls                    │
-│  • Cost anomaly detection                                       │
-│  • Multi-tenant quotas (org/team/user)                          │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Feature Matrix:**
-| Feature | Open Source | Cloud |
-|---------|-------------|-------|
-| Per-query cost calculation | Yes | Yes |
-| Cost estimation (local history) | Yes | Yes (global models) |
-| Budget warnings | Yes | Yes |
-| Budget enforcement | Yes (local) | Yes (org-wide) |
-| Historical dashboards | No | Yes |
-| Cross-user prediction models | No | Yes |
-| Cost anomaly alerts | No | Yes |
-
-**Rationale:**
-- **Safety default**: OSS users need visibility into spend
-- **Transparency**: Users can see exactly how costs are calculated
-- **Extensibility**: Cloud tier adds value without restricting core functionality
-- **Community contribution**: Open cost logic means community can improve it
-
-## Implementation
-
-### API Integration
-
-```python
-# In run_full_council()
-async def run_full_council(
-    user_query: str,
-    cost_tracker: CostTracker | None = None,
-    budget_limit: float | None = None,
-) -> CouncilResult:
-    cost_tracker = cost_tracker or DefaultCostTracker()
-
-    # Pre-flight cost estimation
-    estimate = cost_tracker.estimate(user_query, COUNCIL_MODELS)
-
-    # Budget check
-    if budget_limit:
-        decision, msg = cost_tracker.enforcer.pre_query_check(
-            estimate, budget_limit
-        )
-        if decision == BudgetDecision.REJECT:
-            raise BudgetExceededError(msg, estimate=estimate)
-
-    # ... run stages, tracking actual costs ...
-
-    return CouncilResult(
-        answer=synthesis,
-        cost_summary=cost_tracker.get_summary()
-    )
-```
-
-### Configuration
-
-```python
-# config.py additions
-DEFAULT_BUDGET_MODE = "balanced"  # strict, balanced, permissive
-DEFAULT_COST_TRACKING = True
-DEFAULT_PRICING_CACHE_TTL = 3600  # seconds
-```
-
-### Response Schema
-
-```python
-@dataclass
-class CostSummary:
-    total_cost: float
-    currency: str = "USD"
-    by_stage: dict[str, float]
-    by_model: dict[str, float]
-    estimate_accuracy: float  # actual / estimated
-    tokens: TokenUsage
-
 @dataclass
 class TokenUsage:
     prompt_tokens: int
     completion_tokens: int
     total_tokens: int
+    cached_tokens: int = 0            # from provider, when available
     by_stage: dict[str, dict]
+    by_model: dict[str, dict]         # NEW: fills the per-model gap
+
+@dataclass
+class CostSummary:
+    total_cost_usd: float
+    currency: str = "USD"
+    cost_source: str                  # "provider" | "registry_estimate" | "local_zero" | "mixed"
+    by_stage: dict[str, float]
+    by_model: dict[str, dict]         # reviewer-primary attribution; each carries its own cost + cost_source
+    tokens: TokenUsage
+    estimate_accuracy: float | None = None   # actual/estimated, when a pre-query estimate existed
 ```
+
+**Attribution:** primary cost is attributed to the **reviewer** in Stage 2 (the reviewer's verbosity causes the cost; actionable as "Claude's reviews cost 2× GPT's"), with a secondary analytic view splitting cost across reviewed responses. Unchanged from the original decision.
+
+## Where it lives (open-core)
+
+A slim `llm_council/cost_tracking/` module in the OSS core:
+
+```
+cost_tracking/
+├── types.py         # TokenUsage, CostSummary DTOs
+├── calculator.py    # provider-cost passthrough + registry fallback math
+├── predictor.py     # pre-query percentile estimation (Phase 2)
+└── enforcer.py      # opt-in tiered budget checks (Phase 4)
+```
+
+Pricing fallback data is the existing `models/registry.yaml` — no new bundled price list. Dashboards are PostHog LLM Analytics — no bundled storage backend. Everything cost-related is fully functional offline (registry fallback), consistent with the Sovereign Orchestrator principle (ADR-026).
 
 ## Consequences
 
-### Positive
-- Users can predict costs before running queries
-- Budget controls prevent surprise charges
-- Cost breakdowns enable optimization
-- OSS users get full cost visibility
+**Positive**
+- Full spend transparency for OSS users; provider ground-truth is more accurate than any local estimate and captures cache savings.
+- Per-model + per-stage attribution enables real optimization, not just a total.
+- OTel-standard naming means dashboards work out of the box; PostHog gives history for free.
+- Minimal new surface area — extends existing structures (`UsageInfo`, `total_usage`, `input_metrics`, `MetricsAdapter`, performance index) rather than adding a parallel system.
 
-### Negative
-- Adds complexity to core library
-- Pricing data maintenance required
-- Estimates are inherently uncertain
+**Negative / risks**
+- Registry fallback prices go stale (mitigated: OpenRouter path uses ground truth; registry only covers non-OpenRouter gateways and estimates).
+- OTel GenAI cost metrics are still stabilizing (mitigated: token metrics are standardized; we namespace our cost metric until a standard lands).
+- Per-model attribution requires threading model identity through Stage-2 aggregation, which today only sums per stage.
 
-### Risks
-- **Stale prices**: Mitigated by dynamic fetching + short TTL
-- **Inaccurate estimates**: Mitigated by percentile ranges
-- **Budget too strict**: Mitigated by configurable modes
+## Migration path
 
-## Migration Path
+1. **Phase 1 — Transparency (post-query):** capture provider `cost_usd` at L4; add per-model aggregation at L3; surface typed token/cost blocks in HTTP, MCP, and `VerifyResponse`. Highest leverage, smallest change.
+2. **Phase 2 — Observability:** emit OTel-named token/cost metrics via `MetricsAdapter`; route to StatsD/Prometheus/PostHog.
+3. **Phase 3 — Optimization:** cost dimension in the performance index → cost-per-quality → cost-aware selection (ADR-022/026).
+4. **Phase 4 — Enforcement (opt-in):** pre-query estimation + tiered `BudgetEnforcer` + budget `LayerEvent`s.
 
-1. **Phase 1**: Add cost calculation (post-query only)
-2. **Phase 2**: Add cost estimation (pre-query)
-3. **Phase 3**: Add budget warnings
-4. **Phase 4**: Add budget enforcement (opt-in)
-5. **Phase 5**: Add cost dashboards in cloud tier
+## Definition of Done
+
+This feature adds cross-cutting surface area (config, gateway fields, output rendering, external tooling), so **no phase is "done" on code + tests alone.** Each phase's DoD includes the documentation and LLM-facing text that keep the feature discoverable and context-safe:
+
+1. **Code + tests** — unit tests for the `CostResolver` per gateway (provider / registry_estimate / local_zero), aggregation correctness (per-stage **and** per-model), and soft-fail behavior (accounting errors never propagate to results, per ADR-041).
+2. **User documentation** — update `CLAUDE.md` (env-var index + module map + the L4→L3→edge cost path), the README/docs site (what cost data appears where, the new `cost-report` CLI, `examples/observability/` templates), and `CHANGELOG.md`. Document `cost_source` semantics so users know when a number is billed vs estimated.
+3. **LLM-facing support text (context management)** — this is a first-class deliverable, not an afterthought. Update:
+   - **MCP tool descriptions/instructions** (`consult_council`, `verify`) so calling models know the cost/token fields exist, that a compact summary is returned by default, and that the full breakdown is available via `include_details` — instructing them **not** to request or echo the full breakdown unless the user asks. This encodes progressive disclosure at the protocol boundary so it protects the caller's context window by default.
+   - **Bundled skills** (`skills/` — council-verify, council-review, council-gate) to describe the cost summary and how to surface it succinctly.
+   - **HTTP OpenAPI** field descriptions on the typed `usage`/`CostSummary` model.
+4. **Deployable examples** — `examples/observability/` (compose overlay + Grafana JSON + PostHog snippet) present and referenced from the docs.
+5. **Config surface** — new keys documented in `unified_config.py` schema and the env-var index, defaults called out (accounting on, enforcement off).
+
+**Progressive-disclosure invariant:** the default output of any human/LLM-facing surface is the one-line summary; the verbose breakdown is always gated behind an explicit flag/parameter. A phase that renders full per-model detail by default fails DoD.
+
+## Compliance / Validation
+
+- No cost read occurs in L1/L2 decision code except the explicit `BudgetEnforcer` call (grep-able invariant).
+- Accounting failures are caught and never propagate to verification/council results (mirrors ADR-041's try/except telemetry wiring).
+- Token/cost metric names conform to OTel GenAI semantic conventions.
 
 ## References
 
 - [ADR-009: HTTP API and Open Core Boundary](./ADR-009-http-api-open-core-boundary.md)
-- [OpenRouter Pricing API](https://openrouter.ai/docs#models)
-- [Token Estimation Best Practices](https://platform.openai.com/tokenizer)
+- [ADR-024: Unified Routing Architecture (L1→L4)](./ADR-024-unified-routing-architecture.md)
+- [ADR-030: Scoring Refinements / Metrics Export](./ADR-030-scoring-refinements.md)
+- [ADR-041: Verification Telemetry Wiring](./ADR-041-verification-telemetry-wiring.md)
+- [ADR-023: Multi-Router Gateway Support](./ADR-023-multi-router-gateway-support.md) — provider/BYOK layer; cost-reconciliation gap this ADR closes
+- [OpenRouter Usage Accounting](https://openrouter.ai/docs/cookbook/administration/usage-accounting)
+- [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/)
+- [PostHog LLM Analytics — Calculating costs](https://posthog.com/docs/llm-analytics/calculating-costs) and [OpenTelemetry ingestion](https://posthog.com/docs/ai-observability/installation/opentelemetry)

--- a/docs/adr/ADR-023-multi-router-gateway-support.md
+++ b/docs/adr/ADR-023-multi-router-gateway-support.md
@@ -866,6 +866,8 @@ class UnifiedCostRecord:
 
 **Key insight**: Prefer router-reported costs when available, fall back to calculated costs using a maintained pricing table, always record both for reconciliation.
 
+> **Amendment (2026-07-01):** This cost-tracking gap is now addressed by [ADR-011: Cost and Token Accounting](./ADR-011-cost-tracking.md). ADR-011 realizes the reconciliation model described here: a per-gateway `CostResolver` at L4 stamps each `UsageInfo` with `cost_usd` and a `cost_source` (`provider` | `registry_estimate` | `local_zero`) — the same intent as `UnifiedCostRecord.pricing_source` above. OpenRouter and Requesty supply router-reported ground truth (`usage.cost`); Direct-API providers (Anthropic/OpenAI/Google) fall back to the `models/registry.yaml` pricing table; Ollama is local-zero. Where both a router-reported and a calculated figure exist, ADR-011 logs the delta to tune the pricing table. No changes to this ADR's gateway or BYOK design are required — the resolver sits on top of the existing L4 contracts.
+
 ---
 
 ### Critical Risks Identified (Question 6)

--- a/src/llm_council/cost_summary.py
+++ b/src/llm_council/cost_summary.py
@@ -1,0 +1,72 @@
+"""Human/LLM-facing cost + token summary formatting (ADR-011 Phase 1).
+
+Progressive disclosure: ``format_cost_summary`` returns a single dense line by
+default (safe for a calling LLM's context window) and the full per-model /
+per-stage breakdown only when ``include_details=True``. It consumes the
+``metadata["usage"]`` structure produced by ``council._build_usage_summary``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def _fmt_tokens(n: int) -> str:
+    return f"{n / 1000:.1f}k" if n >= 1000 else str(n)
+
+
+def _fmt_cost(cost: float) -> str:
+    return f"${cost:.4f}"
+
+
+def format_cost_summary(
+    usage: Optional[Dict[str, Any]], *, include_details: bool = False
+) -> str:
+    """Format a usage block for display.
+
+    Returns an empty string when there is no usage data. The default (one-line)
+    form is what surfaces in a chat by default; the full breakdown is gated
+    behind ``include_details`` so it never floods the caller's context.
+    """
+    if not usage:
+        return ""
+
+    total = usage.get("total", {})
+    total_tokens = total.get("total_tokens", 0)
+    cost = total.get("cost_usd", 0.0) or 0.0
+
+    line = f"Council usage: ~{_fmt_tokens(total_tokens)} tokens"
+    if cost:
+        line += f" · ~{_fmt_cost(cost)}"
+    cached = total.get("cached_tokens", 0)
+    if cached:
+        line += f" · {_fmt_tokens(cached)} cached"
+
+    if not include_details:
+        return line
+
+    lines = [line]
+    by_model = usage.get("by_model", {})
+    if by_model:
+        lines += ["", "**By model:**"]
+        for model, mu in by_model.items():
+            entry = f"- {model}: {mu.get('total_tokens', 0)} tok"
+            mc = mu.get("cost_usd", 0.0) or 0.0
+            if mc:
+                entry += f", {_fmt_cost(mc)}"
+            lines.append(entry)
+
+    by_stage = usage.get("by_stage", {})
+    if by_stage:
+        lines += ["", "**By stage:**"]
+        for stage, su in by_stage.items():
+            tok = su.get("total_tokens", 0)
+            if not tok:
+                continue
+            entry = f"- {stage}: {tok} tok"
+            sc = su.get("cost_usd", 0.0) or 0.0
+            if sc:
+                entry += f", {_fmt_cost(sc)}"
+            lines.append(entry)
+
+    return "\n".join(lines)

--- a/src/llm_council/cost_summary.py
+++ b/src/llm_council/cost_summary.py
@@ -34,9 +34,13 @@ def format_cost_summary(
     total = usage.get("total") or {}
     total_tokens = total.get("total_tokens", 0)
     cost = total.get("cost_usd", 0.0) or 0.0
+    # Distinguish a genuine, reported $0 (free/local models) from unknown cost:
+    # show the figure when a cost was actually reported OR is positive; omit it
+    # only when cost is truly unknown.
+    cost_known = bool(total.get("cost_known", False)) or cost > 0
 
     line = f"Council usage: ~{_fmt_tokens(total_tokens)} tokens"
-    if cost:
+    if cost_known:
         line += f" · ~{_fmt_cost(cost)}"
     cached = total.get("cached_tokens", 0)
     if cached:

--- a/src/llm_council/cost_summary.py
+++ b/src/llm_council/cost_summary.py
@@ -21,6 +21,10 @@ def _fmt_tokens(n: object) -> str:
 
 
 def _fmt_cost(cost: float) -> str:
+    # Costs are resolved to 8dp; a flat 4dp display would mask sub-cent costs
+    # (cheap models) as $0.0000. Widen precision for small positive amounts.
+    if 0 < cost < 0.001:
+        return f"${cost:.6f}"
     return f"${cost:.4f}"
 
 
@@ -72,11 +76,14 @@ def format_cost_summary(
         lines += ["", "**By stage:**"]
         for stage, su in by_stage.items():
             tok = su.get("total_tokens", 0)
-            if not tok:
+            sc = su.get("cost_usd", 0.0) or 0.0
+            stage_cost_known = bool(su.get("cost_known", False)) or sc > 0
+            # Skip only truly empty rows — keep a row that carries cost metadata
+            # even if its token count is zero.
+            if not tok and not stage_cost_known:
                 continue
             entry = f"- {stage}: {_fmt_tokens(tok)} tok"
-            sc = su.get("cost_usd", 0.0) or 0.0
-            if bool(su.get("cost_known", False)) or sc > 0:
+            if stage_cost_known:
                 entry += f", {_fmt_cost(sc)}"
             lines.append(entry)
 

--- a/src/llm_council/cost_summary.py
+++ b/src/llm_council/cost_summary.py
@@ -56,7 +56,9 @@ def format_cost_summary(
         for model, mu in by_model.items():
             entry = f"- {model}: {mu.get('total_tokens', 0)} tok"
             mc = mu.get("cost_usd", 0.0) or 0.0
-            if mc:
+            # Consistent with the one-liner: show the figure (incl. a genuine
+            # $0) when cost is known; omit only when cost is unknown.
+            if cost_known or mc > 0:
                 entry += f", {_fmt_cost(mc)}"
             lines.append(entry)
 
@@ -69,7 +71,7 @@ def format_cost_summary(
                 continue
             entry = f"- {stage}: {tok} tok"
             sc = su.get("cost_usd", 0.0) or 0.0
-            if sc:
+            if cost_known or sc > 0:
                 entry += f", {_fmt_cost(sc)}"
             lines.append(entry)
 

--- a/src/llm_council/cost_summary.py
+++ b/src/llm_council/cost_summary.py
@@ -11,8 +11,13 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 
 
-def _fmt_tokens(n: int) -> str:
-    return f"{n / 1000:.1f}k" if n >= 1000 else str(n)
+def _fmt_tokens(n: object) -> str:
+    try:
+        count = int(n)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return "0"
+    count = max(count, 0)
+    return f"{count / 1000:.1f}k" if count >= 1000 else str(count)
 
 
 def _fmt_cost(cost: float) -> str:
@@ -54,11 +59,11 @@ def format_cost_summary(
     if by_model:
         lines += ["", "**By model:**"]
         for model, mu in by_model.items():
-            entry = f"- {model}: {mu.get('total_tokens', 0)} tok"
+            entry = f"- {model}: {_fmt_tokens(mu.get('total_tokens', 0))} tok"
             mc = mu.get("cost_usd", 0.0) or 0.0
-            # Consistent with the one-liner: show the figure (incl. a genuine
-            # $0) when cost is known; omit only when cost is unknown.
-            if cost_known or mc > 0:
+            # Use THIS row's own provenance (not the aggregate): show the figure
+            # (incl. a genuine $0) only when this row's cost is known.
+            if bool(mu.get("cost_known", False)) or mc > 0:
                 entry += f", {_fmt_cost(mc)}"
             lines.append(entry)
 
@@ -69,9 +74,9 @@ def format_cost_summary(
             tok = su.get("total_tokens", 0)
             if not tok:
                 continue
-            entry = f"- {stage}: {tok} tok"
+            entry = f"- {stage}: {_fmt_tokens(tok)} tok"
             sc = su.get("cost_usd", 0.0) or 0.0
-            if cost_known or sc > 0:
+            if bool(su.get("cost_known", False)) or sc > 0:
                 entry += f", {_fmt_cost(sc)}"
             lines.append(entry)
 

--- a/src/llm_council/cost_summary.py
+++ b/src/llm_council/cost_summary.py
@@ -31,7 +31,7 @@ def format_cost_summary(
     if not usage:
         return ""
 
-    total = usage.get("total", {})
+    total = usage.get("total") or {}
     total_tokens = total.get("total_tokens", 0)
     cost = total.get("cost_usd", 0.0) or 0.0
 
@@ -46,7 +46,7 @@ def format_cost_summary(
         return line
 
     lines = [line]
-    by_model = usage.get("by_model", {})
+    by_model = usage.get("by_model") or {}
     if by_model:
         lines += ["", "**By model:**"]
         for model, mu in by_model.items():
@@ -56,7 +56,7 @@ def format_cost_summary(
                 entry += f", {_fmt_cost(mc)}"
             lines.append(entry)
 
-    by_stage = usage.get("by_stage", {})
+    by_stage = usage.get("by_stage") or {}
     if by_stage:
         lines += ["", "**By stage:**"]
         for stage, su in by_stage.items():

--- a/src/llm_council/council.py
+++ b/src/llm_council/council.py
@@ -294,6 +294,38 @@ def _add_cost_to_usage(
         bucket["cached_tokens"] += cached
 
 
+def _build_usage_summary(by_stage: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    """ADR-011: assemble the ``metadata["usage"]`` block from per-stage buckets.
+
+    Produces ``{"by_stage", "by_model", "total"}`` where ``total`` sums tokens +
+    cost + cached across stages and ``by_model`` merges per-model spend. Shared
+    by both council entry points so the HTTP and MCP paths report identically.
+    """
+    grand_total = {
+        "prompt_tokens": sum(s.get("prompt_tokens", 0) for s in by_stage.values()),
+        "completion_tokens": sum(s.get("completion_tokens", 0) for s in by_stage.values()),
+        "total_tokens": sum(s.get("total_tokens", 0) for s in by_stage.values()),
+        "cost_usd": sum(s.get("cost_usd", 0.0) for s in by_stage.values()),
+        "cached_tokens": sum(s.get("cached_tokens", 0) for s in by_stage.values()),
+    }
+    by_model: Dict[str, Dict[str, Any]] = {}
+    for stage_usage in by_stage.values():
+        for model_id, model_usage in stage_usage.get("by_model", {}).items():
+            agg = by_model.setdefault(
+                model_id,
+                {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                    "cost_usd": 0.0,
+                    "cached_tokens": 0,
+                },
+            )
+            for key in agg:
+                agg[key] += model_usage.get(key, 0)
+    return {"by_stage": by_stage, "by_model": by_model, "total": grand_total}
+
+
 async def stage1_collect_responses(user_query: str) -> Tuple[List[Dict[str, Any]], Dict[str, int]]:
     """
     Stage 1: Collect individual responses from all council models.
@@ -795,6 +827,18 @@ async def run_council_with_fallback(
         result["metadata"]["verdict_type"] = verdict_type.value
         result["metadata"]["effective_verdict_type"] = effective_verdict_type.value
         result["metadata"]["deadlock_detected"] = deadlock_detected
+
+        # ADR-011: aggregate usage into metadata so the MCP path reports cost +
+        # tokens (previously absent on this fallback path — parity with
+        # run_full_council).
+        result["metadata"]["usage"] = _build_usage_summary(
+            {
+                "stage1": stage1_usage,
+                "stage1_5": stage1_5_usage,
+                "stage2": stage2_usage,
+                "stage3": stage3_usage,
+            }
+        )
 
         # ADR-025b: Add verdict result for BINARY/TIE_BREAKER modes
         if verdict_result is not None:
@@ -2237,31 +2281,8 @@ async def run_full_council(
         if dissent_text and verdict_result is not None:
             verdict_result.dissent = dissent_text
 
-    # Calculate grand total
-    grand_total = {
-        "prompt_tokens": sum(s["prompt_tokens"] for s in total_usage.values()),
-        "completion_tokens": sum(s["completion_tokens"] for s in total_usage.values()),
-        "total_tokens": sum(s["total_tokens"] for s in total_usage.values()),
-        # ADR-011: cost + cache totals (0 when no provider cost was reported).
-        "cost_usd": sum(s.get("cost_usd", 0.0) for s in total_usage.values()),
-        "cached_tokens": sum(s.get("cached_tokens", 0) for s in total_usage.values()),
-    }
-    # ADR-011: merge per-model spend across stages (reviewer-primary attribution).
-    by_model: Dict[str, Dict[str, Any]] = {}
-    for stage_usage in total_usage.values():
-        for m, mu in stage_usage.get("by_model", {}).items():
-            agg = by_model.setdefault(
-                m,
-                {
-                    "prompt_tokens": 0,
-                    "completion_tokens": 0,
-                    "total_tokens": 0,
-                    "cost_usd": 0.0,
-                    "cached_tokens": 0,
-                },
-            )
-            for key in agg:
-                agg[key] += mu.get(key, 0)
+    # ADR-011: assemble the usage summary (tokens + cost + per-model).
+    usage_summary = _build_usage_summary(total_usage)
 
     # Collect abstention info and score/rank mismatches from Stage 2
     abstentions = []
@@ -2297,7 +2318,7 @@ async def run_full_council(
             "deadlock_detected": deadlock_detected,  # ADR-025b: True if escalated to TIE_BREAKER
             "include_dissent": include_dissent,  # ADR-025b: Dissent extraction enabled
         },
-        "usage": {"by_stage": total_usage, "by_model": by_model, "total": grand_total},
+        "usage": usage_summary,
     }
 
     # ADR-025b: Add verdict result for BINARY/TIE_BREAKER modes

--- a/src/llm_council/council.py
+++ b/src/llm_council/council.py
@@ -262,6 +262,38 @@ MODEL_STATUS_AUTH_ERROR = STATUS_AUTH_ERROR
 ProgressCallback = Callable[[int, int, str], Awaitable[None]]
 
 
+def _add_cost_to_usage(
+    total_usage: Dict[str, Any], usage: Dict[str, Any], model: Optional[str] = None
+) -> None:
+    """ADR-011: accumulate cost_usd, cached_tokens, and optional per-model spend.
+
+    Additive to the existing token aggregation. ``usage["cost"]`` may be None
+    (provider didn't report it) and is treated as a 0 contribution. When
+    ``model`` is given, the same figures also accumulate under
+    ``total_usage["by_model"][model]`` (reviewer-primary attribution).
+    """
+    cost = usage.get("cost") or 0.0
+    cached = usage.get("cached_tokens", 0) or 0
+    total_usage["cost_usd"] = total_usage.get("cost_usd", 0.0) + cost
+    total_usage["cached_tokens"] = total_usage.get("cached_tokens", 0) + cached
+    if model is not None:
+        bucket = total_usage.setdefault("by_model", {}).setdefault(
+            model,
+            {
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+                "cost_usd": 0.0,
+                "cached_tokens": 0,
+            },
+        )
+        bucket["prompt_tokens"] += usage.get("prompt_tokens", 0)
+        bucket["completion_tokens"] += usage.get("completion_tokens", 0)
+        bucket["total_tokens"] += usage.get("total_tokens", 0)
+        bucket["cost_usd"] += cost
+        bucket["cached_tokens"] += cached
+
+
 async def stage1_collect_responses(user_query: str) -> Tuple[List[Dict[str, Any]], Dict[str, int]]:
     """
     Stage 1: Collect individual responses from all council models.
@@ -289,6 +321,7 @@ async def stage1_collect_responses(user_query: str) -> Tuple[List[Dict[str, Any]
             total_usage["prompt_tokens"] += usage.get("prompt_tokens", 0)
             total_usage["completion_tokens"] += usage.get("completion_tokens", 0)
             total_usage["total_tokens"] += usage.get("total_tokens", 0)
+            _add_cost_to_usage(total_usage, usage, model=model)
 
     return stage1_results, total_usage
 
@@ -364,6 +397,7 @@ async def stage1_collect_responses_with_status(
             total_usage["prompt_tokens"] += usage.get("prompt_tokens", 0)
             total_usage["completion_tokens"] += usage.get("completion_tokens", 0)
             total_usage["total_tokens"] += usage.get("total_tokens", 0)
+            _add_cost_to_usage(total_usage, usage, model=model)
 
     return stage1_results, total_usage, model_statuses
 
@@ -1074,6 +1108,7 @@ Rewritten text:"""
             total_usage["prompt_tokens"] += usage.get("prompt_tokens", 0)
             total_usage["completion_tokens"] += usage.get("completion_tokens", 0)
             total_usage["total_tokens"] += usage.get("total_tokens", 0)
+            _add_cost_to_usage(total_usage, usage, model=result["model"])
         else:
             # If normalization fails, use original
             normalized_results.append(
@@ -1359,6 +1394,7 @@ Now provide your evaluation and ranking:"""
             total_usage["prompt_tokens"] += usage.get("prompt_tokens", 0)
             total_usage["completion_tokens"] += usage.get("completion_tokens", 0)
             total_usage["total_tokens"] += usage.get("total_tokens", 0)
+            _add_cost_to_usage(total_usage, usage, model=model)
 
     return stage2_results, label_to_model, total_usage
 
@@ -1514,6 +1550,7 @@ STAGE 2 - Peer Rankings:
     total_usage["prompt_tokens"] = usage.get("prompt_tokens", 0)
     total_usage["completion_tokens"] = usage.get("completion_tokens", 0)
     total_usage["total_tokens"] = usage.get("total_tokens", 0)
+    _add_cost_to_usage(total_usage, usage, model=_get_chairman_model())
 
     response_content = response.get("content", "")
 
@@ -2205,7 +2242,26 @@ async def run_full_council(
         "prompt_tokens": sum(s["prompt_tokens"] for s in total_usage.values()),
         "completion_tokens": sum(s["completion_tokens"] for s in total_usage.values()),
         "total_tokens": sum(s["total_tokens"] for s in total_usage.values()),
+        # ADR-011: cost + cache totals (0 when no provider cost was reported).
+        "cost_usd": sum(s.get("cost_usd", 0.0) for s in total_usage.values()),
+        "cached_tokens": sum(s.get("cached_tokens", 0) for s in total_usage.values()),
     }
+    # ADR-011: merge per-model spend across stages (reviewer-primary attribution).
+    by_model: Dict[str, Dict[str, Any]] = {}
+    for stage_usage in total_usage.values():
+        for m, mu in stage_usage.get("by_model", {}).items():
+            agg = by_model.setdefault(
+                m,
+                {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                    "cost_usd": 0.0,
+                    "cached_tokens": 0,
+                },
+            )
+            for key in agg:
+                agg[key] += mu.get(key, 0)
 
     # Collect abstention info and score/rank mismatches from Stage 2
     abstentions = []
@@ -2241,7 +2297,7 @@ async def run_full_council(
             "deadlock_detected": deadlock_detected,  # ADR-025b: True if escalated to TIE_BREAKER
             "include_dissent": include_dissent,  # ADR-025b: Dissent extraction enabled
         },
-        "usage": {"by_stage": total_usage, "total": grand_total},
+        "usage": {"by_stage": total_usage, "by_model": by_model, "total": grand_total},
     }
 
     # ADR-025b: Add verdict result for BINARY/TIE_BREAKER modes

--- a/src/llm_council/council.py
+++ b/src/llm_council/council.py
@@ -272,10 +272,16 @@ def _add_cost_to_usage(
     ``model`` is given, the same figures also accumulate under
     ``total_usage["by_model"][model]`` (reviewer-primary attribution).
     """
-    cost = usage.get("cost") or 0.0
+    raw_cost = usage.get("cost")
+    cost = raw_cost or 0.0
     cached = usage.get("cached_tokens", 0) or 0
     total_usage["cost_usd"] = total_usage.get("cost_usd", 0.0) + cost
     total_usage["cached_tokens"] = total_usage.get("cached_tokens", 0) + cached
+    # Track whether ANY cost was reported so the summary can tell a genuine
+    # $0 (free/local) from unknown cost (None) — a present cost, even 0.0, is
+    # "known".
+    if raw_cost is not None:
+        total_usage["cost_known"] = True
     if model is not None:
         bucket = total_usage.setdefault("by_model", {}).setdefault(
             model,
@@ -307,6 +313,7 @@ def _build_usage_summary(by_stage: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
         "total_tokens": sum(s.get("total_tokens", 0) for s in by_stage.values()),
         "cost_usd": sum(s.get("cost_usd", 0.0) for s in by_stage.values()),
         "cached_tokens": sum(s.get("cached_tokens", 0) for s in by_stage.values()),
+        "cost_known": any(s.get("cost_known", False) for s in by_stage.values()),
     }
     by_model: Dict[str, Dict[str, Any]] = {}
     for stage_usage in by_stage.values():

--- a/src/llm_council/council.py
+++ b/src/llm_council/council.py
@@ -298,6 +298,8 @@ def _add_cost_to_usage(
         bucket["total_tokens"] += usage.get("total_tokens", 0)
         bucket["cost_usd"] += cost
         bucket["cached_tokens"] += cached
+        if raw_cost is not None:
+            bucket["cost_known"] = True
 
 
 def _build_usage_summary(by_stage: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
@@ -315,6 +317,7 @@ def _build_usage_summary(by_stage: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
         "cached_tokens": sum(s.get("cached_tokens", 0) for s in by_stage.values()),
         "cost_known": any(s.get("cost_known", False) for s in by_stage.values()),
     }
+    numeric_keys = ("prompt_tokens", "completion_tokens", "total_tokens", "cost_usd", "cached_tokens")
     by_model: Dict[str, Dict[str, Any]] = {}
     for stage_usage in by_stage.values():
         for model_id, model_usage in stage_usage.get("by_model", {}).items():
@@ -326,10 +329,13 @@ def _build_usage_summary(by_stage: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
                     "total_tokens": 0,
                     "cost_usd": 0.0,
                     "cached_tokens": 0,
+                    "cost_known": False,
                 },
             )
-            for key in agg:
+            for key in numeric_keys:  # never iterate the bool cost_known
                 agg[key] += model_usage.get(key, 0)
+            if model_usage.get("cost_known"):
+                agg["cost_known"] = True
     return {"by_stage": by_stage, "by_model": by_model, "total": grand_total}
 
 

--- a/src/llm_council/gateway/cost_resolver.py
+++ b/src/llm_council/gateway/cost_resolver.py
@@ -18,6 +18,7 @@ without loading the metadata stack. See ADR-011 §1 and ADR-023 §5.
 
 from __future__ import annotations
 
+import math
 from typing import Callable, Dict, Optional, Tuple
 
 from .types import UsageInfo
@@ -68,11 +69,14 @@ class CostResolver:
         """
         if provider_cost_usd is not None:
             try:
-                return float(provider_cost_usd), "provider"
+                cost = float(provider_cost_usd)
             except (TypeError, ValueError):
-                # A malformed provider cost is not ground truth; fall through
-                # to a registry estimate rather than crashing.
-                pass
+                cost = None
+            # Only a finite, non-negative number is valid ground truth; NaN,
+            # infinity, negatives, or malformed values fall through to an
+            # estimate rather than corrupting accounting metrics.
+            if cost is not None and math.isfinite(cost) and cost >= 0:
+                return cost, "provider"
 
         if gateway in _LOCAL_GATEWAYS:
             return 0.0, "local_zero"

--- a/src/llm_council/gateway/cost_resolver.py
+++ b/src/llm_council/gateway/cost_resolver.py
@@ -1,0 +1,90 @@
+"""Per-gateway cost resolution (ADR-011 Phase 1).
+
+Cost fidelity differs by gateway, so a single resolver applies the right
+strategy and stamps a ``cost_source`` provenance tag onto each call — a
+computed estimate is never presented as a bill:
+
+- OpenRouter / Requesty return an authoritative ``usage.cost`` -> "provider"
+- Direct APIs (Anthropic/OpenAI/Google) return tokens only, so cost is
+  estimated from the bundled ``models/registry.yaml`` pricing -> "registry_estimate"
+- Ollama is local/self-hosted -> "local_zero"
+- pricing unknown and no provider figure -> (None, None)
+
+The resolver takes ``pricing_lookup`` by dependency injection (a callable
+``model_id -> {"prompt": float, "completion": float}`` per-1K-token dict, the
+shape returned by ``MetadataProvider.get_pricing``) so it is unit-testable
+without loading the metadata stack. See ADR-011 §1 and ADR-023 §5.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional, Tuple
+
+from .types import UsageInfo
+
+# Gateways that never incur a marginal per-call API cost.
+_LOCAL_GATEWAYS = frozenset({"ollama"})
+
+PricingLookup = Callable[[str], Dict[str, float]]
+
+
+class CostResolver:
+    """Resolve ``(cost_usd, cost_source)`` for a single model call."""
+
+    def __init__(self, pricing_lookup: Optional[PricingLookup] = None) -> None:
+        self._pricing_lookup = pricing_lookup
+
+    def resolve(
+        self,
+        *,
+        gateway: str,
+        model_id: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        provider_cost_usd: Optional[float] = None,
+    ) -> Tuple[Optional[float], Optional[str]]:
+        """Return ``(cost_usd, cost_source)`` for one call.
+
+        Ground truth wins; otherwise fall back to a registry estimate; local
+        gateways are free; anything unpriced resolves to ``(None, None)``.
+        """
+        if provider_cost_usd is not None:
+            return float(provider_cost_usd), "provider"
+
+        if gateway in _LOCAL_GATEWAYS:
+            return 0.0, "local_zero"
+
+        pricing = self._pricing_lookup(model_id) if self._pricing_lookup else {}
+        if pricing and ("prompt" in pricing or "completion" in pricing):
+            price_in = pricing.get("prompt", 0.0)
+            price_out = pricing.get("completion", 0.0)
+            cost = (prompt_tokens / 1000.0) * price_in + (
+                completion_tokens / 1000.0
+            ) * price_out
+            # 8dp: sub-cent per-call costs must not round to zero.
+            return round(cost, 8), "registry_estimate"
+
+        return None, None
+
+    def apply(
+        self,
+        usage: UsageInfo,
+        *,
+        gateway: str,
+        model_id: str,
+        provider_cost_usd: Optional[float] = None,
+        cached_tokens: Optional[int] = None,
+    ) -> UsageInfo:
+        """Populate cost fields on ``usage`` in place and return it."""
+        cost, source = self.resolve(
+            gateway=gateway,
+            model_id=model_id,
+            prompt_tokens=usage.prompt_tokens,
+            completion_tokens=usage.completion_tokens,
+            provider_cost_usd=provider_cost_usd,
+        )
+        usage.cost_usd = cost
+        usage.cost_source = source
+        if cached_tokens is not None:
+            usage.cached_tokens = cached_tokens
+        return usage

--- a/src/llm_council/gateway/cost_resolver.py
+++ b/src/llm_council/gateway/cost_resolver.py
@@ -28,6 +28,21 @@ _LOCAL_GATEWAYS = frozenset({"ollama"})
 PricingLookup = Callable[[str], Dict[str, float]]
 
 
+def registry_pricing_lookup(model_id: str) -> Dict[str, float]:
+    """Default pricing lookup backed by the metadata provider (registry.yaml).
+
+    Returns a ``{"prompt": ..., "completion": ...}`` per-1K-token dict, or an
+    empty dict if pricing is unknown or the provider is unavailable. Imported
+    lazily to avoid a gateway->metadata import cycle; never raises.
+    """
+    try:
+        from ..metadata import get_provider
+
+        return get_provider().get_pricing(model_id) or {}
+    except Exception:
+        return {}
+
+
 class CostResolver:
     """Resolve ``(cost_usd, cost_source)`` for a single model call."""
 

--- a/src/llm_council/gateway/cost_resolver.py
+++ b/src/llm_council/gateway/cost_resolver.py
@@ -19,7 +19,7 @@ without loading the metadata stack. See ADR-011 §1 and ADR-023 §5.
 from __future__ import annotations
 
 import math
-from typing import Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from .types import UsageInfo
 
@@ -27,6 +27,22 @@ from .types import UsageInfo
 _LOCAL_GATEWAYS = frozenset({"ollama"})
 
 PricingLookup = Callable[[str], Dict[str, float]]
+
+
+def _safe_price(value: Any) -> Optional[float]:
+    """Coerce a registry price to a finite, non-negative float, or None.
+
+    Registry entries can be missing, explicitly null, non-numeric, or malformed;
+    none of those must reach the cost arithmetic (a null price would raise a
+    TypeError, a negative/NaN price would corrupt the estimate).
+    """
+    try:
+        price = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(price) or price < 0:
+        return None
+    return price
 
 
 def registry_pricing_lookup(model_id: str) -> Dict[str, float]:
@@ -82,12 +98,16 @@ class CostResolver:
             return 0.0, "local_zero"
 
         pricing = self._pricing_lookup(model_id) if self._pricing_lookup else {}
-        if pricing and ("prompt" in pricing or "completion" in pricing):
-            price_in = pricing.get("prompt", 0.0)
-            price_out = pricing.get("completion", 0.0)
-            cost = (prompt_tokens / 1000.0) * price_in + (
-                completion_tokens / 1000.0
-            ) * price_out
+        price_in = _safe_price(pricing.get("prompt"))
+        price_out = _safe_price(pricing.get("completion"))
+        if price_in is not None or price_out is not None:
+            # Clamp negative token counts; a bad count must not yield a negative
+            # cost. A missing/invalid side of the price contributes 0.
+            prompt = max(prompt_tokens, 0)
+            completion = max(completion_tokens, 0)
+            cost = (prompt / 1000.0) * (price_in or 0.0) + (completion / 1000.0) * (
+                price_out or 0.0
+            )
             # 8dp: sub-cent per-call costs must not round to zero.
             return round(cost, 8), "registry_estimate"
 

--- a/src/llm_council/gateway/cost_resolver.py
+++ b/src/llm_council/gateway/cost_resolver.py
@@ -47,7 +47,10 @@ class CostResolver:
     """Resolve ``(cost_usd, cost_source)`` for a single model call."""
 
     def __init__(self, pricing_lookup: Optional[PricingLookup] = None) -> None:
-        self._pricing_lookup = pricing_lookup
+        # Default to the registry-backed lookup so a bare CostResolver() can
+        # still price Direct-API calls; local gateways short-circuit before it.
+        # Pass an explicit lookup (e.g. in tests) to override.
+        self._pricing_lookup = pricing_lookup or registry_pricing_lookup
 
     def resolve(
         self,
@@ -64,7 +67,12 @@ class CostResolver:
         gateways are free; anything unpriced resolves to ``(None, None)``.
         """
         if provider_cost_usd is not None:
-            return float(provider_cost_usd), "provider"
+            try:
+                return float(provider_cost_usd), "provider"
+            except (TypeError, ValueError):
+                # A malformed provider cost is not ground truth; fall through
+                # to a registry estimate rather than crashing.
+                pass
 
         if gateway in _LOCAL_GATEWAYS:
             return 0.0, "local_zero"

--- a/src/llm_council/gateway/direct.py
+++ b/src/llm_council/gateway/direct.py
@@ -46,6 +46,12 @@ PROVIDER_KEY_ENV_VARS = {
 }
 
 
+# ADR-011: native provider APIs return tokens only -> registry-priced estimate.
+from .cost_resolver import CostResolver, registry_pricing_lookup
+
+_COST_RESOLVER = CostResolver(pricing_lookup=registry_pricing_lookup)
+
+
 class DirectGateway(BaseRouter):
     """Direct API gateway implementing BaseRouter protocol.
 
@@ -553,6 +559,8 @@ class DirectGateway(BaseRouter):
                 completion_tokens=usage_data.get("completion_tokens", 0),
                 total_tokens=usage_data.get("total_tokens", 0),
             )
+            # ADR-011: native provider APIs return tokens only -> registry estimate.
+            _COST_RESOLVER.apply(usage, gateway="direct", model_id=request.model)
 
         return GatewayResponse(
             content=result.get("content", ""),

--- a/src/llm_council/gateway/ollama.py
+++ b/src/llm_council/gateway/ollama.py
@@ -73,6 +73,12 @@ class QualityDegradationNotice:
     model_size_estimate: Optional[str] = None
 
 
+# ADR-011: local models have no marginal API cost, so no pricing lookup.
+from .cost_resolver import CostResolver
+
+_COST_RESOLVER = CostResolver()
+
+
 class OllamaGateway(BaseRouter):
     """Ollama gateway implementing BaseRouter protocol.
 
@@ -436,6 +442,8 @@ class OllamaGateway(BaseRouter):
                 completion_tokens=usage_data.get("completion_tokens", 0),
                 total_tokens=usage_data.get("total_tokens", 0),
             )
+            # ADR-011: local models have no marginal API cost.
+            _COST_RESOLVER.apply(usage, gateway="ollama", model_id=request.model)
 
         return GatewayResponse(
             content=result.get("content", ""),

--- a/src/llm_council/gateway/openrouter.py
+++ b/src/llm_council/gateway/openrouter.py
@@ -185,6 +185,7 @@ class OpenRouterGateway(BaseRouter):
         disable_tools: bool = False,
         max_tokens: Optional[int] = None,
         temperature: Optional[float] = None,
+        reasoning_params: Optional[ReasoningParams] = None,
     ) -> Dict[str, Any]:
         """Send a query to OpenRouter API.
 
@@ -206,20 +207,17 @@ class OpenRouterGateway(BaseRouter):
             "Content-Type": "application/json",
         }
 
-        payload: Dict[str, Any] = {
-            "model": model,
-            "messages": messages,
-        }
-
-        if disable_tools:
-            payload["tools"] = []
-            payload["tool_choice"] = "none"
-
-        if max_tokens is not None:
-            payload["max_tokens"] = max_tokens
-
-        if temperature is not None:
-            payload["temperature"] = temperature
+        # ADR-026: use the shared payload builder so reasoning_params are
+        # propagated (previously dropped on this gateway path) — identical
+        # tool/token/temperature handling to the inline form it replaces.
+        payload = build_openrouter_payload(
+            model=model,
+            messages=messages,
+            reasoning_params=reasoning_params,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            disable_tools=disable_tools,
+        )
 
         start_time = time.time()
 
@@ -272,7 +270,7 @@ class OpenRouterGateway(BaseRouter):
                         "cost": usage.get("cost"),
                         "cached_tokens": (
                             usage.get("cached_tokens")
-                            or usage.get("prompt_tokens_details", {}).get(
+                            or (usage.get("prompt_tokens_details") or {}).get(
                                 "cached_tokens", 0
                             )
                             or 0
@@ -318,6 +316,7 @@ class OpenRouterGateway(BaseRouter):
             timeout=timeout,
             max_tokens=request.max_tokens,
             temperature=request.temperature,
+            reasoning_params=request.reasoning_params,
         )
 
         # Convert to GatewayResponse

--- a/src/llm_council/gateway/openrouter.py
+++ b/src/llm_council/gateway/openrouter.py
@@ -16,6 +16,12 @@ import httpx
 # ADR-032: Migrated to unified_config
 from llm_council.unified_config import get_api_key
 
+# ADR-011: per-gateway cost resolution. OpenRouter returns authoritative cost,
+# so no pricing lookup is needed here (provider path).
+from .cost_resolver import CostResolver
+
+_COST_RESOLVER = CostResolver()
+
 # Default constants
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
 
@@ -261,6 +267,16 @@ class OpenRouterGateway(BaseRouter):
                         "prompt_tokens": usage.get("prompt_tokens", 0),
                         "completion_tokens": usage.get("completion_tokens", 0),
                         "total_tokens": usage.get("total_tokens", 0),
+                        # ADR-011: OpenRouter returns the authoritative billed
+                        # cost inline; capture it (previously discarded).
+                        "cost": usage.get("cost"),
+                        "cached_tokens": (
+                            usage.get("cached_tokens")
+                            or usage.get("prompt_tokens_details", {}).get(
+                                "cached_tokens", 0
+                            )
+                            or 0
+                        ),
                     },
                 }
 
@@ -312,6 +328,14 @@ class OpenRouterGateway(BaseRouter):
                 prompt_tokens=usage_data.get("prompt_tokens", 0),
                 completion_tokens=usage_data.get("completion_tokens", 0),
                 total_tokens=usage_data.get("total_tokens", 0),
+            )
+            # ADR-011: stamp cost_usd + cost_source (provider ground-truth).
+            _COST_RESOLVER.apply(
+                usage,
+                gateway="openrouter",
+                model_id=request.model,
+                provider_cost_usd=usage_data.get("cost"),
+                cached_tokens=usage_data.get("cached_tokens"),
             )
 
         return GatewayResponse(

--- a/src/llm_council/gateway/requesty.py
+++ b/src/llm_council/gateway/requesty.py
@@ -34,6 +34,12 @@ from .types import (
 REQUESTY_API_URL = "https://router.requesty.ai/v1/chat/completions"
 
 
+# ADR-011: provider cost when Requesty reports it, else registry estimate.
+from .cost_resolver import CostResolver, registry_pricing_lookup
+
+_COST_RESOLVER = CostResolver(pricing_lookup=registry_pricing_lookup)
+
+
 class RequestyGateway(BaseRouter):
     """Requesty gateway implementing BaseRouter protocol.
 
@@ -246,6 +252,17 @@ class RequestyGateway(BaseRouter):
                         "prompt_tokens": usage.get("prompt_tokens", 0),
                         "completion_tokens": usage.get("completion_tokens", 0),
                         "total_tokens": usage.get("total_tokens", 0),
+                        # ADR-011: capture cost if Requesty reports it (ground
+                        # truth); else the gateway falls back to a registry
+                        # estimate.
+                        "cost": usage.get("cost"),
+                        "cached_tokens": (
+                            usage.get("cached_tokens")
+                            or usage.get("prompt_tokens_details", {}).get(
+                                "cached_tokens", 0
+                            )
+                            or 0
+                        ),
                     },
                 }
 
@@ -301,6 +318,14 @@ class RequestyGateway(BaseRouter):
                 prompt_tokens=usage_data.get("prompt_tokens", 0),
                 completion_tokens=usage_data.get("completion_tokens", 0),
                 total_tokens=usage_data.get("total_tokens", 0),
+            )
+            # ADR-011: provider cost if Requesty reported it, else registry.
+            _COST_RESOLVER.apply(
+                usage,
+                gateway="requesty",
+                model_id=request.model,
+                provider_cost_usd=usage_data.get("cost"),
+                cached_tokens=usage_data.get("cached_tokens"),
             )
 
         return GatewayResponse(

--- a/src/llm_council/gateway/requesty.py
+++ b/src/llm_council/gateway/requesty.py
@@ -258,7 +258,7 @@ class RequestyGateway(BaseRouter):
                         "cost": usage.get("cost"),
                         "cached_tokens": (
                             usage.get("cached_tokens")
-                            or usage.get("prompt_tokens_details", {}).get(
+                            or (usage.get("prompt_tokens_details") or {}).get(
                                 "cached_tokens", 0
                             )
                             or 0

--- a/src/llm_council/gateway/types.py
+++ b/src/llm_council/gateway/types.py
@@ -42,11 +42,23 @@ class CanonicalMessage:
 
 @dataclass
 class UsageInfo:
-    """Token usage information from an API response."""
+    """Token usage (and, when known, cost) from an API response.
+
+    Cost fields are populated by the ``CostResolver`` (ADR-011 Phase 1):
+
+        cost_usd:     USD cost for this call, or None if it could not be resolved.
+        cost_source:  provenance of ``cost_usd`` so an estimate is never mistaken
+                      for a bill — one of "provider" | "registry_estimate" |
+                      "local_zero", or None when unknown.
+        cached_tokens: prompt tokens served from a provider cache, when reported.
+    """
 
     prompt_tokens: int
     completion_tokens: int
     total_tokens: int
+    cost_usd: Optional[float] = None
+    cost_source: Optional[str] = None
+    cached_tokens: int = 0
 
 
 @dataclass

--- a/src/llm_council/http_server.py
+++ b/src/llm_council/http_server.py
@@ -130,6 +130,21 @@ class CouncilRequest(BaseModel):
     )
 
 
+class UsageSummary(BaseModel):
+    """ADR-011 cost/token accounting for a council run.
+
+    ``total`` and each ``by_stage`` / ``by_model`` entry carry
+    ``prompt_tokens``, ``completion_tokens``, ``total_tokens``, ``cost_usd``
+    (USD; 0 when no provider cost was reported), and ``cached_tokens``.
+    """
+
+    by_stage: Dict[str, Any] = Field(default_factory=dict, description="Usage per stage")
+    by_model: Dict[str, Any] = Field(
+        default_factory=dict, description="Usage per model (reviewer-primary attribution)"
+    )
+    total: Dict[str, Any] = Field(default_factory=dict, description="Grand total across stages")
+
+
 class CouncilResponse(BaseModel):
     """Response from council deliberation."""
 
@@ -137,6 +152,9 @@ class CouncilResponse(BaseModel):
     stage2: List[Dict[str, Any]] = Field(..., description="Peer review rankings")
     stage3: Dict[str, Any] = Field(..., description="Final synthesis")
     metadata: Dict[str, Any] = Field(..., description="Aggregate rankings and config")
+    usage: Optional[UsageSummary] = Field(
+        None, description="ADR-011 cost/token accounting (also present under metadata.usage)"
+    )
 
 
 class HealthResponse(BaseModel):
@@ -217,6 +235,7 @@ async def council_run(request: CouncilRequest) -> CouncilResponse:
             stage2=stage2,
             stage3=stage3,
             metadata=metadata,
+            usage=metadata.get("usage"),  # ADR-011: typed, OpenAPI-documented
         )
     except HTTPException:
         raise

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -166,7 +166,11 @@ async def consult_council(
             in your client config to at least the tier's server budget when
             using these tiers — otherwise the client will cut the connection
             before the council finishes deliberating.
-        include_details: If True, includes individual model responses and rankings.
+        include_details: If True, includes individual model responses, rankings,
+            and the full per-model/per-stage Cost & Tokens breakdown. When False
+            (default) only a one-line cost/token summary is returned. Leave it
+            False unless the user explicitly wants the detail — the breakdown is
+            verbose and consumes context; do not echo it to the user unprompted.
         verdict_type: Type of verdict to render (ADR-025b Jury Mode):
             - "synthesis": Default behavior, unstructured natural language synthesis
             - "binary": Go/no-go decision (approved/rejected) with confidence score

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -292,6 +292,16 @@ async def consult_council(
         if alerts:
             result += f"\n**Alerts**: {', '.join(alerts)}\n"
 
+    # ADR-011: cost/token summary. One dense line by default; full per-model /
+    # per-stage breakdown only under include_details (progressive disclosure).
+    from .cost_summary import format_cost_summary
+
+    usage_summary = format_cost_summary(
+        metadata.get("usage"), include_details=include_details
+    )
+    if usage_summary:
+        result += "\n### Cost & Tokens\n" + usage_summary + "\n"
+
     if include_details:
         result += "\n\n### Council Details\n"
 

--- a/src/llm_council/openrouter.py
+++ b/src/llm_council/openrouter.py
@@ -148,6 +148,15 @@ async def query_model_with_status(
                     "prompt_tokens": usage.get("prompt_tokens", 0),
                     "completion_tokens": usage.get("completion_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
+                    # ADR-011: OpenRouter returns the authoritative billed cost
+                    # inline; capture it (previously discarded) so the council
+                    # can account cost, not just tokens.
+                    "cost": usage.get("cost"),
+                    "cached_tokens": (
+                        usage.get("cached_tokens")
+                        or usage.get("prompt_tokens_details", {}).get("cached_tokens", 0)
+                        or 0
+                    ),
                 },
             }
 

--- a/src/llm_council/openrouter.py
+++ b/src/llm_council/openrouter.py
@@ -154,7 +154,7 @@ async def query_model_with_status(
                     "cost": usage.get("cost"),
                     "cached_tokens": (
                         usage.get("cached_tokens")
-                        or usage.get("prompt_tokens_details", {}).get("cached_tokens", 0)
+                        or (usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0)
                         or 0
                     ),
                 },

--- a/tests/test_cost_resolver.py
+++ b/tests/test_cost_resolver.py
@@ -121,6 +121,21 @@ class TestCostResolver:
         assert source == "registry_estimate"
         assert cost == 0.0075
 
+    def test_invalid_provider_costs_fall_through(self):
+        # NaN / infinity / negative are not valid ground truth; they must not
+        # corrupt accounting — fall through to a registry estimate instead.
+        r = CostResolver(pricing_lookup=_pricing_lookup)
+        for bad in (float("nan"), float("inf"), float("-inf"), -0.01):
+            cost, source = r.resolve(
+                gateway="direct",
+                model_id="openai/gpt-4o",
+                prompt_tokens=1000,
+                completion_tokens=500,
+                provider_cost_usd=bad,
+            )
+            assert source == "registry_estimate", bad
+            assert cost == 0.0075
+
     def test_default_resolver_uses_registry_lookup(self, monkeypatch):
         # A bare CostResolver() defaults to the registry lookup so Direct-API
         # calls are still priced (finding: missing default fallback).

--- a/tests/test_cost_resolver.py
+++ b/tests/test_cost_resolver.py
@@ -1,0 +1,117 @@
+"""Tests for the per-gateway CostResolver (ADR-011 Phase 1, #360).
+
+The resolver assigns a USD cost and a provenance tag (`cost_source`) to a
+model call, honouring the gateway's cost fidelity:
+
+- provider ground-truth (OpenRouter/Requesty return `usage.cost`)  -> "provider"
+- registry-pricing estimate (Direct APIs return tokens only)        -> "registry_estimate"
+- local models (Ollama)                                             -> "local_zero"
+- pricing unknown                                                    -> (None, None)
+"""
+
+from llm_council.gateway.cost_resolver import CostResolver
+from llm_council.gateway.types import UsageInfo
+
+
+# --- registry pricing double: gpt-4o-ish, per 1K tokens --------------------
+def _pricing_lookup(model_id):
+    table = {
+        "openai/gpt-4o": {"prompt": 0.0025, "completion": 0.01},
+        "anthropic/claude-3-5-sonnet": {"prompt": 0.003, "completion": 0.015},
+    }
+    return table.get(model_id, {})
+
+
+class TestCostResolver:
+    def test_provider_reported_cost_wins(self):
+        r = CostResolver(pricing_lookup=_pricing_lookup)
+        cost, source = r.resolve(
+            gateway="openrouter",
+            model_id="openai/gpt-4o",
+            prompt_tokens=1000,
+            completion_tokens=1000,
+            provider_cost_usd=0.0125,
+        )
+        # Ground truth is used verbatim, never recomputed from the table.
+        assert cost == 0.0125
+        assert source == "provider"
+
+    def test_registry_estimate_when_no_provider_cost(self):
+        r = CostResolver(pricing_lookup=_pricing_lookup)
+        cost, source = r.resolve(
+            gateway="direct",
+            model_id="openai/gpt-4o",
+            prompt_tokens=1000,
+            completion_tokens=500,
+        )
+        # (1000/1000)*0.0025 + (500/1000)*0.01 = 0.0025 + 0.005 = 0.0075
+        assert cost == 0.0075
+        assert source == "registry_estimate"
+
+    def test_local_gateway_is_zero(self):
+        r = CostResolver(pricing_lookup=_pricing_lookup)
+        cost, source = r.resolve(
+            gateway="ollama",
+            model_id="ollama/llama3",
+            prompt_tokens=5000,
+            completion_tokens=5000,
+        )
+        assert cost == 0.0
+        assert source == "local_zero"
+
+    def test_unknown_pricing_returns_none(self):
+        r = CostResolver(pricing_lookup=_pricing_lookup)
+        cost, source = r.resolve(
+            gateway="direct",
+            model_id="some/unpriced-model",
+            prompt_tokens=1000,
+            completion_tokens=1000,
+        )
+        assert cost is None
+        assert source is None
+
+    def test_apply_mutates_usage_in_place(self):
+        r = CostResolver(pricing_lookup=_pricing_lookup)
+        usage = UsageInfo(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+        out = r.apply(
+            usage,
+            gateway="direct",
+            model_id="openai/gpt-4o",
+        )
+        assert out is usage  # returns the same object for convenience
+        assert usage.cost_usd == 0.0075
+        assert usage.cost_source == "registry_estimate"
+
+    def test_apply_records_cached_tokens(self):
+        r = CostResolver(pricing_lookup=_pricing_lookup)
+        usage = UsageInfo(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+        r.apply(
+            usage,
+            gateway="openrouter",
+            model_id="openai/gpt-4o",
+            provider_cost_usd=0.01,
+            cached_tokens=200,
+        )
+        assert usage.cost_usd == 0.01
+        assert usage.cost_source == "provider"
+        assert usage.cached_tokens == 200
+
+    def test_missing_pricing_lookup_falls_back_to_none(self):
+        # No lookup injected: only provider/local paths can produce a cost.
+        r = CostResolver()
+        cost, source = r.resolve(
+            gateway="direct",
+            model_id="openai/gpt-4o",
+            prompt_tokens=1000,
+            completion_tokens=1000,
+        )
+        assert cost is None
+        assert source is None
+
+
+class TestUsageInfoCostFields:
+    def test_new_fields_default_safely(self):
+        usage = UsageInfo(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+        assert usage.cost_usd is None
+        assert usage.cost_source is None
+        assert usage.cached_tokens == 0

--- a/tests/test_cost_resolver.py
+++ b/tests/test_cost_resolver.py
@@ -136,6 +136,41 @@ class TestCostResolver:
             assert source == "registry_estimate", bad
             assert cost == 0.0075
 
+    def test_null_registry_price_does_not_crash(self):
+        # A present-but-null price must not reach the arithmetic (TypeError).
+        r = CostResolver(pricing_lookup=lambda m: {"prompt": None, "completion": 0.01})
+        cost, source = r.resolve(
+            gateway="direct", model_id="x/y", prompt_tokens=1000, completion_tokens=1000
+        )
+        assert source == "registry_estimate"
+        assert cost == 0.01  # prompt None -> 0; 1000/1000 * 0.01
+
+    def test_all_prices_invalid_returns_none(self):
+        r = CostResolver(pricing_lookup=lambda m: {"prompt": None, "completion": "n/a"})
+        cost, source = r.resolve(
+            gateway="direct", model_id="x/y", prompt_tokens=1000, completion_tokens=1000
+        )
+        assert cost is None and source is None
+
+    def test_negative_registry_price_ignored(self):
+        r = CostResolver(pricing_lookup=lambda m: {"prompt": -1.0, "completion": 0.01})
+        cost, source = r.resolve(
+            gateway="direct", model_id="x/y", prompt_tokens=1000, completion_tokens=1000
+        )
+        assert source == "registry_estimate"
+        assert cost == 0.01  # negative prompt price treated as 0
+
+    def test_negative_token_counts_clamped(self):
+        r = CostResolver(pricing_lookup=_pricing_lookup)
+        cost, source = r.resolve(
+            gateway="direct",
+            model_id="openai/gpt-4o",
+            prompt_tokens=-100,
+            completion_tokens=-50,
+        )
+        assert source == "registry_estimate"
+        assert cost == 0.0  # clamped, never negative
+
     def test_default_resolver_uses_registry_lookup(self, monkeypatch):
         # A bare CostResolver() defaults to the registry lookup so Direct-API
         # calls are still priced (finding: missing default fallback).

--- a/tests/test_cost_resolver.py
+++ b/tests/test_cost_resolver.py
@@ -96,17 +96,47 @@ class TestCostResolver:
         assert usage.cost_source == "provider"
         assert usage.cached_tokens == 200
 
-    def test_missing_pricing_lookup_falls_back_to_none(self):
-        # No lookup injected: only provider/local paths can produce a cost.
-        r = CostResolver()
+    def test_unknown_pricing_returns_none_with_empty_lookup(self):
+        # An explicit empty lookup models "pricing unknown".
+        r = CostResolver(pricing_lookup=lambda m: {})
         cost, source = r.resolve(
             gateway="direct",
-            model_id="openai/gpt-4o",
+            model_id="unpriced/model",
             prompt_tokens=1000,
             completion_tokens=1000,
         )
         assert cost is None
         assert source is None
+
+    def test_non_numeric_provider_cost_falls_through(self):
+        # A malformed provider cost must not crash; fall back to a registry estimate.
+        r = CostResolver(pricing_lookup=_pricing_lookup)
+        cost, source = r.resolve(
+            gateway="direct",
+            model_id="openai/gpt-4o",
+            prompt_tokens=1000,
+            completion_tokens=500,
+            provider_cost_usd="not-a-number",
+        )
+        assert source == "registry_estimate"
+        assert cost == 0.0075
+
+    def test_default_resolver_uses_registry_lookup(self, monkeypatch):
+        # A bare CostResolver() defaults to the registry lookup so Direct-API
+        # calls are still priced (finding: missing default fallback).
+        monkeypatch.setattr(
+            "llm_council.gateway.cost_resolver.registry_pricing_lookup",
+            lambda m: {"prompt": 0.001, "completion": 0.002},
+        )
+        r = CostResolver()
+        cost, source = r.resolve(
+            gateway="direct",
+            model_id="x/y",
+            prompt_tokens=1000,
+            completion_tokens=1000,
+        )
+        assert source == "registry_estimate"
+        assert cost == 0.003
 
 
 class TestUsageInfoCostFields:

--- a/tests/test_cost_resolver.py
+++ b/tests/test_cost_resolver.py
@@ -115,3 +115,25 @@ class TestUsageInfoCostFields:
         assert usage.cost_usd is None
         assert usage.cost_source is None
         assert usage.cached_tokens == 0
+
+
+class TestRegistryPricingLookup:
+    def test_delegates_to_metadata_provider(self, monkeypatch):
+        from llm_council.gateway.cost_resolver import registry_pricing_lookup
+
+        class _FakeProvider:
+            def get_pricing(self, model_id):
+                return {"prompt": 0.001, "completion": 0.002}
+
+        monkeypatch.setattr("llm_council.metadata.get_provider", lambda: _FakeProvider())
+        assert registry_pricing_lookup("any/model") == {"prompt": 0.001, "completion": 0.002}
+
+    def test_swallows_provider_errors(self, monkeypatch):
+        from llm_council.gateway.cost_resolver import registry_pricing_lookup
+
+        def _boom():
+            raise RuntimeError("provider unavailable")
+
+        monkeypatch.setattr("llm_council.metadata.get_provider", _boom)
+        # Never raises into the hot path; unknown pricing -> empty dict.
+        assert registry_pricing_lookup("any/model") == {}

--- a/tests/test_cost_summary.py
+++ b/tests/test_cost_summary.py
@@ -39,6 +39,23 @@ def test_details_include_per_model_and_stage():
     assert out.splitlines()[0].startswith("Council usage:")
 
 
+def test_sub_cent_cost_not_masked_as_zero():
+    # An 8dp-resolved sub-cent cost must not display as $0.0000.
+    usage = {"total": {"total_tokens": 100, "cost_usd": 0.00005, "cost_known": True}}
+    out = format_cost_summary(usage)
+    assert "$0.0000 " not in out and not out.endswith("$0.0000")
+    assert "$0.000050" in out
+
+
+def test_stage_with_cost_but_zero_tokens_is_kept():
+    usage = {
+        "total": {"total_tokens": 0, "cost_usd": 0.01, "cost_known": True},
+        "by_stage": {"stage1": {"total_tokens": 0, "cost_usd": 0.01, "cost_known": True}},
+    }
+    out = format_cost_summary(usage, include_details=True)
+    assert "stage1: 0 tok, $0.0100" in out
+
+
 def test_none_nested_values_do_not_crash():
     # A malformed usage block with null sub-sections must not raise.
     usage = {"total": None, "by_model": None, "by_stage": None}

--- a/tests/test_cost_summary.py
+++ b/tests/test_cost_summary.py
@@ -48,8 +48,16 @@ def test_none_nested_values_do_not_crash():
     assert out.startswith("Council usage:")
 
 
-def test_cost_omitted_when_zero_or_unknown():
+def test_cost_omitted_when_unknown():
+    # cost_usd 0.0 with no cost_known signal == unknown -> omit the cost figure.
     usage = {"total": {"total_tokens": 100, "cost_usd": 0.0}}
     out = format_cost_summary(usage)
     assert "tokens" in out
-    assert "$" not in out  # never show a $0.0000 bill when cost is unknown/free
+    assert "$" not in out
+
+
+def test_genuine_zero_cost_shown_when_known():
+    # A reported $0 (free/local) is distinguished from unknown and IS shown.
+    usage = {"total": {"total_tokens": 100, "cost_usd": 0.0, "cost_known": True}}
+    out = format_cost_summary(usage)
+    assert "$0.0000" in out

--- a/tests/test_cost_summary.py
+++ b/tests/test_cost_summary.py
@@ -61,3 +61,15 @@ def test_genuine_zero_cost_shown_when_known():
     usage = {"total": {"total_tokens": 100, "cost_usd": 0.0, "cost_known": True}}
     out = format_cost_summary(usage)
     assert "$0.0000" in out
+
+
+def test_detail_lines_show_known_zero_consistently():
+    # Detail per-model/per-stage lines must not suppress a known $0 (must match
+    # the one-liner's known-vs-unknown logic).
+    usage = {
+        "total": {"total_tokens": 20, "cost_usd": 0.0, "cost_known": True},
+        "by_model": {"ollama/llama3": {"total_tokens": 20, "cost_usd": 0.0}},
+        "by_stage": {"stage1": {"total_tokens": 20, "cost_usd": 0.0}},
+    }
+    out = format_cost_summary(usage, include_details=True)
+    assert out.count("$0.0000") >= 2  # one-liner + model + stage all show it

--- a/tests/test_cost_summary.py
+++ b/tests/test_cost_summary.py
@@ -64,12 +64,27 @@ def test_genuine_zero_cost_shown_when_known():
 
 
 def test_detail_lines_show_known_zero_consistently():
-    # Detail per-model/per-stage lines must not suppress a known $0 (must match
-    # the one-liner's known-vs-unknown logic).
+    # A row with its own cost_known must show a genuine $0 (not suppress it).
     usage = {
         "total": {"total_tokens": 20, "cost_usd": 0.0, "cost_known": True},
-        "by_model": {"ollama/llama3": {"total_tokens": 20, "cost_usd": 0.0}},
-        "by_stage": {"stage1": {"total_tokens": 20, "cost_usd": 0.0}},
+        "by_model": {"ollama/llama3": {"total_tokens": 20, "cost_usd": 0.0, "cost_known": True}},
+        "by_stage": {"stage1": {"total_tokens": 20, "cost_usd": 0.0, "cost_known": True}},
     }
     out = format_cost_summary(usage, include_details=True)
     assert out.count("$0.0000") >= 2  # one-liner + model + stage all show it
+
+
+def test_unknown_row_not_shown_as_zero_even_if_aggregate_known():
+    # Per-row provenance: an unknown-cost row must NOT display $0.0000 just
+    # because some other row (and thus the aggregate) has a known cost.
+    usage = {
+        "total": {"total_tokens": 20, "cost_usd": 0.01, "cost_known": True},
+        "by_model": {
+            "known/m": {"total_tokens": 10, "cost_usd": 0.01, "cost_known": True},
+            "unknown/m": {"total_tokens": 10, "cost_usd": 0.0},  # no cost_known
+        },
+    }
+    out = format_cost_summary(usage, include_details=True)
+    assert "known/m: 10 tok, $0.0100" in out
+    assert "unknown/m: 10 tok" in out
+    assert "unknown/m: 10 tok, $" not in out

--- a/tests/test_cost_summary.py
+++ b/tests/test_cost_summary.py
@@ -1,0 +1,46 @@
+"""Tests for cost/token summary formatting + progressive disclosure (ADR-011)."""
+
+from llm_council.cost_summary import format_cost_summary
+
+_USAGE = {
+    "total": {"total_tokens": 8500, "cost_usd": 0.0212, "cached_tokens": 200},
+    "by_model": {
+        "openai/gpt-4o": {"total_tokens": 5000, "cost_usd": 0.015},
+        "anthropic/claude-3-5-sonnet": {"total_tokens": 3500, "cost_usd": 0.0062},
+    },
+    "by_stage": {
+        "stage1": {"total_tokens": 4000, "cost_usd": 0.01},
+        "stage2": {"total_tokens": 3500, "cost_usd": 0.009},
+        "stage3": {"total_tokens": 1000, "cost_usd": 0.0022},
+    },
+}
+
+
+def test_empty_usage_is_empty_string():
+    assert format_cost_summary(None) == ""
+    assert format_cost_summary({}) == ""
+
+
+def test_default_is_one_line():
+    out = format_cost_summary(_USAGE)
+    assert "\n" not in out  # progressive disclosure: single line by default
+    assert "~8.5k tokens" in out
+    assert "$0.0212" in out
+    assert "cached" in out
+
+
+def test_details_include_per_model_and_stage():
+    out = format_cost_summary(_USAGE, include_details=True)
+    assert "By model:" in out
+    assert "openai/gpt-4o" in out
+    assert "By stage:" in out
+    assert "stage2" in out
+    # Still leads with the one-line summary.
+    assert out.splitlines()[0].startswith("Council usage:")
+
+
+def test_cost_omitted_when_zero_or_unknown():
+    usage = {"total": {"total_tokens": 100, "cost_usd": 0.0}}
+    out = format_cost_summary(usage)
+    assert "tokens" in out
+    assert "$" not in out  # never show a $0.0000 bill when cost is unknown/free

--- a/tests/test_cost_summary.py
+++ b/tests/test_cost_summary.py
@@ -39,6 +39,15 @@ def test_details_include_per_model_and_stage():
     assert out.splitlines()[0].startswith("Council usage:")
 
 
+def test_none_nested_values_do_not_crash():
+    # A malformed usage block with null sub-sections must not raise.
+    usage = {"total": None, "by_model": None, "by_stage": None}
+    assert format_cost_summary(usage) == "Council usage: ~0 tokens"
+    # include_details path must also survive nulls.
+    out = format_cost_summary(usage, include_details=True)
+    assert out.startswith("Council usage:")
+
+
 def test_cost_omitted_when_zero_or_unknown():
     usage = {"total": {"total_tokens": 100, "cost_usd": 0.0}}
     out = format_cost_summary(usage)

--- a/tests/test_council_cost_aggregation.py
+++ b/tests/test_council_cost_aggregation.py
@@ -20,6 +20,13 @@ def test_none_cost_is_zero_contribution():
     _add_cost_to_usage(bucket, {"prompt_tokens": 10})  # no cost/cached keys
     assert bucket["cost_usd"] == 0.0
     assert bucket["cached_tokens"] == 0
+    assert not bucket.get("cost_known")  # cost genuinely unknown
+
+
+def test_cost_known_set_even_for_reported_zero():
+    bucket = {}
+    _add_cost_to_usage(bucket, {"cost": 0.0})  # a reported $0 is "known"
+    assert bucket.get("cost_known") is True
 
 
 def test_per_model_accumulation():

--- a/tests/test_council_cost_aggregation.py
+++ b/tests/test_council_cost_aggregation.py
@@ -29,6 +29,44 @@ def test_cost_known_set_even_for_reported_zero():
     assert bucket.get("cost_known") is True
 
 
+def test_per_model_cost_known_tracked():
+    bucket = {}
+    _add_cost_to_usage(bucket, {"cost": 0.0, "total_tokens": 5}, model="m")
+    assert bucket["by_model"]["m"]["cost_known"] is True
+    other = {}
+    _add_cost_to_usage(other, {"total_tokens": 5}, model="m")  # no cost reported
+    assert not other["by_model"]["m"].get("cost_known")
+
+
+def test_build_usage_summary_merges_per_model_cost_known():
+    from llm_council.council import _build_usage_summary
+
+    by_stage = {
+        "stage1": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "cost_usd": 0.01,
+            "cached_tokens": 0,
+            "cost_known": True,
+            "by_model": {
+                "m": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                    "cost_usd": 0.01,
+                    "cached_tokens": 0,
+                    "cost_known": True,
+                }
+            },
+        }
+    }
+    summary = _build_usage_summary(by_stage)
+    assert summary["by_model"]["m"]["cost_known"] is True
+    assert summary["by_model"]["m"]["total_tokens"] == 15
+    assert summary["total"]["cost_known"] is True
+
+
 def test_per_model_accumulation():
     bucket = {}
     usage = {

--- a/tests/test_council_cost_aggregation.py
+++ b/tests/test_council_cost_aggregation.py
@@ -1,0 +1,54 @@
+"""Cost/token aggregation in the council (ADR-011 #360, slice 4).
+
+`_add_cost_to_usage` is additive to the existing token aggregation: it sums
+cost_usd + cached_tokens onto a stage bucket and, when a model is supplied,
+also accumulates per-model spend under `by_model`.
+"""
+
+from llm_council.council import _add_cost_to_usage
+
+
+def test_accumulates_cost_and_cached():
+    bucket = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    _add_cost_to_usage(bucket, {"cost": 0.01, "cached_tokens": 5})
+    assert bucket["cost_usd"] == 0.01
+    assert bucket["cached_tokens"] == 5
+
+
+def test_none_cost_is_zero_contribution():
+    bucket = {}
+    _add_cost_to_usage(bucket, {"prompt_tokens": 10})  # no cost/cached keys
+    assert bucket["cost_usd"] == 0.0
+    assert bucket["cached_tokens"] == 0
+
+
+def test_per_model_accumulation():
+    bucket = {}
+    usage = {
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "total_tokens": 150,
+        "cost": 0.02,
+        "cached_tokens": 3,
+    }
+    _add_cost_to_usage(bucket, usage, model="openai/gpt-4o")
+    bm = bucket["by_model"]["openai/gpt-4o"]
+    assert bm["prompt_tokens"] == 100
+    assert bm["cost_usd"] == 0.02
+    assert bm["cached_tokens"] == 3
+
+    # A second call for the same model accumulates.
+    _add_cost_to_usage(
+        bucket,
+        {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150, "cost": 0.02},
+        model="openai/gpt-4o",
+    )
+    bm = bucket["by_model"]["openai/gpt-4o"]
+    assert bm["prompt_tokens"] == 200
+    assert bm["cost_usd"] == 0.04
+
+
+def test_no_model_skips_by_model():
+    bucket = {}
+    _add_cost_to_usage(bucket, {"cost": 0.01})
+    assert "by_model" not in bucket

--- a/tests/test_gateway_cost_capture.py
+++ b/tests/test_gateway_cost_capture.py
@@ -1,0 +1,60 @@
+"""Gateways populate UsageInfo cost fields via the CostResolver (ADR-011 #360).
+
+OpenRouter returns an authoritative `usage.cost` on every response; the gateway
+must capture it (it was previously discarded) and stamp cost_source="provider".
+Ollama is local, so its calls resolve to cost 0 / "local_zero".
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from llm_council.gateway.openrouter import OpenRouterGateway
+from llm_council.gateway.types import CanonicalMessage, ContentBlock, GatewayRequest
+
+
+def _req(model="openai/gpt-4o"):
+    return GatewayRequest(
+        model=model,
+        messages=[CanonicalMessage(role="user", content=[ContentBlock(type="text", text="hi")])],
+    )
+
+
+class TestOpenRouterCostCapture:
+    async def test_captures_provider_cost_and_cached_tokens(self):
+        gw = OpenRouterGateway()
+        fake = {
+            "status": "ok",
+            "content": "hi",
+            "latency_ms": 12,
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "total_tokens": 150,
+                "cost": 0.0012,
+                "cached_tokens": 20,
+            },
+        }
+        with patch.object(gw, "_query_openrouter", new=AsyncMock(return_value=fake)):
+            resp = await gw.complete(_req())
+
+        assert resp.usage is not None
+        assert resp.usage.cost_usd == 0.0012
+        assert resp.usage.cost_source == "provider"
+        assert resp.usage.cached_tokens == 20
+
+    async def test_no_provider_cost_leaves_cost_unknown(self):
+        # If OpenRouter omits cost, there's no ground truth and (without a
+        # pricing lookup wired at this layer) cost stays unresolved.
+        gw = OpenRouterGateway()
+        fake = {
+            "status": "ok",
+            "content": "hi",
+            "latency_ms": 12,
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+        }
+        with patch.object(gw, "_query_openrouter", new=AsyncMock(return_value=fake)):
+            resp = await gw.complete(_req())
+
+        assert resp.usage is not None
+        assert resp.usage.cost_usd is None
+        assert resp.usage.cost_source is None
+        assert resp.usage.cached_tokens == 0

--- a/tests/test_gateway_cost_capture.py
+++ b/tests/test_gateway_cost_capture.py
@@ -58,3 +58,72 @@ class TestOpenRouterCostCapture:
         assert resp.usage.cost_usd is None
         assert resp.usage.cost_source is None
         assert resp.usage.cached_tokens == 0
+
+
+class TestDirectCostCapture:
+    async def test_direct_uses_registry_estimate(self, monkeypatch):
+        from llm_council.gateway import direct as direct_mod
+        from llm_council.gateway.cost_resolver import CostResolver
+        from llm_council.gateway.direct import DirectGateway
+
+        # Inject a key so complete() doesn't short-circuit with auth_error.
+        gw = DirectGateway(provider_keys={"openai": "test-key"})
+        # Deterministic pricing so the estimate is exact.
+        monkeypatch.setattr(
+            direct_mod,
+            "_COST_RESOLVER",
+            CostResolver(pricing_lookup=lambda m: {"prompt": 0.0025, "completion": 0.01}),
+        )
+        fake = {
+            "status": "ok",
+            "content": "hi",
+            "latency_ms": 5,
+            "usage": {"prompt_tokens": 1000, "completion_tokens": 500, "total_tokens": 1500},
+        }
+        with patch.object(gw, "_query_provider", new=AsyncMock(return_value=fake)):
+            resp = await gw.complete(_req())
+
+        assert resp.usage.cost_usd == 0.0075
+        assert resp.usage.cost_source == "registry_estimate"
+
+
+class TestOllamaCostCapture:
+    async def test_ollama_is_local_zero(self):
+        from llm_council.gateway.ollama import OllamaGateway
+
+        gw = OllamaGateway()
+        fake = {
+            "status": "ok",
+            "content": "hi",
+            "latency_ms": 5,
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+        }
+        with patch.object(gw, "_query_ollama", new=AsyncMock(return_value=fake)):
+            resp = await gw.complete(_req("ollama/llama3"))
+
+        assert resp.usage.cost_usd == 0.0
+        assert resp.usage.cost_source == "local_zero"
+
+
+class TestRequestyCostCapture:
+    async def test_requesty_prefers_provider_cost(self):
+        from llm_council.gateway.requesty import RequestyGateway
+
+        gw = RequestyGateway(api_key="test")
+        fake = {
+            "status": "ok",
+            "content": "hi",
+            "latency_ms": 5,
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "total_tokens": 150,
+                "cost": 0.002,
+                "cached_tokens": 0,
+            },
+        }
+        with patch.object(gw, "_query_requesty", new=AsyncMock(return_value=fake)):
+            resp = await gw.complete(_req())
+
+        assert resp.usage.cost_usd == 0.002
+        assert resp.usage.cost_source == "provider"

--- a/tests/test_gateway_cost_capture.py
+++ b/tests/test_gateway_cost_capture.py
@@ -41,9 +41,10 @@ class TestOpenRouterCostCapture:
         assert resp.usage.cost_source == "provider"
         assert resp.usage.cached_tokens == 20
 
-    async def test_no_provider_cost_leaves_cost_unknown(self):
-        # If OpenRouter omits cost, there's no ground truth and (without a
-        # pricing lookup wired at this layer) cost stays unresolved.
+    async def test_no_provider_cost_unknown_model_stays_unknown(self):
+        # No provider cost AND a model absent from the registry -> unresolved.
+        # (A known model would instead get a registry_estimate via the default
+        # lookup — the layered fallback from ADR-011 §1.)
         gw = OpenRouterGateway()
         fake = {
             "status": "ok",
@@ -52,12 +53,39 @@ class TestOpenRouterCostCapture:
             "usage": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
         }
         with patch.object(gw, "_query_openrouter", new=AsyncMock(return_value=fake)):
-            resp = await gw.complete(_req())
+            resp = await gw.complete(_req("zzz/nonexistent-model-xyz"))
 
         assert resp.usage is not None
         assert resp.usage.cost_usd is None
         assert resp.usage.cost_source is None
         assert resp.usage.cached_tokens == 0
+
+
+class TestReasoningParamsForwarding:
+    async def test_complete_forwards_reasoning_params(self):
+        # ADR-026: the gateway path previously dropped reasoning_params.
+        from llm_council.gateway.openrouter import OpenRouterGateway
+        from llm_council.gateway.types import ReasoningParams
+
+        gw = OpenRouterGateway()
+        rp = ReasoningParams(effort="high", max_tokens=1000)
+        captured = {}
+
+        async def _fake_query(**kwargs):
+            captured.update(kwargs)
+            return {
+                "status": "ok",
+                "content": "hi",
+                "latency_ms": 1,
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            }
+
+        with patch.object(gw, "_query_openrouter", new=_fake_query):
+            req = _req()
+            req.reasoning_params = rp
+            await gw.complete(req)
+
+        assert captured.get("reasoning_params") is rp
 
 
 class TestDirectCostCapture:

--- a/tests/test_http_usage_field.py
+++ b/tests/test_http_usage_field.py
@@ -1,0 +1,25 @@
+"""CouncilResponse exposes a typed, OpenAPI-documented usage field (ADR-011 #360)."""
+
+from llm_council.http_server import CouncilResponse, UsageSummary
+
+
+def test_usage_summary_coerces_from_metadata_dict():
+    usage = {
+        "by_stage": {"stage1": {"total_tokens": 40, "cost_usd": 0.01}},
+        "by_model": {"openai/gpt-4o": {"total_tokens": 40, "cost_usd": 0.01}},
+        "total": {"total_tokens": 40, "cost_usd": 0.01, "cached_tokens": 5},
+    }
+    resp = CouncilResponse(stage1=[], stage2=[], stage3={}, metadata={"usage": usage}, usage=usage)
+    assert isinstance(resp.usage, UsageSummary)
+    assert resp.usage.total["cost_usd"] == 0.01
+    assert resp.usage.by_model["openai/gpt-4o"]["total_tokens"] == 40
+
+
+def test_usage_optional_when_absent():
+    resp = CouncilResponse(stage1=[], stage2=[], stage3={}, metadata={})
+    assert resp.usage is None
+
+
+def test_usage_present_in_openapi_schema():
+    schema = CouncilResponse.model_json_schema()
+    assert "usage" in schema["properties"]

--- a/tests/test_openrouter_cost.py
+++ b/tests/test_openrouter_cost.py
@@ -1,0 +1,65 @@
+"""OpenRouter query path captures the authoritative usage.cost (ADR-011 #360).
+
+The council collects usage via query_models_parallel -> query_model ->
+query_model_with_status, which previously discarded OpenRouter's inline cost.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _ok_response(usage):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {
+        "choices": [{"message": {"content": "hi"}}],
+        "usage": usage,
+    }
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_query_model_with_status_captures_cost_and_cached():
+    from llm_council.openrouter import STATUS_OK, query_model_with_status
+
+    usage = {
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "total_tokens": 150,
+        "cost": 0.0012,
+        "cached_tokens": 20,
+    }
+    with (
+        patch("llm_council.openrouter.OPENROUTER_API_KEY", "test-key"),
+        patch("httpx.AsyncClient") as mock_client,
+    ):
+        mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+            return_value=_ok_response(usage)
+        )
+        result = await query_model_with_status("openai/gpt-4o", [{"role": "user", "content": "hi"}])
+
+    assert result["status"] == STATUS_OK
+    assert result["usage"]["cost"] == 0.0012
+    assert result["usage"]["cached_tokens"] == 20
+
+
+@pytest.mark.asyncio
+async def test_cost_absent_is_none_not_error():
+    from llm_council.openrouter import query_model
+
+    usage = {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150}
+    with (
+        patch("llm_council.openrouter.OPENROUTER_API_KEY", "test-key"),
+        patch("httpx.AsyncClient") as mock_client,
+    ):
+        mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+            return_value=_ok_response(usage)
+        )
+        result = await query_model("openai/gpt-4o", [{"role": "user", "content": "hi"}])
+
+    # query_model passes usage through; cost is None when the API omits it.
+    assert result is not None
+    assert result["usage"]["cost"] is None
+    assert result["usage"]["cached_tokens"] == 0

--- a/tests/test_openrouter_cost.py
+++ b/tests/test_openrouter_cost.py
@@ -63,3 +63,28 @@ async def test_cost_absent_is_none_not_error():
     assert result is not None
     assert result["usage"]["cost"] is None
     assert result["usage"]["cached_tokens"] == 0
+
+
+@pytest.mark.asyncio
+async def test_null_prompt_tokens_details_does_not_crash():
+    # OpenRouter may send "prompt_tokens_details": null; .get(...,{}) returns
+    # None for a present-but-null key, so the chained .get must be guarded.
+    from llm_council.openrouter import STATUS_OK, query_model_with_status
+
+    usage = {
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "total_tokens": 150,
+        "prompt_tokens_details": None,
+    }
+    with (
+        patch("llm_council.openrouter.OPENROUTER_API_KEY", "test-key"),
+        patch("httpx.AsyncClient") as mock_client,
+    ):
+        mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+            return_value=_ok_response(usage)
+        )
+        result = await query_model_with_status("m", [{"role": "user", "content": "x"}])
+
+    assert result["status"] == STATUS_OK
+    assert result["usage"]["cached_tokens"] == 0


### PR DESCRIPTION
Implements **Phase 1** of epic #359 (ADR-011 Cost and Token Accounting).

First commit is the epic groundwork (refreshed ADR-011/023 + epic-loop config);
subsequent commits add the Phase-1 implementation via TDD.

## Phase 1 scope (per ADR-011 §1/§2/§7)
- `cost_usd` / `cost_source` / `cached_tokens` on `UsageInfo`
- per-gateway `CostResolver` (provider ground-truth → registry estimate → local-zero)
- per-model cost aggregation in the council; fix `run_council_with_fallback` usage gap
- surface typed cost/token blocks (HTTP, MCP `consult_council`, `VerifyResponse`) with progressive disclosure
- DoD: user docs + LLM-facing tool text + tests

Closes #360. Epic: #359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)