### PR TITLE
Release v0.25.0 — ADR-011 cost & token accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-07-01
+
+**Cost and token accounting (ADR-011)** — a four-phase epic ([#359](https://github.com/amiable-dev/llm-council/issues/359)) that makes LLM spend transparent and optimizable: capture & surfacing (Phase 1), OpenTelemetry-standard observability (Phase 2), cost-per-quality optimization (Phase 3), and an opt-in budget gate (Phase 4). Everything is additive and backward-compatible — new behaviour is opt-in or soft-fail, and the council never fails a request because of cost accounting.
+
 ### Added
 
 - **Opt-in budget enforcement (ADR-011, Phase 4)** — a new `budget/` module (DEFAULT OFF) adds a pre-query `CostEstimator` (low/expected/high USD estimate from per-model cost history) and a tiered `BudgetEnforcer`: `STRICT` rejects if even the high estimate exceeds the budget, `BALANCED` rejects on the expected estimate (warns on high), `PERMISSIVE` warns only. Between stages it can abort **gracefully** (returning partial results) but never aborts a completion in flight (ADR-040). Every reject/warn/abort emits an auditable `L1_BUDGET_DECISION` LayerEvent — budget never causes a silent tier change (ADR-024). Enable with `LLM_COUNCIL_BUDGET_ENFORCEMENT=true` and `LLM_COUNCIL_BUDGET_MODE=strict|balanced|permissive`.

--- a/docs/adr/ADR-011-cost-tracking.md
+++ b/docs/adr/ADR-011-cost-tracking.md
@@ -1,6 +1,6 @@
 # ADR-011: Cost and Token Accounting
 
-**Status:** Accepted 2026-07-01
+**Status:** Implemented 2026-07-01 (Phases 1–4, v0.25.0; epic #359) — was Accepted 2026-07-01
 **Date:** 2026-07-01 (refreshed from Proposed draft 2024-12-12)
 **Decision Makers:** Chris Joseph, LLM Council
 **Related:** ADR-009 (open-core boundary), ADR-024 (L1→L4 layers), ADR-030 (metrics export), ADR-041 (verification telemetry), ADR-022/ADR-026 (tier/model selection), ADR-027 (frontier cost ceiling)


### PR DESCRIPTION
Release **v0.25.0** — completes the ADR-011 cost/token accounting epic (#359).

## Included (4 phases)
- **P1** #364 — per-gateway CostResolver, per-model aggregation, MCP/HTTP surfacing (progressive disclosure)
- **P2** #368 — OTel GenAI metrics + `examples/observability/` (PostHog/Grafana)
- **P3** #369 — cost-per-quality (Borda-per-dollar) + opt-in cost-aware selection
- **P4** #371 — opt-in tiered budget gate (estimator + enforcer + audited LayerEvent)

All additive & backward-compatible (opt-in / soft-fail). Suite 2941 green.

CHANGELOG reorganized under v0.25.0; ADR-011 marked Implemented. Version is git-tag-derived (setuptools-scm) — the tag push after merge triggers `publish.yml` → PyPI.

Open follow-ups (not blocking): #365 #366 #367 #370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)