### PR TITLE
fix(openrouter): request-time key + nullable content + tool-call preservation (#367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **OpenRouter gateway correctness (#367)** — (1) the API key is no longer frozen at import: `OpenRouterGateway` resolves it per-request via the ADR-013 chain, so a request-scoped BYOK key is honored (was silently bypassed); (2) null response `content` (e.g. a tool-call-only turn) is coerced to `""` so downstream never sees `None`; (3) `tool_calls`/`tool_call_id` are now propagated in message conversion instead of being silently dropped.
+
 ## [0.25.0] - 2026-07-01
 
 **Cost and token accounting (ADR-011)** — a four-phase epic ([#359](https://github.com/amiable-dev/llm-council/issues/359)) that makes LLM spend transparent and optimizable: capture & surfacing (Phase 1), OpenTelemetry-standard observability (Phase 2), cost-per-quality optimization (Phase 3), and an opt-in budget gate (Phase 4). Everything is additive and backward-compatible — new behaviour is opt-in or soft-fail, and the council never fails a request because of cost accounting.

--- a/src/llm_council/gateway/openrouter.py
+++ b/src/llm_council/gateway/openrouter.py
@@ -121,7 +121,10 @@ class OpenRouterGateway(BaseRouter):
             base_url: Base URL for OpenRouter API. If None, uses OPENROUTER_API_URL.
             default_timeout: Default request timeout in seconds.
         """
-        self._api_key = api_key or OPENROUTER_API_KEY
+        # Store only an EXPLICIT key here; when none is given, resolve
+        # per-request in _query_openrouter so a request-scoped BYOK key
+        # (ADR-013 ContextVar) is honored instead of a value frozen at import.
+        self._api_key = api_key
         self._base_url = base_url or OPENROUTER_API_URL
         self._default_timeout = default_timeout
         self._capabilities = RouterCapabilities(
@@ -155,6 +158,7 @@ class OpenRouterGateway(BaseRouter):
         # Check if we have any image content
         has_images = any(block.type == "image" for block in msg.content)
 
+        message: Dict[str, Any]
         if has_images:
             # Multi-part content for vision models
             content_parts = []
@@ -165,13 +169,21 @@ class OpenRouterGateway(BaseRouter):
                     content_parts.append(
                         {"type": "image_url", "image_url": {"url": block.image_url}}
                     )
-            return {"role": msg.role, "content": content_parts}
+            message = {"role": msg.role, "content": content_parts}
         else:
             # Simple text content
             text_content = " ".join(
                 block.text for block in msg.content if block.type == "text" and block.text
             )
-            return {"role": msg.role, "content": text_content}
+            message = {"role": msg.role, "content": text_content}
+
+        # Preserve tool-calling fields (OpenRouter/OpenAI carry these on the
+        # message, not in content blocks) — previously silently dropped.
+        if msg.tool_calls:
+            message["tool_calls"] = msg.tool_calls
+        if msg.tool_call_id:
+            message["tool_call_id"] = msg.tool_call_id
+        return message
 
     def _convert_messages(self, messages: List[CanonicalMessage]) -> List[Dict[str, Any]]:
         """Convert list of CanonicalMessages to OpenRouter format."""
@@ -202,8 +214,11 @@ class OpenRouterGateway(BaseRouter):
         Returns:
             Structured result dict with status, content, latency_ms, etc.
         """
+        # Resolve the key at request time (ADR-013 chain: request ContextVar →
+        # env → keychain → config) unless an explicit key was injected.
+        api_key = self._api_key or get_api_key("openrouter") or ""
         headers = {
-            "Authorization": f"Bearer {self._api_key}",
+            "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
         }
 
@@ -258,7 +273,9 @@ class OpenRouterGateway(BaseRouter):
 
                 return {
                     "status": "ok",
-                    "content": message.get("content"),
+                    # Content may be null (e.g. a tool-call-only assistant turn);
+                    # coerce to "" so downstream str handling never sees None.
+                    "content": message.get("content") or "",
                     "reasoning_details": message.get("reasoning_details"),
                     "latency_ms": latency_ms,
                     "usage": {

--- a/tests/test_gateway_openrouter.py
+++ b/tests/test_gateway_openrouter.py
@@ -289,13 +289,15 @@ class TestOpenRouterHealthCheck:
 class TestOpenRouterGatewayConfig:
     """Test OpenRouterGateway configuration."""
 
-    def test_gateway_uses_config_api_key(self):
-        """Gateway should use OPENROUTER_API_KEY from config."""
+    def test_gateway_defers_key_resolution_to_request_time(self):
+        """No explicit key must NOT be frozen at import (#367) — it is resolved
+        per-request via get_api_key so a request-scoped BYOK key is honored."""
         from llm_council.gateway.openrouter import OpenRouterGateway
 
         with patch("llm_council.gateway.openrouter.OPENROUTER_API_KEY", "test-key"):
             gateway = OpenRouterGateway()
-            assert gateway._api_key == "test-key"
+            # The import-time constant is no longer frozen into the instance.
+            assert gateway._api_key is None
 
     def test_gateway_allows_custom_api_key(self):
         """Gateway should accept custom API key."""

--- a/tests/test_openrouter_debt.py
+++ b/tests/test_openrouter_debt.py
@@ -1,0 +1,89 @@
+"""Regression tests for pre-existing openrouter gateway debt (#367)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import llm_council.gateway.openrouter as gw_mod
+from llm_council.gateway.openrouter import OpenRouterGateway
+from llm_council.gateway.types import CanonicalMessage, ContentBlock, GatewayRequest
+
+
+def _req(model="openai/gpt-4o"):
+    return GatewayRequest(
+        model=model,
+        messages=[CanonicalMessage(role="user", content=[ContentBlock(type="text", text="hi")])],
+    )
+
+
+def _resp(message_content="hi"):
+    r = MagicMock()
+    r.status_code = 200
+    r.raise_for_status = MagicMock()
+    r.json.return_value = {
+        "choices": [{"message": {"content": message_content}}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+    return r
+
+
+class TestRequestTimeKey:
+    async def test_key_resolved_at_request_time_honors_byok(self, monkeypatch):
+        # No explicit key -> resolve via get_api_key at REQUEST time (so a
+        # request-scoped BYOK key is honored, not a value frozen at import).
+        monkeypatch.setattr(gw_mod, "get_api_key", lambda p: "reqkey" if p == "openrouter" else None)
+        captured = {}
+
+        async def _post(url, headers=None, json=None):
+            captured["auth"] = headers["Authorization"]
+            return _resp()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(side_effect=_post)
+            await OpenRouterGateway().complete(_req())  # no explicit key
+
+        assert captured["auth"] == "Bearer reqkey"
+
+    async def test_explicit_key_takes_precedence(self, monkeypatch):
+        monkeypatch.setattr(gw_mod, "get_api_key", lambda p: "should-not-be-used")
+        captured = {}
+
+        async def _post(url, headers=None, json=None):
+            captured["auth"] = headers["Authorization"]
+            return _resp()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(side_effect=_post)
+            await OpenRouterGateway(api_key="explicit").complete(_req())
+
+        assert captured["auth"] == "Bearer explicit"
+
+
+class TestNullableContent:
+    async def test_null_content_coerced_to_empty_string(self, monkeypatch):
+        monkeypatch.setattr(gw_mod, "get_api_key", lambda p: "k")
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=_resp(message_content=None)
+            )
+            resp = await OpenRouterGateway().complete(_req())
+        assert resp.content == ""  # never None
+
+
+class TestToolCallPreservation:
+    def test_convert_message_preserves_tool_calls(self):
+        gw = OpenRouterGateway()
+        msg = CanonicalMessage(
+            role="assistant",
+            content=[ContentBlock(type="text", text="")],
+            tool_calls=[{"id": "1", "function": {"name": "f", "arguments": "{}"}}],
+            tool_call_id="tc1",
+        )
+        out = gw._convert_message(msg)
+        assert out["tool_calls"] == [{"id": "1", "function": {"name": "f", "arguments": "{}"}}]
+        assert out["tool_call_id"] == "tc1"
+
+    def test_convert_message_without_tools_has_no_tool_keys(self):
+        gw = OpenRouterGateway()
+        msg = CanonicalMessage(role="user", content=[ContentBlock(type="text", text="hi")])
+        out = gw._convert_message(msg)
+        assert "tool_calls" not in out
+        assert "tool_call_id" not in out


### PR DESCRIPTION
Child of epic #373. Fixes pre-existing `openrouter.py` gateway debt surfaced during the ADR-011 epic:

1. **Import-time API key → request-time** — `OpenRouterGateway` no longer freezes the key at import (bypassing request-scoped BYOK); it resolves per-request via the ADR-013 chain unless an explicit key is injected.
2. **Nullable content** — a null response `content` (e.g. tool-call-only turn) is coerced to `""`.
3. **Tool-call preservation** — `tool_calls`/`tool_call_id` are propagated in message conversion (were dropped).

6 new tests; suite 2946 green.

Closes #367. Epic: #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)