### PR TITLE
fix(performance): tracker correctness debt (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Performance tracker correctness (#370)** — (1) `get_quality_percentile` now excludes the model itself from its own ranking (self-inclusion inflated the rank by 1/N and biased the ADR-029 graduation gate); (2) `_calculate_decay_weight` docstring corrected — `decay_days` is an e-folding time-constant, not a half-life (behaviour unchanged); (3) documented the intentional 0–1 (`get_all_model_scores`) vs 0–100 (`get_quality_score`) scale split and the intentionally-unweighted parse-success rate.
 - **OpenRouter gateway correctness (#367)** — (1) the API key is no longer frozen at import: `OpenRouterGateway` resolves it per-request via the ADR-013 chain, so a request-scoped BYOK key is honored (was silently bypassed); (2) null response `content` (e.g. a tool-call-only turn) is coerced to `""` so downstream never sees `None`; (3) `tool_calls`/`tool_call_id` are now propagated in message conversion instead of being silently dropped.
 
 ## [0.25.0] - 2026-07-01

--- a/src/llm_council/performance/tracker.py
+++ b/src/llm_council/performance/tracker.py
@@ -82,11 +82,14 @@ def _determine_confidence_level(sample_size: int) -> str:
 def _calculate_decay_weight(timestamp: str, decay_days: int) -> float:
     """Calculate exponential decay weight based on age.
 
-    Weight = exp(-days_ago / decay_days)
+    Uses e-folding decay: ``weight = exp(-days_ago / decay_days)``, so a record
+    ``decay_days`` old has weight 1/e (~0.37). NOTE: ``decay_days`` is the decay
+    time-constant (mean lifetime), NOT a half-life — the half-life would be
+    ``decay_days * ln 2``.
 
     Args:
         timestamp: ISO 8601 timestamp string
-        decay_days: Half-life of decay in days
+        decay_days: Decay time-constant (e-folding lifetime) in days
 
     Returns:
         Weight between 0 and 1 (1 = most recent, approaching 0 = very old)
@@ -209,7 +212,9 @@ class InternalPerformanceTracker:
         # Weighted mean Borda score
         mean_borda = weighted_borda_sum / total_weight if total_weight > 0 else 0.5
 
-        # Parse success rate (unweighted - all samples count equally)
+        # Parse success rate: intentionally UNWEIGHTED (unlike decay-weighted
+        # Borda) — it is a reliability metric where every historical failure
+        # should count in full, not be discounted by age.
         parse_success_rate = parse_success_count / sample_size if sample_size > 0 else 1.0
 
         # Latency percentiles
@@ -301,6 +306,11 @@ class InternalPerformanceTracker:
         Reads all records and returns mean Borda scores for models
         with at least 10 samples (PRELIMINARY confidence).
 
+        Scale note: this returns the raw mean Borda on a **0–1** scale (used by
+        the percentile math), whereas ``get_quality_score`` returns a **0–100**
+        selection score. The two scales are intentional and must not be compared
+        directly.
+
         Returns:
             Dict mapping model_id to mean Borda score (0-1)
         """
@@ -359,9 +369,11 @@ class InternalPerformanceTracker:
         if len(all_scores) == 1:
             return 1.0
 
-        # Calculate percentile: fraction of models this model beats or ties
-        scores_list = list(all_scores.values())
-        beaten_or_tied = sum(1 for s in scores_list if target_score >= s)
-        percentile = beaten_or_tied / len(scores_list)
-
-        return percentile
+        # Percentile = fraction of OTHER models this model beats or ties.
+        # Excluding self matters: including it always adds a self-tie, inflating
+        # the rank by 1/N and biasing the ADR-029 graduation gate upward.
+        others = [score for other_id, score in all_scores.items() if other_id != model_id]
+        if not others:
+            return 1.0
+        beaten_or_tied = sum(1 for s in others if target_score >= s)
+        return beaten_or_tied / len(others)

--- a/src/llm_council/performance/tracker.py
+++ b/src/llm_council/performance/tracker.py
@@ -124,7 +124,7 @@ class InternalPerformanceTracker:
 
     Attributes:
         store_path: Path to JSONL storage file
-        decay_days: Half-life for exponential decay weighting
+        decay_days: e-folding decay time-constant in days (NOT a half-life)
     """
 
     def __init__(
@@ -137,8 +137,8 @@ class InternalPerformanceTracker:
         Args:
             store_path: Path to JSONL file for storing metrics.
                        Defaults to ~/.llm-council/performance_metrics.jsonl
-            decay_days: Half-life for decay weighting. Sessions older than
-                       decay_days have reduced weight. Default: 30 days.
+            decay_days: e-folding decay time-constant in days (NOT a half-life);
+                       a session decay_days old has weight 1/e. Default: 30 days.
         """
         self.store_path = store_path or DEFAULT_STORE_PATH
         self.decay_days = decay_days

--- a/tests/test_tracker_debt.py
+++ b/tests/test_tracker_debt.py
@@ -1,0 +1,31 @@
+"""Regression tests for pre-existing tracker debt (#370)."""
+
+import pytest
+
+from llm_council.performance.tracker import InternalPerformanceTracker
+
+
+def _tracker(tmp_path, scores):
+    t = InternalPerformanceTracker(store_path=tmp_path / "perf.jsonl")
+    t.get_all_model_scores = lambda: scores  # type: ignore[method-assign]
+    return t
+
+
+class TestPercentileSelfExclusion:
+    def test_excludes_self_from_ranking(self, tmp_path):
+        # B=0.5 ranked among OTHERS {A:0.9, C:0.4, D:0.3}: beats C,D -> 2/3.
+        # (Self-inclusive would wrongly give 3/4 = 0.75.)
+        t = _tracker(tmp_path, {"A": 0.9, "B": 0.5, "C": 0.4, "D": 0.3})
+        assert t.get_quality_percentile("B") == pytest.approx(2 / 3)
+
+    def test_top_model_is_100th_percentile(self, tmp_path):
+        t = _tracker(tmp_path, {"A": 0.9, "B": 0.5, "C": 0.4})
+        assert t.get_quality_percentile("A") == pytest.approx(1.0)
+
+    def test_single_model_is_top(self, tmp_path):
+        t = _tracker(tmp_path, {"only": 0.5})
+        assert t.get_quality_percentile("only") == 1.0
+
+    def test_unknown_model_returns_none(self, tmp_path):
+        t = _tracker(tmp_path, {"A": 0.9})
+        assert t.get_quality_percentile("missing") is None


### PR DESCRIPTION
Child of epic #373. Fixes pre-existing `performance/tracker.py` debt:

1. **Self-inclusive percentile** — `get_quality_percentile` now excludes the model from its own ranking (self-inclusion inflated rank by 1/N, biasing the ADR-029 graduation gate). **Real logic fix.**
2. **Half-life naming** — `_calculate_decay_weight` docstring corrected: `decay_days` is an e-folding time-constant, not a half-life (behaviour unchanged).
3. **Scale + decay docs** — documented the intentional 0–1 vs 0–100 scale split and the intentionally-unweighted parse-success rate.

4 new tests; suite 2950 green.

Closes #370. Epic: #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)