### PR TITLE
fix(reasoning): thread reasoning_params through query_models_with_progress (#365)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`reasoning_params` no longer dropped in `query_models_with_progress` (#365)** — the progress-callback query path (used by the council) now threads `reasoning_params` through to each model call, matching `query_models_parallel` and the gateway path (ADR-026). Reasoning-effort injection was previously silently lost on this path.
 - **Performance tracker correctness (#370)** — (1) `get_quality_percentile` now excludes the model itself from its own ranking (self-inclusion inflated the rank by 1/N and biased the ADR-029 graduation gate); (2) `_calculate_decay_weight` docstring corrected — `decay_days` is an e-folding time-constant, not a half-life (behaviour unchanged); (3) documented the intentional 0–1 (`get_all_model_scores`) vs 0–100 (`get_quality_score`) scale split and the intentionally-unweighted parse-success rate.
 - **OpenRouter gateway correctness (#367)** — (1) the API key is no longer frozen at import: `OpenRouterGateway` resolves it per-request via the ADR-013 chain, so a request-scoped BYOK key is honored (was silently bypassed); (2) null response `content` (e.g. a tool-call-only turn) is coerced to `""` so downstream never sees `None`; (3) `tool_calls`/`tool_call_id` are now propagated in message conversion instead of being silently dropped.
 

--- a/src/llm_council/openrouter.py
+++ b/src/llm_council/openrouter.py
@@ -23,6 +23,18 @@ def _get_openrouter_api_key() -> str:
 # Module-level alias for backwards compatibility with tests
 OPENROUTER_API_KEY = _get_openrouter_api_key()
 
+
+def _extract_cached_tokens(usage: Dict[str, Any]) -> int:
+    """Cached prompt tokens from an OpenRouter usage object (0 if absent).
+
+    Explicit None-check so a genuine reported 0 isn't discarded by a truthiness
+    short-circuit (#365 review).
+    """
+    direct = usage.get("cached_tokens")
+    if direct is not None:
+        return direct
+    return (usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0) or 0
+
 if TYPE_CHECKING:
     from llm_council.gateway.types import ReasoningParams
 
@@ -152,11 +164,7 @@ async def query_model_with_status(
                     # inline; capture it (previously discarded) so the council
                     # can account cost, not just tokens.
                     "cost": usage.get("cost"),
-                    "cached_tokens": (
-                        usage.get("cached_tokens")
-                        or (usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0)
-                        or 0
-                    ),
+                    "cached_tokens": _extract_cached_tokens(usage),
                 },
             }
 

--- a/src/llm_council/openrouter.py
+++ b/src/llm_council/openrouter.py
@@ -227,6 +227,7 @@ async def query_models_with_progress(
     on_progress: Optional[ProgressCallback] = None,
     timeout: float = 25.0,
     disable_tools: bool = False,
+    reasoning_params: Optional["ReasoningParams"] = None,
     shared_results: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> Dict[str, Dict[str, Any]]:
     """
@@ -238,6 +239,8 @@ async def query_models_with_progress(
         on_progress: Async callback(completed, total, message) for progress updates
         timeout: Per-model timeout in seconds (default 25s per ADR-012)
         disable_tools: If True, disable tool/function calling for all queries
+        reasoning_params: Optional reasoning parameters for reasoning models
+            (ADR-026) — previously dropped on this path (#365)
         shared_results: Optional dict to populate incrementally. If provided, results
             are written here as each model completes, preserving state even if the
             function is cancelled by an outer timeout. This fixes ADR-012 diagnostic
@@ -258,7 +261,11 @@ async def query_models_with_progress(
     # Create tasks with model tracking
     async def query_with_tracking(model: str) -> tuple[str, Dict[str, Any]]:
         result = await query_model_with_status(
-            model, messages, timeout=timeout, disable_tools=disable_tools
+            model,
+            messages,
+            timeout=timeout,
+            disable_tools=disable_tools,
+            reasoning_params=reasoning_params,
         )
         return model, result
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -386,7 +386,7 @@ async def test_shared_results_populated_incrementally():
     """Test that query_models_with_progress populates shared_results as models complete."""
     from llm_council.openrouter import STATUS_OK, query_models_with_progress
 
-    async def mock_query(model, messages, timeout=None, disable_tools=False):
+    async def mock_query(model, messages, timeout=None, disable_tools=False, reasoning_params=None):
         return {
             "status": STATUS_OK,
             "content": f"Response from {model}",

--- a/tests/test_openrouter_cost.py
+++ b/tests/test_openrouter_cost.py
@@ -88,3 +88,14 @@ async def test_null_prompt_tokens_details_does_not_crash():
 
     assert result["status"] == STATUS_OK
     assert result["usage"]["cached_tokens"] == 0
+
+
+def test_extract_cached_tokens_keeps_reported_zero():
+    from llm_council.openrouter import _extract_cached_tokens
+
+    # A genuine reported 0 must NOT fall through to the details lookup.
+    assert _extract_cached_tokens({"cached_tokens": 0, "prompt_tokens_details": {"cached_tokens": 9}}) == 0
+    # Absent -> fall back to details, then 0.
+    assert _extract_cached_tokens({"prompt_tokens_details": {"cached_tokens": 5}}) == 5
+    assert _extract_cached_tokens({}) == 0
+    assert _extract_cached_tokens({"prompt_tokens_details": None}) == 0

--- a/tests/test_reasoning_progress_365.py
+++ b/tests/test_reasoning_progress_365.py
@@ -1,0 +1,35 @@
+"""query_models_with_progress forwards reasoning_params (ADR-026, #365)."""
+
+import pytest
+
+from llm_council.gateway.types import ReasoningParams
+from llm_council.openrouter import query_models_with_progress
+
+
+@pytest.mark.asyncio
+async def test_forwards_reasoning_params_to_each_model(monkeypatch):
+    rp = ReasoningParams(effort="high", max_tokens=1000)
+    captured = {}
+
+    async def _fake_status(model, messages, timeout=120.0, disable_tools=False, reasoning_params=None):
+        captured[model] = reasoning_params
+        return {"status": "ok", "content": "x", "latency_ms": 1, "usage": {}}
+
+    monkeypatch.setattr("llm_council.openrouter.query_model_with_status", _fake_status)
+    await query_models_with_progress(
+        ["m1", "m2"], [{"role": "user", "content": "hi"}], reasoning_params=rp
+    )
+    assert captured == {"m1": rp, "m2": rp}
+
+
+@pytest.mark.asyncio
+async def test_none_reasoning_params_still_works(monkeypatch):
+    captured = {}
+
+    async def _fake_status(model, messages, timeout=120.0, disable_tools=False, reasoning_params=None):
+        captured[model] = reasoning_params
+        return {"status": "ok", "content": "x", "latency_ms": 1, "usage": {}}
+
+    monkeypatch.setattr("llm_council.openrouter.query_model_with_status", _fake_status)
+    await query_models_with_progress(["m1"], [{"role": "user", "content": "hi"}])
+    assert captured["m1"] is None


### PR DESCRIPTION
Child of epic #373. `query_models_with_progress` (the council's progress-callback path) dropped `reasoning_params`, silently losing reasoning-effort injection — inconsistent with `query_models_parallel` and the gateway path (ADR-026). Now threaded through to each `query_model_with_status` call.

2 new tests; suite 2952 green.

Closes #365. Epic: #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)