### PR TITLE
feat(cost): surface token/cost in VerifyResponse.input_metrics (#366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Token/cost in `VerifyResponse` (ADR-011 Phase 2 follow-up, #366)** — `verify` now surfaces per-run token and cost totals (`prompt_tokens`, `completion_tokens`, `total_tokens`, `cost_usd`, `cost_known`, `cached_tokens`) under `input_metrics`, sourced from the council usage summary. `cost_known` distinguishes a genuine $0 from unknown cost; the fields are omitted entirely when usage is unavailable.
+
 ### Fixed
 
 - **`reasoning_params` no longer dropped in `query_models_with_progress` (#365)** — the progress-callback query path (used by the council) now threads `reasoning_params` through to each model call, matching `query_models_parallel` and the gateway path (ADR-026). Reasoning-effort injection was previously silently lost on this path.

--- a/src/llm_council/verification/api.py
+++ b/src/llm_council/verification/api.py
@@ -806,6 +806,27 @@ def _build_evidence_section(
     )
 
 
+def _usage_input_metrics(usage: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """ADR-011 (#366): per-run token/cost totals for VerifyResponse.input_metrics.
+
+    Reads the council usage summary's grand total (from ``partial_state["usage"]``).
+    Returns an empty dict when usage is unavailable, so the field is simply
+    absent rather than reporting phantom zeros. ``cost_known`` distinguishes a
+    genuine $0 from unknown cost.
+    """
+    total = (usage or {}).get("total") or {}
+    if not total:
+        return {}
+    return {
+        "prompt_tokens": total.get("prompt_tokens", 0),
+        "completion_tokens": total.get("completion_tokens", 0),
+        "total_tokens": total.get("total_tokens", 0),
+        "cost_usd": total.get("cost_usd", 0.0),
+        "cost_known": bool(total.get("cost_known", False)),
+        "cached_tokens": total.get("cached_tokens", 0),
+    }
+
+
 def _evidence_input_metrics(
     request_evidence: Optional[List[EvidenceItem]],
     render_info: Optional[Dict[str, Any]],
@@ -2015,6 +2036,8 @@ async def _run_verification_pipeline(
         "num_models": num_models,
         "num_reviewers": num_models,
         "tier": request.tier,
+        # ADR-011 (#366): per-run token/cost totals (absent if usage unavailable).
+        **_usage_input_metrics(partial_state.get("usage")),
         # ADR-042: evidence-specific input metrics.
         **_evidence_input_metrics(
             request.evidence,

--- a/tests/test_verify_cost_366.py
+++ b/tests/test_verify_cost_366.py
@@ -1,0 +1,34 @@
+"""VerifyResponse.input_metrics surfaces token/cost totals (ADR-011 #366)."""
+
+from llm_council.verification.api import _usage_input_metrics
+
+
+def test_reads_grand_total():
+    usage = {
+        "total": {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+            "cost_usd": 0.02,
+            "cost_known": True,
+            "cached_tokens": 5,
+        }
+    }
+    m = _usage_input_metrics(usage)
+    assert m["prompt_tokens"] == 100
+    assert m["completion_tokens"] == 50
+    assert m["total_tokens"] == 150
+    assert m["cost_usd"] == 0.02
+    assert m["cost_known"] is True
+    assert m["cached_tokens"] == 5
+
+
+def test_empty_when_usage_absent():
+    assert _usage_input_metrics(None) == {}
+    assert _usage_input_metrics({}) == {}
+    assert _usage_input_metrics({"total": {}}) == {}
+
+
+def test_cost_known_false_for_unknown_cost():
+    m = _usage_input_metrics({"total": {"total_tokens": 10, "cost_usd": 0.0}})
+    assert m["cost_known"] is False  # no phantom "known $0"


### PR DESCRIPTION
Child of epic #373 (final). Completes the ADR-011 Phase 2 follow-up: `verify` surfaces per-run token/cost totals under `input_metrics` (prompt/completion/total tokens, `cost_usd`, `cost_known`, `cached_tokens`), read from the usage summary staged in `partial_state` (Phase 3). `cost_known` distinguishes a genuine $0 from unknown; fields omitted when usage unavailable.

Additive — makes the follow-up release **minor**. 3 new tests; suite 2956 green.

Closes #366. Epic: #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)