### PR TITLE
Release v0.26.0 — ADR-011 follow-ups & tech-debt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-07-02
+
+Follow-up & tech-debt cleanup from the ADR-011 cost-accounting epic (batched as [#373](https://github.com/amiable-dev/llm-council/issues/373)): one additive enhancement (token/cost in `VerifyResponse`) plus correctness fixes to the OpenRouter gateway, the performance tracker, and the reasoning path.
+
 ### Added
 
 - **Token/cost in `VerifyResponse` (ADR-011 Phase 2 follow-up, #366)** — `verify` now surfaces per-run token and cost totals (`prompt_tokens`, `completion_tokens`, `total_tokens`, `cost_usd`, `cost_known`, `cached_tokens`) under `input_metrics`, sourced from the council usage summary. `cost_known` distinguishes a genuine $0 from unknown cost; the fields are omitted entirely when usage is unavailable.


### PR DESCRIPTION
Release **v0.26.0** — completes the follow-up epic #373.

- **Added** #366 — token/cost totals in `VerifyResponse.input_metrics` (additive → minor)
- **Fixed** #367 — OpenRouter request-time key (BYOK), nullable content, tool-call preservation
- **Fixed** #370 — performance tracker: percentile self-exclusion + decay/scale docs
- **Fixed** #365 — `reasoning_params` threaded through `query_models_with_progress`

Suite 2956 green. Version is git-tag-derived — tag push after merge triggers `publish.yml` → PyPI.

Remaining tracked debt (not blocking): #375, #377, #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)