### PR TITLE
fix(gateway): surface reasoning_details + real SSE streaming (#375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **OpenRouter gateway: reasoning trace + real streaming (#375)** — `GatewayResponse` now carries `reasoning_details` (o1/o3/deepseek-r1 reasoning traces were captured but dropped on the gateway path), and `complete_stream` now performs a true SSE stream yielding incremental content deltas instead of buffering the whole response into one chunk.
 - **Performance tracker minor debt (#377)** — `record_session` now stamps its `session_id` onto every metric as the authoritative id (the parameter was previously unused); clarified that `get_quality_score`'s 0–100 scale (selection-facing) vs `get_all_model_scores`' 0–1 scale (percentile math) is intentional, and that latency percentiles are intentionally unweighted.
 
 ## [0.26.0] - 2026-07-02

--- a/src/llm_council/gateway/openrouter.py
+++ b/src/llm_council/gateway/openrouter.py
@@ -399,6 +399,16 @@ class OpenRouterGateway(BaseRouter):
             async with client.stream(
                 "POST", self._base_url, headers=headers, json=payload
             ) as response:
+                # Surface HTTP errors instead of silently parsing an error body
+                # as SSE (which would yield nothing).
+                if response.status_code >= 400:
+                    body = await response.aread()
+                    detail = body.decode("utf-8", "replace")[:200]
+                    raise httpx.HTTPStatusError(
+                        f"OpenRouter streaming failed ({response.status_code}): {detail}",
+                        request=response.request,
+                        response=response,
+                    )
                 async for line in response.aiter_lines():
                     if not line or not line.startswith("data:"):
                         continue

--- a/src/llm_council/gateway/openrouter.py
+++ b/src/llm_council/gateway/openrouter.py
@@ -7,6 +7,7 @@ The gateway wraps the existing openrouter module functionality while
 conforming to the BaseRouter interface.
 """
 
+import json
 import time
 from datetime import datetime
 from typing import AsyncIterator, Dict, Any, List, Optional
@@ -362,26 +363,55 @@ class OpenRouterGateway(BaseRouter):
             latency_ms=result.get("latency_ms"),
             error=result.get("error"),
             retry_after=result.get("retry_after"),
+            # #375: surface the reasoning trace instead of dropping it.
+            reasoning_details=result.get("reasoning_details"),
         )
 
     async def complete_stream(self, request: GatewayRequest) -> AsyncIterator[str]:
-        """Send a streaming completion request.
+        """Send a streaming completion request, yielding content deltas.
+
+        Uses OpenRouter's SSE stream (#375): each `data:` line carries a JSON
+        chunk whose `choices[0].delta.content` is the incremental text. Malformed
+        chunks are skipped; the stream ends on `data: [DONE]`.
 
         Args:
             request: The gateway request with model and messages.
 
         Yields:
-            String chunks of the generated content.
-
-        Note:
-            Streaming is not yet fully implemented. This yields the complete
-            response as a single chunk for now.
+            Incremental string chunks of the generated content.
         """
-        # For now, just yield the complete response
-        # Full streaming implementation can be added later
-        response = await self.complete(request)
-        if response.content:
-            yield response.content
+        api_key = self._api_key or get_api_key("openrouter") or ""
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = build_openrouter_payload(
+            model=request.model,
+            messages=self._convert_messages(request.messages),
+            reasoning_params=request.reasoning_params,
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+        )
+        payload["stream"] = True
+        timeout = request.timeout if request.timeout is not None else self._default_timeout
+
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            async with client.stream(
+                "POST", self._base_url, headers=headers, json=payload
+            ) as response:
+                async for line in response.aiter_lines():
+                    if not line or not line.startswith("data:"):
+                        continue
+                    data = line[len("data:") :].strip()
+                    if data == "[DONE]":
+                        break
+                    try:
+                        chunk = json.loads(data)
+                        delta = chunk["choices"][0]["delta"].get("content")
+                    except (json.JSONDecodeError, KeyError, IndexError, TypeError):
+                        continue
+                    if delta:
+                        yield delta
 
     async def health_check(self) -> RouterHealth:
         """Check the health of this router.

--- a/src/llm_council/gateway/types.py
+++ b/src/llm_council/gateway/types.py
@@ -130,3 +130,5 @@ class GatewayResponse:
     latency_ms: Optional[int] = None
     error: Optional[str] = None
     retry_after: Optional[int] = None  # For rate limiting
+    # Provider reasoning trace (o1/o3/deepseek-r1 etc.), when returned (#375).
+    reasoning_details: Optional[Any] = None

--- a/tests/test_openrouter_debt.py
+++ b/tests/test_openrouter_debt.py
@@ -87,3 +87,74 @@ class TestToolCallPreservation:
         out = gw._convert_message(msg)
         assert "tool_calls" not in out
         assert "tool_call_id" not in out
+
+
+class TestReasoningDetailsSurfaced:
+    async def test_complete_surfaces_reasoning_details(self):
+        gw = OpenRouterGateway()
+        fake = {
+            "status": "ok",
+            "content": "answer",
+            "latency_ms": 10,
+            "reasoning_details": [{"type": "reasoning", "text": "thinking..."}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+        with patch.object(gw, "_query_openrouter", new=AsyncMock(return_value=fake)):
+            resp = await gw.complete(_req())
+        assert resp.reasoning_details == [{"type": "reasoning", "text": "thinking..."}]
+
+
+class _FakeStream:
+    def __init__(self, lines):
+        self._lines = lines
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+
+class _FakeClient:
+    def __init__(self, lines):
+        self._lines = lines
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    def stream(self, method, url, headers=None, json=None):
+        return _FakeStream(self._lines)
+
+
+class TestTrueStreaming:
+    async def test_yields_content_deltas(self, monkeypatch):
+        monkeypatch.setattr(gw_mod, "get_api_key", lambda p: "k")
+        lines = [
+            'data: {"choices":[{"delta":{"content":"Hel"}}]}',
+            'data: {"choices":[{"delta":{"content":"lo"}}]}',
+            "data: [DONE]",
+            'data: {"choices":[{"delta":{"content":"IGNORED"}}]}',
+        ]
+        with patch("httpx.AsyncClient", return_value=_FakeClient(lines)):
+            chunks = [c async for c in OpenRouterGateway().complete_stream(_req())]
+        assert chunks == ["Hel", "lo"]  # stops at [DONE], skips nothing else
+
+    async def test_skips_malformed_and_empty_lines(self, monkeypatch):
+        monkeypatch.setattr(gw_mod, "get_api_key", lambda p: "k")
+        lines = [
+            "",
+            ": comment",
+            "data: not-json",
+            'data: {"choices":[{"delta":{}}]}',  # no content
+            'data: {"choices":[{"delta":{"content":"ok"}}]}',
+        ]
+        with patch("httpx.AsyncClient", return_value=_FakeClient(lines)):
+            chunks = [c async for c in OpenRouterGateway().complete_stream(_req())]
+        assert chunks == ["ok"]

--- a/tests/test_openrouter_debt.py
+++ b/tests/test_openrouter_debt.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 import llm_council.gateway.openrouter as gw_mod
 from llm_council.gateway.openrouter import OpenRouterGateway
 from llm_council.gateway.types import CanonicalMessage, ContentBlock, GatewayRequest
@@ -105,8 +107,10 @@ class TestReasoningDetailsSurfaced:
 
 
 class _FakeStream:
-    def __init__(self, lines):
+    def __init__(self, lines, status_code=200):
         self._lines = lines
+        self.status_code = status_code
+        self.request = MagicMock()
 
     async def __aenter__(self):
         return self
@@ -118,10 +122,14 @@ class _FakeStream:
         for line in self._lines:
             yield line
 
+    async def aread(self):
+        return b"error body"
+
 
 class _FakeClient:
-    def __init__(self, lines):
+    def __init__(self, lines, status_code=200):
         self._lines = lines
+        self._status_code = status_code
 
     async def __aenter__(self):
         return self
@@ -130,7 +138,7 @@ class _FakeClient:
         return False
 
     def stream(self, method, url, headers=None, json=None):
-        return _FakeStream(self._lines)
+        return _FakeStream(self._lines, self._status_code)
 
 
 class TestTrueStreaming:
@@ -158,3 +166,14 @@ class TestTrueStreaming:
         with patch("httpx.AsyncClient", return_value=_FakeClient(lines)):
             chunks = [c async for c in OpenRouterGateway().complete_stream(_req())]
         assert chunks == ["ok"]
+
+
+class TestStreamingErrorHandling:
+    async def test_http_error_raises_not_silent(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(gw_mod, "get_api_key", lambda p: "k")
+        with patch("httpx.AsyncClient", return_value=_FakeClient([], status_code=500)):
+            with pytest.raises(httpx.HTTPStatusError):
+                async for _ in OpenRouterGateway().complete_stream(_req()):
+                    pass


### PR DESCRIPTION
Child of epic #382.
- **reasoning_details** — `GatewayResponse` now carries it; the OpenRouter gateway captured the reasoning trace but dropped it (no field + `complete()` didn't pass it). Correctness fix (data loss).
- **True streaming** — `complete_stream` now does a real SSE stream (yields incremental `delta.content`, stops on `[DONE]`, skips malformed chunks) instead of buffering into one chunk.

3 new tests; suite 2961 green.

Closes #375. Epic: #382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)