### PR TITLE
feat(routing): ADR-044 P1 — performance-aware selection blending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Performance-aware model selection (ADR-044 Phase 1, #390)** — the internal performance index (ADR-026 P3, previously write-only) now optionally blends into candidate quality scores during tier selection: `w·live + (1−w)·static` with `w` stepped by the index's confidence tier (0.3/0.6/0.8; cold start stays fully static). **Default OFF** (`LLM_COUNCIL_PERFORMANCE_SELECTION`); flag-off behaviour is byte-identical. When blending changes the selected model set, an auditable `L2_PERFORMANCE_SELECTION_APPLIED` LayerEvent records the static vs blended selections (route receipt). Soft-fail: tracker errors never affect selection.
+
 ## [0.27.1] - 2026-07-02
 
 Tech-debt cleanup, part 2 (epic #382): internal perf + a scoring fix for the opt-in cost-aware ranking, and the `verification/api.py` module split — no public API changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,9 @@ Evaluation & scoring
 - `evaluation.py`, `quality/`, `verdict.py`, `dissent.py` — additional evaluation/quality surfaces.
 - `gateway/` (ADR-030) — `EnhancedCircuitBreaker` (sliding-window failure rate, default 25% over 10-min window, 30-min cooldown, half-open probes) + per-model registry that emits `L4_CIRCUIT_BREAKER_OPEN/CLOSE`. `scoring.py` — cost-scoring algorithms (linear/log_ratio/exponential).
 
+Compute-optimal deliberation (ADR-044, Phase 1)
+- `metadata/selection.py` `_blend_quality_with_performance` — opt-in (`LLM_COUNCIL_PERFORMANCE_SELECTION`) blend of the live index (`mean_borda_score`) into static quality, weighted by confidence tier (PRELIMINARY 0.3 / MODERATE 0.6 / HIGH 0.8, cap 0.8; INSUFFICIENT→static). `select_tier_models` compares static vs blended selections and emits `L2_PERFORMANCE_SELECTION_APPLIED` only when the set changed (route receipt). Soft-fail; flag-off is byte-identical.
+
 Cost & token accounting (ADR-011, Phase 1–4)
 - `budget/` (Phase 4) — **opt-in** budget enforcement, DEFAULT OFF. `CostEstimator` pre-query estimate (low/expected/high) from per-model cost history; `BudgetEnforcer` tiered `pre_query_check` (STRICT/BALANCED/PERMISSIVE) + `mid_query_check` (abort *gracefully* between stages, never mid-completion). Every reject/warn/abort emits an auditable `L1_BUDGET_DECISION` LayerEvent — budget never causes a silent tier change (ADR-024). Enable via `LLM_COUNCIL_BUDGET_ENFORCEMENT=true` + `LLM_COUNCIL_BUDGET_MODE`; wire at the L1 entry (module + hook, not in the hot path by default).
 - `performance/` (Phase 3) — `ModelSessionMetric.cost_usd` + `ModelPerformanceIndex.mean_cost_usd`/`.quality_per_cost` (Borda-per-dollar). `tracker.get_cost_per_quality` and `get_all_cost_aware_scores` provide an **opt-in** cost-aware ranking — `get_all_cost_aware_scores` is identical to `get_all_model_scores` unless `LLM_COUNCIL_COST_AWARE_SELECTION=true`, and is the SOLE path by which cost may influence selection (audited). `persist_session_performance_data` records per-model cost from the council's `usage.by_model` (only when `cost_known`).
@@ -98,6 +101,7 @@ Single Pydantic source of truth consolidating ADR-020/022/023/026/030/031. Prior
 | Var | Effect |
 |---|---|
 | `LLM_COUNCIL_MODELS` | Override council members |
+| `LLM_COUNCIL_PERFORMANCE_SELECTION` | ADR-044 P1: blend the live performance index into model selection (default off; auditable route receipt on change) |
 | `LLM_COUNCIL_MODEL_INTELLIGENCE=true` | Enable dynamic model selection (ADR-026) |
 | `LLM_COUNCIL_OFFLINE=true` | Force offline / static provider |
 | `LLM_COUNCIL_DISCOVERY_ENABLED` / `_INTERVAL` (300) / `_MIN_CANDIDATES` (3) | Background discovery (ADR-028) |

--- a/docs/adr/ADR-044-compute-optimal-deliberation.md
+++ b/docs/adr/ADR-044-compute-optimal-deliberation.md
@@ -1,0 +1,151 @@
+# ADR-044: Compute-Optimal Deliberation
+
+**Status:** Draft 2026-07-02
+**Date:** 2026-07-02
+**Decision Makers:** Chris Joseph, LLM Council
+**Related:** ADR-026 (Phase 3 — the index this wires in), ADR-011 (Phase 3 — cost-per-quality), ADR-040 (Options E/F), ADR-020 (Tier-1 fast path), ADR-024 (layer sovereignty), ADR-036 (CSS)
+**Supersedes:** ADR-039 (LLMRouter — external router no longer needed), ADR-043 (Pareto Router — folded in as an optional pool source)
+
+---
+
+## Context
+
+### The write-only index
+
+The internal performance index (ADR-026 Phase 3) records per-model, per-session
+quality (Borda), latency, parse success, and — since v0.25.0 (ADR-011 Phase 3) —
+**cost**, deriving a Borda-per-dollar `quality_per_cost` signal with an opt-in
+cost-aware ranking (`get_all_cost_aware_scores`, `LLM_COUNCIL_COST_AWARE_SELECTION`).
+
+**None of it influences selection.** Verified 2026-07-02: `metadata/selection.py`
+scores candidates purely from *static* metadata (`calculate_model_score`,
+`_estimate_quality_score` → registry benchmarks), with zero references to
+`InternalPerformanceTracker`. Two epics of telemetry (v0.25.x–v0.27.x) are a
+dormant asset. ADR-040's Options E (tiered Stage 2) and F (early consensus
+termination) were deferred "pending observability data" — that data now exists
+(ADR-041 timing + ADR-011 cost).
+
+### The field (July 2026)
+
+- **Learned routing/cascades**: RouteLLM-class routers cut ~85% of cost while
+  retaining ~95% of top-model quality; production gateways report 30–50% spend
+  reduction from routing alone.
+- **Compute-optimal test-time scaling**: spending inference compute adaptively
+  (more deliberation only where the query needs it) dominates fixed-depth
+  strategies; heterogeneous-model ensembles are explicitly called out as
+  underexplored — this project is one.
+- **Route auditability** ("route receipts") is emerging as a trust requirement —
+  aligning with ADR-024's explicit/auditable-escalation principle.
+
+### Why the drafts die
+
+ADR-039 (NVIDIA LLMRouter) and ADR-043 (OpenRouter Pareto) both outsourced
+routing intelligence to external dependencies. With the in-house index now
+carrying real quality/latency/cost history per model, an internal, auditable
+wiring is simpler, offline-capable (Sovereign Orchestrator, ADR-026), and keeps
+the routing signal aligned with the council's own Borda ground truth rather
+than a third party's benchmark. ADR-039 is superseded outright; ADR-043's
+`openrouter/pareto-code` remains available as an ordinary pool entry if wanted.
+
+## Decision
+
+Make deliberation **compute-optimal** in three opt-in, individually-shippable
+phases. Sovereignty guardrail (ADR-024): every behaviour below is **default
+OFF**, flag-gated, emits an auditable `LayerEvent` when it changes an outcome,
+and soft-fails to today's behaviour on any error. Cost/quality history may
+influence routing **only** through these audited paths.
+
+### Phase 1 — Performance-aware selection (ADR-026 P3 completion)
+
+Blend the live index into candidate scoring in `metadata/selection.py`:
+
+- `_estimate_quality_score` consults `InternalPerformanceTracker` when the
+  model's `confidence_level` is ≥ PRELIMINARY (≥10 samples): blend
+  `live = tracker score`, `static = registry estimate` as
+  `w·live + (1−w)·static`, with `w` stepping up by confidence tier
+  (PRELIMINARY 0.3, MODERATE 0.6, HIGH 0.8). INSUFFICIENT → static only
+  (cold-start safe).
+- When `LLM_COUNCIL_COST_AWARE_SELECTION=true` (the existing ADR-011 flag),
+  the blended quality feeds the cost-aware ranking so value-for-money
+  reorders within the quality span (cohort-floor rule from v0.27.1 applies).
+- Master flag: `LLM_COUNCIL_PERFORMANCE_SELECTION` (default **false**).
+- Emit `L2_PERFORMANCE_SELECTION_APPLIED` LayerEvent whenever blending
+  changes the selected set vs. static-only (auditable route receipt).
+
+### Phase 2 — Early consensus termination (ADR-040 Option F)
+
+In `stage2_collect_rankings`, when the Borda margin of the leader is
+**mathematically unassailable** given the reviewers still outstanding
+(worst-case remaining votes cannot change the top ranking), cancel the
+outstanding reviewer calls and proceed to Stage 3.
+
+- Flag: `LLM_COUNCIL_EARLY_CONSENSUS` (default **false**).
+- Never cancels a call already in flight past its first token where the
+  gateway cannot cancel cleanly; cancellation is cooperative (asyncio).
+- Emits `L3_EARLY_CONSENSUS_TERMINATION` with votes-saved + est. cost saved
+  (from ADR-011 per-model history).
+- Shadow mode first: when the flag is off, still *detect and log* the
+  would-have-terminated point so savings are measurable before enabling.
+
+### Phase 3 — Graduated deliberation depth (cascade)
+
+Extend the ADR-020 Tier-1 confidence-gated fast path from binary
+(single model vs. full council) to graduated depth:
+
+- Depth ladder: `single → mini-council (2–3) → full council`.
+- Escalation signal: Consensus Strength Score (ADR-036 CSS) + verdict
+  confidence from the shallower pass; low consensus ⇒ escalate one rung,
+  reusing the already-collected responses as Stage-1 members of the deeper
+  pass (no wasted spend).
+- Budget integration: the ADR-011 estimator prices each rung; the opt-in
+  `BudgetEnforcer` can veto an escalation (auditable WARN/REJECT, never a
+  silent downgrade).
+- Flag: `LLM_COUNCIL_GRADUATED_DEPTH` (default **false**).
+- Escalations emit the existing `L2_DELIBERATION_ESCALATION` event.
+
+### ADR housekeeping
+
+Mark ADR-039 and ADR-043 **Superseded by ADR-044**; ADR-040 Options E/F and
+ADR-026 Phase 3 notes updated to point here.
+
+## Consequences
+
+**Positive**
+- Activates two epics of dormant telemetry into the largest available
+  cost/quality lever (field evidence: 30–85% spend reduction from routing and
+  adaptive depth), while quality is protected by confidence-tiered blending
+  and consensus-gated escalation.
+- Kills two stale draft ADRs and completes two deferred ones with a single
+  coherent mechanism, all in-house and offline-capable.
+- Route receipts (LayerEvents) make every routing influence auditable.
+
+**Negative / risks**
+- Feedback loops: selection favouring historically-good models starves
+  challengers of samples → mitigated by the existing anti-herding penalty
+  (`apply_anti_herding_penalty`), the audition/graduation pipeline
+  (ADR-027/029) as the sanctioned entry path, and capped blend weight (≤0.8).
+- Early termination could suppress dissent → it only fires on *mathematical*
+  unassailability of the ranking, never on score similarity; dissent
+  extraction (ADR-025b) still runs on collected reviews.
+- Miscalibrated history misroutes → all phases default OFF; shadow-mode
+  logging precedes enablement; blending is bounded, never a replacement.
+
+## Definition of Done (per phase)
+
+Code + tests (cold-start, flag-off no-op byte-identical, event emission,
+cancellation safety); user docs (CLAUDE.md env index + module map, README,
+CHANGELOG); LLM-facing text where surfaced; flag defaults documented
+(everything off). A phase that changes flag-off behaviour fails DoD.
+
+## Compliance / Validation
+
+- Grep-able invariant: outside `metadata/selection.py` blending, the budget
+  enforcer, and the graduated-depth escalator, no L1/L2 code reads the
+  performance tracker or cost history.
+- Flag-off test suite proves byte-identical selection to pre-ADR-044.
+- Shadow-mode metrics (would-have-saved) recorded before any default flips.
+
+## References
+
+- [ADR-026 Dynamic Model Intelligence](./ADR-026-dynamic-model-intelligence.md) · [ADR-011 Cost & Token Accounting](./ADR-011-cost-tracking.md) · [ADR-040 Timeout Guardrails](./ADR-040-verification-timeout-observability.md) · [ADR-020 Not Diamond Strategy](./ADR-020-not-diamond-integration-strategy.md)
+- RouteLLM-class routing results; compute-optimal test-time scaling; route-receipt auditability (see `docs/roadmap-2026-h2.md` sources)

--- a/docs/roadmap-2026-h2.md
+++ b/docs/roadmap-2026-h2.md
@@ -1,0 +1,75 @@
+# Roadmap — 2026 H2
+
+Five highest-value deliverables, identified 2026-07-02 by (a) a reverse-order ADR
+sweep for unimplemented items and (b) a survey of the July-2026 GenAI landscape.
+Ordered by value; #1 is in flight (ADR-044).
+
+## 1. Compute-Optimal Deliberation — ADR-044 (in flight)
+
+**What:** Wire the internal performance index (ADR-026 P3, currently write-only)
+and the cost-per-quality scores (ADR-011 P3, currently unconsumed) into model
+selection; add early-consensus termination (ADR-040 Option F) and graduated
+deliberation depth. Subsumes drafts ADR-039 (LLMRouter) and ADR-043 (Pareto).
+
+**Why now:** RouteLLM-class routers demonstrate ~85% cost reduction at ~95%
+quality; compute-optimal test-time scaling (spend depth only where the query
+needs it) beats fixed-depth ensembles; heterogeneous-model ensembles are cited
+as underexplored — this project is one. The telemetry needed was shipped in
+v0.25.x–v0.27.x and has no consumer yet.
+
+## 2. MCP 2026-07-28 Adoption — Tasks primitive + Server Card
+
+**What:** Adopt the MCP 2026-07-28 spec (final 2026-07-28): the **Tasks
+primitive** for long-running deliberations (submit → poll/resume; survives
+client disconnects) and a **Server Card** (`.well-known` metadata) for
+registry discovery; stateless transport for load-balanced serving.
+
+**Why now:** The council's #1 documented UX pain is MCP client timeouts on
+high/reasoning tiers (README instructs raising `MCP_TIMEOUT`); Tasks is
+purpose-built for it. Server Cards make the council discoverable across
+19k+-server MCP registries. Extends ADR-012.
+
+## 3. Streaming Deliberation, end-to-end
+
+**What:** Stream Stage-1 responses as they land, ranking events as they
+resolve, and chairman synthesis token-by-token — over the existing SSE
+endpoint and MCP progress/Tasks. Builds on the true gateway SSE shipped in
+v0.27.1.
+
+**Why now:** No implementation in the growing llm-council ecosystem streams;
+a 30–600s deliberation behind a spinner is the product's felt weakness.
+Listed as the first "future enhancement" in CLAUDE.md.
+
+## 4. Verifier Calibration & Judge Reliability
+
+**What:** Calibrate `verify`'s confidence signal against observed outcomes
+(the `.council/logs` transcript corpus is training data we own); add a
+lightweight screening judge before full-council verification; harden
+UNCLEAR/timeout semantics; position-debias per bias-amplification research.
+ADR-036 Phase 2 (calibration report) + ADR-015/017.
+
+**Why now:** 2026 judge research shows multi-agent judges can *amplify* bias
+and confidence signals are systematically miscalibrated — matching our own
+operational evidence (multi-round verify asymptotes with zero blocking
+issues; confidence pinned below its own PASS threshold). Verification is the
+flagship CI-gate feature; its reliability is the product.
+
+## 5. Council Quality Benchmark + Golden-Dataset Regression
+
+**What:** A published benchmark answering "when does a council beat a single
+frontier model, per dollar?" (uses ADR-011 cost ground truth), plus a
+golden-dataset regression suite in CI so council quality can't silently
+drift. ADR-036 Phases 2–3 slice; DeepEval/RAGAS bridges.
+
+**Why now:** Positions the project with evidence in an increasingly crowded
+llm-council space, and produces the empirical tuning data #1's router needs.
+
+---
+
+### Sources (July 2026)
+
+- [Multi-Agent Verification: Scaling Test-Time Compute](https://arxiv.org/pdf/2502.20379) · [Compute-Optimal Scaling as an Optimizable Graph](https://arxiv.org/pdf/2511.00086) · [Mixture-of-Models: N-Way Self-Evaluating Deliberation](https://arxiv.org/pdf/2601.16863)
+- [The 2026 MCP Roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/) · [MCP 2026-07-28 Release Candidate](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
+- [LLM Model Routing in 2026](https://www.digitalapplied.com/blog/llm-model-routing-2026-cost-quality-optimization-engineering-guide) · [Routing, Cascades, and User Choice](https://arxiv.org/pdf/2602.09902) · [Model Routing as a Trust Problem](https://arxiv.org/pdf/2605.01710)
+- [Agent-as-a-Judge Survey](https://arxiv.org/pdf/2601.05111) · [Judging with Many Minds (bias amplification)](https://arxiv.org/pdf/2505.19477) · [LLM-as-a-Judge in 2026 — DeepEval](https://deepeval.com/guides/guides-llm-as-a-judge)
+- [Awesome LLM Council Projects](https://github.com/danielrosehill/Awesome-LLM-Council-Projects)

--- a/src/llm_council/layer_contracts.py
+++ b/src/llm_council/layer_contracts.py
@@ -95,6 +95,9 @@ class LayerEventType(Enum):
     L2_WILDCARD_SELECTED = "l2_wildcard_selected"
     L2_DELIBERATION_ESCALATION = "l2_deliberation_escalation"
     L2_FAST_PATH_TRIGGERED = "l2_fast_path_triggered"
+    # ADR-044 P1: performance-index blending changed the selected model set
+    # (auditable route receipt; emitted only on an actual outcome change).
+    L2_PERFORMANCE_SELECTION_APPLIED = "l2_performance_selection_applied"
 
     # L3 Events (Council Execution)
     L3_COUNCIL_START = "l3_council_start"

--- a/src/llm_council/metadata/selection.py
+++ b/src/llm_council/metadata/selection.py
@@ -20,11 +20,15 @@ Example usage:
     )
 """
 
+import logging
+import os
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
 from ..tier_contract import _get_tier_model_pools
 from .types import QualityTier
+
+logger = logging.getLogger(__name__)  # (re-bound identically further down)
 
 if TYPE_CHECKING:
     from .protocol import MetadataProvider
@@ -378,6 +382,55 @@ def _is_preview_model(model_id: str) -> bool:
     return any(indicator in model_lower for indicator in preview_indicators)
 
 
+# ---------------------------------------------------------------------------
+# ADR-044 Phase 1: performance-aware selection blending (default OFF)
+# ---------------------------------------------------------------------------
+
+# Blend weight of the LIVE index per confidence tier; static metadata always
+# keeps >= 20% influence (cap 0.8). INSUFFICIENT (<10 samples) -> static only.
+_PERF_BLEND_WEIGHTS: Dict[str, float] = {
+    "PRELIMINARY": 0.3,
+    "MODERATE": 0.6,
+    "HIGH": 0.8,
+}
+
+
+def performance_selection_enabled() -> bool:
+    """ADR-044 P1: opt-in performance-aware selection (default OFF)."""
+    return os.getenv("LLM_COUNCIL_PERFORMANCE_SELECTION", "false").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+
+
+def _get_perf_tracker() -> Any:
+    """Lazy tracker accessor (injectable in tests; avoids import cycles)."""
+    from ..performance.integration import get_tracker
+
+    return get_tracker()
+
+
+def _blend_quality_with_performance(model_id: str, static_score: float) -> float:
+    """Blend the live performance index into a static quality estimate.
+
+    ``w * live + (1 - w) * static`` where ``w`` steps by the index's
+    confidence tier (see _PERF_BLEND_WEIGHTS). Cold start (INSUFFICIENT) and
+    any tracker failure return the static score unchanged — blending must
+    never break or destabilize selection (ADR-044 soft-fail rule).
+    """
+    try:
+        index = _get_perf_tracker().get_model_index(model_id)
+        weight = _PERF_BLEND_WEIGHTS.get(str(index.confidence_level), 0.0)
+        if weight <= 0.0:
+            return static_score
+        live = float(index.mean_borda_score)
+        return weight * live + (1.0 - weight) * static_score
+    except Exception as exc:
+        logger.debug("performance blend failed for %r (ignored): %s", model_id, exc)
+        return static_score
+
+
 def select_tier_models(
     tier: str,
     task_domain: Optional[str] = None,
@@ -449,8 +502,46 @@ def select_tier_models(
         score = calculate_model_score(candidate, tier)
         scored.append((candidate.model_id, score))
 
-    # Select with diversity enforcement
-    return select_with_diversity(scored, count=count, min_providers=2)
+    # Select with diversity enforcement (static baseline)
+    static_selection = select_with_diversity(scored, count=count, min_providers=2)
+
+    # ADR-044 P1: opt-in performance-aware blending. Re-score with the live
+    # index blended into quality; if (and only if) the selected set changes,
+    # emit an auditable route receipt and use the blended selection.
+    if performance_selection_enabled():
+        from dataclasses import replace as _dc_replace
+
+        blended_scored: List[Tuple[str, float]] = []
+        for candidate in candidates:
+            blended_quality = _blend_quality_with_performance(
+                candidate.model_id, candidate.quality_score
+            )
+            blended_candidate = _dc_replace(candidate, quality_score=blended_quality)
+            blended_scored.append(
+                (candidate.model_id, calculate_model_score(blended_candidate, tier))
+            )
+        blended_selection = select_with_diversity(
+            blended_scored, count=count, min_providers=2
+        )
+        if blended_selection != static_selection:
+            try:
+                from ..layer_contracts import LayerEventType, emit_layer_event
+
+                emit_layer_event(
+                    LayerEventType.L2_PERFORMANCE_SELECTION_APPLIED,
+                    {
+                        "tier": tier,
+                        "static_selection": static_selection,
+                        "blended_selection": blended_selection,
+                    },
+                    layer_from="L2",
+                    layer_to="L2",
+                )
+            except Exception as exc:  # observability never breaks selection
+                logger.debug("route-receipt emit failed (ignored): %s", exc)
+        return blended_selection
+
+    return static_selection
 
 
 def _create_candidates_from_pool(pool: List[str], tier: str) -> List[ModelCandidate]:

--- a/tests/test_performance_selection.py
+++ b/tests/test_performance_selection.py
@@ -1,0 +1,121 @@
+"""ADR-044 Phase 1: performance-aware selection blending (#390).
+
+The live performance index blends into candidate quality scores — default OFF,
+cold-start safe, soft-fail, and emitting an auditable LayerEvent only when
+blending actually changes the selected set.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import llm_council.metadata.selection as sel
+from llm_council.metadata.selection import (
+    _blend_quality_with_performance,
+    performance_selection_enabled,
+)
+
+
+def _fake_tracker(confidence="HIGH", borda=0.9, raises=False):
+    class _T:
+        def get_model_index(self, model_id):
+            if raises:
+                raise RuntimeError("store unavailable")
+            return SimpleNamespace(confidence_level=confidence, mean_borda_score=borda)
+
+    return _T()
+
+
+class TestFlag:
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("LLM_COUNCIL_PERFORMANCE_SELECTION", raising=False)
+        assert performance_selection_enabled() is False
+
+    def test_enabled_via_env(self, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_PERFORMANCE_SELECTION", "true")
+        assert performance_selection_enabled() is True
+
+
+class TestBlend:
+    def test_insufficient_confidence_returns_static(self, monkeypatch):
+        monkeypatch.setattr(sel, "_get_perf_tracker", lambda: _fake_tracker("INSUFFICIENT", 0.99))
+        assert _blend_quality_with_performance("m", 0.70) == 0.70
+
+    @pytest.mark.parametrize(
+        "confidence,weight",
+        [("PRELIMINARY", 0.3), ("MODERATE", 0.6), ("HIGH", 0.8)],
+    )
+    def test_blend_weight_steps_by_confidence(self, monkeypatch, confidence, weight):
+        monkeypatch.setattr(sel, "_get_perf_tracker", lambda: _fake_tracker(confidence, 0.9))
+        expected = weight * 0.9 + (1 - weight) * 0.5
+        assert _blend_quality_with_performance("m", 0.5) == pytest.approx(expected)
+
+    def test_weight_never_exceeds_cap(self, monkeypatch):
+        # Even at HIGH confidence, static keeps >= 20% influence.
+        monkeypatch.setattr(sel, "_get_perf_tracker", lambda: _fake_tracker("HIGH", 1.0))
+        blended = _blend_quality_with_performance("m", 0.0)
+        assert blended <= 0.8
+
+    def test_tracker_error_soft_fails_to_static(self, monkeypatch):
+        monkeypatch.setattr(sel, "_get_perf_tracker", lambda: _fake_tracker(raises=True))
+        assert _blend_quality_with_performance("m", 0.42) == 0.42
+
+
+class TestSelectionIntegration:
+    def _run(self, monkeypatch, enabled, tracker):
+        if enabled:
+            monkeypatch.setenv("LLM_COUNCIL_PERFORMANCE_SELECTION", "true")
+        else:
+            monkeypatch.delenv("LLM_COUNCIL_PERFORMANCE_SELECTION", raising=False)
+        monkeypatch.setattr(sel, "_get_perf_tracker", lambda: tracker)
+        # Deterministic: score = quality only, so outcomes are fully decided by
+        # the static heuristics (opus/gpt-4 0.95 > sonnet 0.85 > mini 0.65)
+        # and by the blend — no dependence on latency/cost weight tuning.
+        monkeypatch.setattr(
+            sel, "calculate_model_score", lambda c, t: c.quality_score
+        )
+        pool = ["alpha/opus-1", "beta/gpt-4-z", "gamma/sonnet-y", "weak/mini-x"]
+        monkeypatch.setattr(sel, "_get_tier_model_pools", lambda: {"balanced": pool})
+        monkeypatch.setattr(sel, "_is_discovery_enabled", lambda: False)
+        monkeypatch.setattr(sel, "_is_circuit_breaker_open", lambda m: False)
+        monkeypatch.setattr(sel, "_filter_by_tier_intersection", lambda c, t, p: c)
+        return sel.select_tier_models("balanced", count=2)
+
+    class _BoostMini:
+        def get_model_index(self, model_id):
+            borda = 1.0 if model_id == "weak/mini-x" else 0.0
+            return SimpleNamespace(confidence_level="HIGH", mean_borda_score=borda)
+
+    def test_flag_off_is_byte_identical(self, monkeypatch):
+        # Even with a tracker that would massively boost weak/mini-x, the
+        # flag-off path never consults it: static top-2 by quality.
+        baseline = self._run(monkeypatch, enabled=False, tracker=self._BoostMini())
+        assert baseline == ["alpha/opus-1", "beta/gpt-4-z"]
+        assert "weak/mini-x" not in baseline
+
+    def test_flag_on_blending_can_change_selection_and_emits_event(self, monkeypatch):
+        from llm_council import layer_contracts
+
+        before = len(getattr(layer_contracts, "_layer_events", []))
+        selected = self._run(monkeypatch, enabled=True, tracker=self._BoostMini())
+        # Blended: mini = 0.8*1.0 + 0.2*0.65 = 0.93 (top); others crater to 0.2*static.
+        assert "weak/mini-x" in selected  # live record flipped it in
+        events = getattr(layer_contracts, "_layer_events", [])
+        new = [e for e in events[before:] if "performance_selection" in str(getattr(e.event_type, "value", e.event_type))]
+        assert new, "route receipt LayerEvent must be emitted when the set changed"
+        payload = new[-1].data
+        assert payload["static_selection"] != payload["blended_selection"]
+
+    def test_flag_on_no_change_no_event(self, monkeypatch):
+        from llm_council import layer_contracts
+
+        class _Uniform:  # same live score for all -> order preserved -> no change
+            def get_model_index(self, model_id):
+                return SimpleNamespace(confidence_level="PRELIMINARY", mean_borda_score=0.7)
+
+        before = len(getattr(layer_contracts, "_layer_events", []))
+        selected = self._run(monkeypatch, enabled=True, tracker=_Uniform())
+        assert selected == ["alpha/opus-1", "beta/gpt-4-z"]  # unchanged set
+        events = getattr(layer_contracts, "_layer_events", [])
+        new = [e for e in events[before:] if "performance_selection" in str(getattr(e.event_type, "value", e.event_type))]
+        assert not new, "no event when blending did not change the selected set"


### PR DESCRIPTION
Child of epic #394 (ADR-044 Compute-Optimal Deliberation). First commit is the epic groundwork (2026-H2 roadmap + ADR-044 draft); second is the P1 implementation.

- `_blend_quality_with_performance`: live index → static quality blend, confidence-tiered weights (0.3/0.6/0.8, cap 0.8), cold-start safe, soft-fail.
- Flag `LLM_COUNCIL_PERFORMANCE_SELECTION` (default **OFF**; flag-off byte-identical — tested).
- Route receipt: `L2_PERFORMANCE_SELECTION_APPLIED` emitted **only** when blending changes the selected set (static vs blended payload).

11 new tests; suite 2975 green.

Closes #390. Epic: #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)