### PR TITLE
feat(council): ADR-044 P2 — early consensus termination (shadow-first)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Early consensus termination (ADR-044 Phase 2, #391)** — during Stage-2 peer review, once the leading response's Borda margin is mathematically unassailable given the reviewers still outstanding, the remaining reviewer calls can be cancelled (flag `LLM_COUNCIL_EARLY_CONSENSUS`, default **OFF**). Off = **shadow mode**: the would-have-terminated point and estimated cost saved (from ADR-011 history) are logged so savings are measurable before enabling. Active terminations emit an auditable `L3_EARLY_CONSENSUS_TERMINATION` LayerEvent (votes saved, reviewers cancelled, est. cost saved); usage aggregation for completed reviewers is unaffected and dissent extraction still runs.
 - **Performance-aware model selection (ADR-044 Phase 1, #390)** — the internal performance index (ADR-026 P3, previously write-only) now optionally blends into candidate quality scores during tier selection: `w·live + (1−w)·static` with `w` stepped by the index's confidence tier (0.3/0.6/0.8; cold start stays fully static). **Default OFF** (`LLM_COUNCIL_PERFORMANCE_SELECTION`); flag-off behaviour is byte-identical. When blending changes the selected model set, an auditable `L2_PERFORMANCE_SELECTION_APPLIED` LayerEvent records the static vs blended selections (route receipt). Soft-fail: tracker errors never affect selection.
 
 ## [0.27.1] - 2026-07-02

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,8 @@ Evaluation & scoring
 - `evaluation.py`, `quality/`, `verdict.py`, `dissent.py` — additional evaluation/quality surfaces.
 - `gateway/` (ADR-030) — `EnhancedCircuitBreaker` (sliding-window failure rate, default 25% over 10-min window, 30-min cooldown, half-open probes) + per-model registry that emits `L4_CIRCUIT_BREAKER_OPEN/CLOSE`. `scoring.py` — cost-scoring algorithms (linear/log_ratio/exponential).
 
-Compute-optimal deliberation (ADR-044, Phase 1)
+Compute-optimal deliberation (ADR-044, Phase 1–2)
+- `early_consensus.py` (P2) — `unassailable_leader` (strict Borda-margin math: decided iff leader > best rival + remaining×(n−1)) + `borda_update` + `estimate_reviewers_cost` (ADR-011 history). Stage 2 checks per completion on the incremental path; flag ON cancels outstanding reviewers cooperatively and emits `L3_EARLY_CONSENSUS_TERMINATION` (votes/cost saved); flag OFF (default) is **shadow mode** — logs the would-have-terminated point so savings are measurable before enabling. Detection is non-authoritative and soft-fail; dissent extraction still runs on collected reviews.
 - `metadata/selection.py` `_blend_quality_with_performance` — opt-in (`LLM_COUNCIL_PERFORMANCE_SELECTION`) blend of the live index (`mean_borda_score`) into static quality, weighted by confidence tier (PRELIMINARY 0.3 / MODERATE 0.6 / HIGH 0.8, cap 0.8; INSUFFICIENT→static). `select_tier_models` compares static vs blended selections and emits `L2_PERFORMANCE_SELECTION_APPLIED` only when the set changed (route receipt). Soft-fail; flag-off is byte-identical.
 
 Cost & token accounting (ADR-011, Phase 1–4)
@@ -102,6 +103,7 @@ Single Pydantic source of truth consolidating ADR-020/022/023/026/030/031. Prior
 |---|---|
 | `LLM_COUNCIL_MODELS` | Override council members |
 | `LLM_COUNCIL_PERFORMANCE_SELECTION` | ADR-044 P1: blend the live performance index into model selection (default off; auditable route receipt on change) |
+| `LLM_COUNCIL_EARLY_CONSENSUS` | ADR-044 P2: cancel remaining Stage-2 reviewers once the Borda leader is mathematically unassailable (default off = shadow mode, which only logs would-have-saved) |
 | `LLM_COUNCIL_MODEL_INTELLIGENCE=true` | Enable dynamic model selection (ADR-026) |
 | `LLM_COUNCIL_OFFLINE=true` | Force offline / static provider |
 | `LLM_COUNCIL_DISCOVERY_ENABLED` / `_INTERVAL` (300) / `_MIN_CANDIDATES` (3) | Background discovery (ADR-028) |

--- a/src/llm_council/council.py
+++ b/src/llm_council/council.py
@@ -132,7 +132,17 @@ from llm_council.bias_audit import (
     BiasAuditResult,
 )
 from llm_council.bias_persistence import persist_session_bias_data
+import logging
+
+from llm_council.early_consensus import (
+    borda_update,
+    early_consensus_enabled,
+    estimate_reviewers_cost,
+    unassailable_leader,
+)
 from llm_council.observability.usage_metrics import emit_usage_metrics
+
+logger = logging.getLogger(__name__)
 from llm_council.cache import get_cache_key, get_cached_response, save_to_cache
 from llm_council.dissent import extract_dissent_from_stage2
 from llm_council.layer_contracts import (
@@ -1358,7 +1368,10 @@ Now provide your evaluation and ranking:"""
     # Get rankings from reviewer models in parallel
     # Disable tools to prevent prompt injection via tool invocation
     # ADR-040: Pass timeout parameter instead of relying on default 120s
-    if on_progress is not None:
+    # ADR-044 P2: the incremental path is also used (without progress) when
+    # early-consensus termination is enabled, since cancellation requires
+    # observing completions one at a time.
+    if on_progress is not None or early_consensus_enabled():
         # ADR-040 Option D: Use asyncio.as_completed for per-model progress reporting
         # This ensures one slow reviewer doesn't block progress for completed ones
         tasks = {
@@ -1369,28 +1382,83 @@ Now provide your evaluation and ranking:"""
         }
         responses: Dict[str, Any] = {}
         completed_count = 0
+        # ADR-044 P2: running Borda tally for early-consensus detection.
+        # Non-authoritative (the formatting loop below re-parses); soft-fail.
+        ec_points: Dict[str, float] = {}
+        ec_num_candidates = len(shuffled_results)
+        ec_shadow_logged = False
+        ec_terminated = False
         for coro in asyncio.as_completed(list(tasks.keys())):
-            result = await coro
+            try:
+                result = await coro
+            except asyncio.CancelledError:
+                continue  # a reviewer we cancelled after early consensus
             # Find which model this task belonged to
             for task, model in tasks.items():
-                if task.done() and model not in responses:
+                if task.done() and not task.cancelled() and model not in responses:
                     try:
                         task_result = task.result()
                         if task_result is result:
                             responses[model] = result
                             completed_count += 1
                             model_short = model.split("/")[-1] if "/" in model else model
-                            try:
-                                await on_progress(
-                                    completed_count,
-                                    len(reviewers),
-                                    f"{model_short} reviewed ({completed_count}/{len(reviewers)})",
-                                )
-                            except Exception:
-                                pass
+                            if on_progress is not None:
+                                try:
+                                    await on_progress(
+                                        completed_count,
+                                        len(reviewers),
+                                        f"{model_short} reviewed ({completed_count}/{len(reviewers)})",
+                                    )
+                                except Exception:
+                                    pass
                             break
                     except Exception:
                         pass
+
+            # ADR-044 P2: check for a mathematically decided ranking.
+            if ec_terminated or ec_shadow_logged or result is None:
+                continue
+            try:
+                parsed = parse_ranking_from_text(result.get("content", ""))
+                borda_update(ec_points, parsed.get("ranking", []), ec_num_candidates)
+                remaining = [m for t, m in tasks.items() if not t.done()]
+                leader = unassailable_leader(ec_points, len(remaining), ec_num_candidates)
+                if leader is None:
+                    continue
+                saved_cost = estimate_reviewers_cost(remaining)
+                if early_consensus_enabled():
+                    for task, model in tasks.items():
+                        if not task.done():
+                            task.cancel()
+                    ec_terminated = True
+                    try:
+                        emit_layer_event(
+                            LayerEventType.L3_EARLY_CONSENSUS_TERMINATION,
+                            {
+                                "leader": leader,
+                                "votes_saved": len(remaining),
+                                "reviewers_cancelled": remaining,
+                                "est_cost_saved_usd": saved_cost,
+                            },
+                            layer_from="L3",
+                            layer_to="L3",
+                        )
+                    except Exception:
+                        pass  # observability never blocks the council
+                else:
+                    # Shadow mode (default): measure, don't act.
+                    ec_shadow_logged = True
+                    logger.info(
+                        "early-consensus (shadow): ranking decided for %s with %d "
+                        "reviewer(s) outstanding (~$%.6f would be saved)",
+                        leader,
+                        len(remaining),
+                        saved_cost,
+                    )
+            except Exception:
+                pass  # detection is best-effort; never disturb collection
+            if ec_terminated:
+                break
     else:
         # Backward-compatible path: use query_models_parallel when no progress needed
         responses = await query_models_parallel(

--- a/src/llm_council/early_consensus.py
+++ b/src/llm_council/early_consensus.py
@@ -1,0 +1,79 @@
+"""Early consensus termination for Stage-2 peer review (ADR-044 Phase 2).
+
+Implements ADR-040 Option F: when the leading response's Borda margin is
+mathematically unassailable given the reviewers still outstanding, the
+remaining reviewer calls can be cancelled (flag ON) — or, in **shadow mode**
+(flag OFF, the default), the would-have-terminated point is only logged so
+savings are measurable before enabling.
+
+All helpers are soft: they never raise into the council hot path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def early_consensus_enabled() -> bool:
+    """ADR-044 P2: opt-in early consensus termination (default OFF = shadow)."""
+    return os.getenv("LLM_COUNCIL_EARLY_CONSENSUS", "false").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+
+
+def borda_update(
+    points: Dict[str, float], ranking: List[str], num_candidates: int
+) -> None:
+    """Add one reviewer's Borda contribution: rank i gets (n-1-i) points."""
+    for idx, label in enumerate(ranking[:num_candidates]):
+        points[label] = points.get(label, 0.0) + float(num_candidates - 1 - idx)
+
+
+def unassailable_leader(
+    points: Dict[str, float], remaining_votes: int, num_candidates: int
+) -> Optional[str]:
+    """Return the leader's label iff no remaining votes can dethrone it.
+
+    Worst case for the leader: every outstanding reviewer awards it 0 points
+    and awards some rival the maximum (num_candidates - 1). The ranking is
+    decided iff ``leader > best_rival + remaining * (n - 1)`` — strictly, so
+    ties are never "decided".
+    """
+    if not points or num_candidates < 2:
+        return None
+    ordered = sorted(points.items(), key=lambda kv: kv[1], reverse=True)
+    leader_label, leader_points = ordered[0]
+    best_rival = ordered[1][1] if len(ordered) > 1 else 0.0
+    max_swing = remaining_votes * (num_candidates - 1)
+    if leader_points > best_rival + max_swing:
+        return leader_label
+    return None
+
+
+def estimate_reviewers_cost(models: Iterable[str]) -> float:
+    """Best-effort USD estimate for a set of reviewer calls (ADR-011 history).
+
+    Sums each model's mean historical cost; unknown-cost models contribute 0.
+    Never raises.
+    """
+    total = 0.0
+    try:
+        from .performance.integration import get_tracker
+
+        tracker = get_tracker()
+        for model_id in models:
+            try:
+                mean_cost = tracker.get_model_index(model_id).mean_cost_usd
+            except Exception:
+                mean_cost = None
+            if mean_cost:
+                total += max(float(mean_cost), 0.0)
+    except Exception as exc:  # telemetry-grade: never break the caller
+        logger.debug("reviewer cost estimate failed (ignored): %s", exc)
+    return round(total, 8)

--- a/src/llm_council/layer_contracts.py
+++ b/src/llm_council/layer_contracts.py
@@ -104,6 +104,9 @@ class LayerEventType(Enum):
     L3_COUNCIL_COMPLETE = "l3_council_complete"
     L3_STAGE_COMPLETE = "l3_stage_complete"
     L3_MODEL_TIMEOUT = "l3_model_timeout"
+    # ADR-044 P2: stage-2 reviews cancelled because the Borda leader was
+    # mathematically unassailable (auditable; carries votes/cost saved).
+    L3_EARLY_CONSENSUS_TERMINATION = "l3_early_consensus_termination"
 
     # L4 Events (Gateway Routing)
     L4_GATEWAY_REQUEST = "l4_gateway_request"

--- a/tests/test_early_consensus.py
+++ b/tests/test_early_consensus.py
@@ -122,8 +122,11 @@ async def test_active_mode_cancels_unneeded_reviewers(monkeypatch):
         timeout=10.0,  # far below r5's 30s: proves cancellation, not waiting
     )
     # After 4 unanimous A>B>C votes: A=8, B=4, remaining=1*2 → decided; r5 cancelled.
-    assert "r5" in cancelled
+    # NOTE: don't assert on the mock's CancelledError capture — a task cancelled
+    # before its coroutine first runs never enters the mock body (CI scheduling).
+    # The wait_for(10s) above vs r5's 30s sleep IS the cancellation proof.
     assert len(results) == 4
+    assert "r5" not in [r["model"] for r in results]
     # usage aggregated for the completed four only
     assert usage["prompt_tokens"] == 40
     events = getattr(layer_contracts, "_layer_events", [])
@@ -133,6 +136,7 @@ async def test_active_mode_cancels_unneeded_reviewers(monkeypatch):
         if "early_consensus" in str(getattr(e.event_type, "value", e.event_type))
     ]
     assert new and new[-1].data["votes_saved"] == 1
+    assert new[-1].data["reviewers_cancelled"] == ["r5"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_early_consensus.py
+++ b/tests/test_early_consensus.py
@@ -1,0 +1,167 @@
+"""ADR-044 Phase 2: early consensus termination (#391)."""
+
+import asyncio
+from itertools import permutations
+
+import pytest
+
+from llm_council.early_consensus import (
+    borda_update,
+    early_consensus_enabled,
+    estimate_reviewers_cost,
+    unassailable_leader,
+)
+
+
+class TestFlag:
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("LLM_COUNCIL_EARLY_CONSENSUS", raising=False)
+        assert early_consensus_enabled() is False
+
+
+class TestUnassailabilityMath:
+    def test_decided_case(self):
+        # 3 candidates, 5 reviewers, 4 voted A>B>C: A=8, B=4, C=0, 1 remaining.
+        points = {"Response A": 8.0, "Response B": 4.0, "Response C": 0.0}
+        assert unassailable_leader(points, remaining_votes=1, num_candidates=3) == "Response A"
+
+    def test_not_decided_when_reachable(self):
+        # A=6, B=3, 2 remaining, max swing 2*2=4: B could reach 7 > 6.
+        points = {"Response A": 6.0, "Response B": 3.0, "Response C": 0.0}
+        assert unassailable_leader(points, remaining_votes=2, num_candidates=3) is None
+
+    def test_tie_never_decided(self):
+        points = {"Response A": 4.0, "Response B": 4.0}
+        assert unassailable_leader(points, remaining_votes=0, num_candidates=2) is None
+
+    def test_exhaustive_soundness_small(self):
+        # Property check: whenever the checker says "decided" mid-count, no
+        # completion of the remaining votes may change the winner.
+        n = 3
+        labels = [f"Response {c}" for c in "ABC"]
+        all_votes = list(permutations(labels))
+        for v1 in all_votes:
+            for v2 in all_votes:
+                points: dict = {}
+                borda_update(points, list(v1), n)
+                borda_update(points, list(v2), n)
+                leader = unassailable_leader(points, remaining_votes=1, num_candidates=n)
+                if leader is None:
+                    continue
+                for v3 in all_votes:
+                    final = dict(points)
+                    borda_update(final, list(v3), n)
+                    winner = max(final.items(), key=lambda kv: kv[1])
+                    # strict: decided leader must remain the unique max
+                    others = [p for lbl, p in final.items() if lbl != leader]
+                    assert final[leader] > max(others), (v1, v2, v3, final)
+
+
+class TestCostEstimate:
+    def test_sums_known_costs_and_never_raises(self, monkeypatch):
+        class _T:
+            def get_model_index(self, m):
+                from types import SimpleNamespace
+
+                return SimpleNamespace(mean_cost_usd={"a": 0.01, "b": None}.get(m))
+
+        import llm_council.performance.integration as integ
+
+        monkeypatch.setattr(integ, "get_tracker", lambda: _T())
+        assert estimate_reviewers_cost(["a", "b"]) == 0.01
+
+
+# ---------------------------------------------------------------------------
+# stage2 integration
+# ---------------------------------------------------------------------------
+
+_STAGE1 = [
+    {"model": "m1", "response": "answer one"},
+    {"model": "m2", "response": "answer two"},
+    {"model": "m3", "response": "answer three"},
+]
+
+_RANKING_TEXT = "FINAL RANKING:\n1. Response A\n2. Response B\n3. Response C"
+
+
+def _mock_query_model(delays, calls, cancelled):
+    async def fake(model, messages, disable_tools=False, timeout=120.0, **kw):
+        try:
+            await asyncio.sleep(delays.get(model, 0.0))
+        except asyncio.CancelledError:
+            cancelled.append(model)
+            raise
+        calls.append(model)
+        return {
+            "content": _RANKING_TEXT,
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_active_mode_cancels_unneeded_reviewers(monkeypatch):
+    from llm_council import council as council_mod
+    from llm_council import layer_contracts
+
+    monkeypatch.setenv("LLM_COUNCIL_EARLY_CONSENSUS", "true")
+    # Anonymization shuffles; pin it so 'Response A' is deterministic.
+    monkeypatch.setattr(council_mod.random, "shuffle", lambda x: None)
+    reviewers = [f"r{i}" for i in range(1, 6)]
+    delays = {f"r{i}": 0.01 * i for i in range(1, 5)}
+    delays["r5"] = 30.0  # would dominate wall-clock if not cancelled
+    calls, cancelled = [], []
+    monkeypatch.setattr(council_mod, "query_model", _mock_query_model(delays, calls, cancelled))
+
+    before = len(getattr(layer_contracts, "_layer_events", []))
+    results, label_to_model, usage = await asyncio.wait_for(
+        council_mod.stage2_collect_rankings(
+            "q", _STAGE1, timeout=5.0, models=reviewers, on_progress=None
+        ),
+        timeout=10.0,  # far below r5's 30s: proves cancellation, not waiting
+    )
+    # After 4 unanimous A>B>C votes: A=8, B=4, remaining=1*2 → decided; r5 cancelled.
+    assert "r5" in cancelled
+    assert len(results) == 4
+    # usage aggregated for the completed four only
+    assert usage["prompt_tokens"] == 40
+    events = getattr(layer_contracts, "_layer_events", [])
+    new = [
+        e
+        for e in events[before:]
+        if "early_consensus" in str(getattr(e.event_type, "value", e.event_type))
+    ]
+    assert new and new[-1].data["votes_saved"] == 1
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_runs_everything_and_emits_nothing(monkeypatch):
+    from llm_council import council as council_mod
+    from llm_council import layer_contracts
+
+    monkeypatch.delenv("LLM_COUNCIL_EARLY_CONSENSUS", raising=False)
+    monkeypatch.setattr(council_mod.random, "shuffle", lambda x: None)
+    reviewers = [f"r{i}" for i in range(1, 6)]
+    calls, cancelled = [], []
+    monkeypatch.setattr(
+        council_mod, "query_model", _mock_query_model({}, calls, cancelled)
+    )
+
+    async def _noop_progress(done, total, msg):
+        return None
+
+    before = len(getattr(layer_contracts, "_layer_events", []))
+    results, _, usage = await council_mod.stage2_collect_rankings(
+        "q", _STAGE1, timeout=5.0, models=reviewers, on_progress=_noop_progress
+    )
+    assert cancelled == []
+    assert len(results) == 5  # every reviewer ran
+    assert usage["prompt_tokens"] == 50
+    events = getattr(layer_contracts, "_layer_events", [])
+    new = [
+        e
+        for e in events[before:]
+        if "early_consensus" in str(getattr(e.event_type, "value", e.event_type))
+    ]
+    assert not new  # shadow mode: log only, no event


### PR DESCRIPTION
Child of epic #394. Implements ADR-040 Option F per ADR-044 §Phase 2:

- `early_consensus.py`: strict unassailability math (leader > best rival + remaining×(n−1)), Borda tally, ADR-011-based cost estimate — all soft-fail.
- Stage 2 checks per completed review on the incremental path; **flag ON** cancels outstanding reviewers cooperatively + emits `L3_EARLY_CONSENSUS_TERMINATION` (votes/cost saved); **flag OFF (default) = shadow mode** — logs would-have-saved so the win is measurable before enabling.
- Dissent still runs; partial usage aggregation intact; exhaustive-soundness test over all 3-candidate vote permutations; cancellation proven by wall-clock bound (30s reviewer cancelled, test capped at 10s).

8 new tests; suite 2983 green.

Closes #391. Epic: #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)