### PR TITLE
chore: ADR-044 currency — supersede ADR-039/043, cross-refs (#393)

### DIFF
--- a/docs/adr/ADR-026-dynamic-model-intelligence.md
+++ b/docs/adr/ADR-026-dynamic-model-intelligence.md
@@ -9,6 +9,8 @@
 
 ---
 
+> **Update (2026-07-03):** the Phase-3 performance index is no longer write-only — [ADR-044](./ADR-044-compute-optimal-deliberation.md) P1 wires it into tier selection (opt-in blending, `LLM_COUNCIL_PERFORMANCE_SELECTION`).
+
 ## ⚠️ CRITICAL: Strategic Council Review - Vendor Dependency Risk
 
 ### Verdict: CONDITIONAL APPROVAL

--- a/docs/adr/ADR-039-llmrouter-integration.md
+++ b/docs/adr/ADR-039-llmrouter-integration.md
@@ -1,6 +1,6 @@
 # ADR-038: One-Click Deployment Strategy
 
-**Status:** Draft <2025-12-30>
+**Status:** Superseded by [ADR-044](./ADR-044-compute-optimal-deliberation.md) 2026-07-03 — was Draft 2025-12-30. The in-house performance index (ADR-026 P3, wired by ADR-044 P1) provides the routing signal this ADR outsourced to NVIDIA LLMRouter.
 **Date:** 2025-12-30
 **Decision Makers:** @amiable-dev, LLM Council (High Tier)
 **Supersedes:** -

--- a/docs/adr/ADR-040-verification-timeout-observability.md
+++ b/docs/adr/ADR-040-verification-timeout-observability.md
@@ -7,6 +7,8 @@
 
 ---
 
+> **Update (2026-07-03):** Options E/F (tiered Stage 2 / early consensus termination) are now delivered by [ADR-044](./ADR-044-compute-optimal-deliberation.md) — Option F shipped as `early_consensus.py` (shadow-first) in epic #394.
+
 ## Context
 
 Users of the `verify` and `review` MCP tools (invoked via council-verify and council-review skills) frequently experience excessively long execution times. A recent high-tier verification ran for **57 minutes** before being manually cancelled. Users regularly wait 10+ minutes with minimal feedback before killing the process. This leads to poor UX, resource waste, and trust erosion in the tool.

--- a/docs/adr/ADR-043-pareto-router-integration.md
+++ b/docs/adr/ADR-043-pareto-router-integration.md
@@ -1,6 +1,6 @@
 # ADR-043: OpenRouter Pareto Router Integration
 
-**Status:** Draft <2026-05-12>
+**Status:** Superseded by [ADR-044](./ADR-044-compute-optimal-deliberation.md) 2026-07-03 — was Draft 2026-05-12. `openrouter/pareto-code` remains usable as an ordinary pool entry; the routing intelligence this ADR sought now comes from the in-house index (ADR-044).
 **Date:** 2026-05-12
 **Decision Makers:** @amiable-dev, LLM Council (Proposed)
 **Extends:** ADR-022 (Tiered Model Selection), ADR-023 (Multi-Router Gateway), ADR-028 (Dynamic Candidate Discovery)

--- a/docs/adr/ADR-044-compute-optimal-deliberation.md
+++ b/docs/adr/ADR-044-compute-optimal-deliberation.md
@@ -1,6 +1,6 @@
 # ADR-044: Compute-Optimal Deliberation
 
-**Status:** Draft 2026-07-02
+**Status:** Implemented 2026-07-03 (Phases 1–3, epic #394) — was Draft 2026-07-02
 **Date:** 2026-07-02
 **Decision Makers:** Chris Joseph, LLM Council
 **Related:** ADR-026 (Phase 3 — the index this wires in), ADR-011 (Phase 3 — cost-per-quality), ADR-040 (Options E/F), ADR-020 (Tier-1 fast path), ADR-024 (layer sovereignty), ADR-036 (CSS)

--- a/docs/roadmap-2026-h2.md
+++ b/docs/roadmap-2026-h2.md
@@ -4,7 +4,7 @@ Five highest-value deliverables, identified 2026-07-02 by (a) a reverse-order AD
 sweep for unimplemented items and (b) a survey of the July-2026 GenAI landscape.
 Ordered by value; #1 is in flight (ADR-044).
 
-## 1. Compute-Optimal Deliberation — ADR-044 (in flight)
+## 1. Compute-Optimal Deliberation — ADR-044 (✅ shipped, epic #394)
 
 **What:** Wire the internal performance index (ADR-026 P3, currently write-only)
 and the cost-per-quality scores (ADR-011 P3, currently unconsumed) into model


### PR DESCRIPTION
Final child of epic #394 (docs-only): ADR-044 → Implemented; ADR-039 + ADR-043 → Superseded by ADR-044; ADR-040 (Options E/F) + ADR-026 (P3) cross-ref notes; roadmap item 1 marked shipped.

Closes #393. Epic: #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)