### PR TITLE
fix(council): surface underlying error on stage-3 chairman failure (#397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stage-3 chairman failures no longer swallow the underlying error (#397)** — `stage3_synthesize_final` used `query_model`, which collapses every failure (billing 402, auth, rate-limit, timeout) into `None`, so the fallback emitted only 'Error: Unable to generate final synthesis.' During the 2026-07-02 OpenRouter billing outage this made an infra failure look like a dead chairman model. Stage 3 now uses the status-preserving call and surfaces the failure class and detail in the synthesis text (`… (auth_error: Payment required (402): …)`), in structured `error_status`/`error_detail` fields, and in a warning log.
+
 ## [0.28.0] - 2026-07-03
 
 **Compute-Optimal Deliberation (ADR-044)** — epic [#394](https://github.com/amiable-dev/llm-council/issues/394). The write-only performance index (ADR-026 P3) and cost-per-quality signals (ADR-011 P3) now power adaptive routing: performance-aware selection, early consensus termination, and a graduated deliberation-depth cascade. Everything is **default-OFF**, flag-gated, and LayerEvent-audited (route receipts); flag-off behaviour is byte-identical. Supersedes draft ADRs 039 (LLMRouter) and 043 (Pareto Router).

--- a/src/llm_council/council.py
+++ b/src/llm_council/council.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, List, Dict, Any, Tuple, Optional, Callable, Aw
 from llm_council.gateway_adapter import (
     query_models_parallel,
     query_model,
+    query_model_with_status,
     query_models_with_progress,
     STATUS_OK,
     STATUS_TIMEOUT,
@@ -1656,22 +1657,46 @@ STAGE 2 - Peer Rankings:
     # Query the chairman model
     # Disable tools to prevent prompt injection via tool invocation
     # ADR-040: Pass timeout parameter instead of relying on default 120s
-    response = await query_model(
+    # #397: use the status-preserving variant — query_model collapses every
+    # failure (billing 402, auth, rate-limit, timeout) into None, which made
+    # the 2026-07-02 billing outage undiagnosable ("dead model" misdiagnosis).
+    status_response = await query_model_with_status(
         _get_chairman_model(), messages, disable_tools=True, timeout=timeout
     )
 
     total_usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 
-    if response is None:
-        # Fallback if chairman fails
+    if status_response.get("status") != STATUS_OK:
+        # Fallback if chairman fails — SURFACE the status + underlying error
+        # so operators can tell an infra outage apart from a code defect.
+        error_status = status_response.get("status", "error")
+        error_detail = status_response.get("error", "no detail returned")
+        logger.warning(
+            "stage-3 chairman synthesis failed: %s — %s (model=%s, latency=%sms)",
+            error_status,
+            error_detail,
+            _get_chairman_model(),
+            status_response.get("latency_ms"),
+        )
         return (
             {
                 "model": _get_chairman_model(),
-                "response": "Error: Unable to generate final synthesis.",
+                "response": (
+                    "Error: Unable to generate final synthesis "
+                    f"({error_status}: {error_detail})"
+                ),
+                "error_status": error_status,
+                "error_detail": error_detail,
             },
             total_usage,
             None,
         )
+
+    response = {
+        "content": status_response.get("content"),
+        "reasoning_details": status_response.get("reasoning_details"),
+        "usage": status_response.get("usage", {}),
+    }
 
     # Capture usage
     usage = response.get("usage", {})

--- a/tests/test_adr040_timeout_guardrails.py
+++ b/tests/test_adr040_timeout_guardrails.py
@@ -134,7 +134,7 @@ class TestStage3TimeoutFix:
         stage1_results = [{"model": "m1", "response": "Answer"}]
         stage2_results = [{"model": "m1", "ranking": "ranked"}]
 
-        with patch("llm_council.council.query_model", new_callable=AsyncMock) as mock_qm:
+        with patch("llm_council.council.query_model_with_status", new_callable=AsyncMock) as mock_qm:
             mock_qm.return_value = {
                 "content": "Synthesis",
                 "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},

--- a/tests/test_stage3_error_surfacing.py
+++ b/tests/test_stage3_error_surfacing.py
@@ -31,18 +31,25 @@ def _ok_status(content="SYNTHESIS: all good"):
     return fake
 
 
-_STAGE1 = [{"model": "m1", "response": "a"}, {"model": "m2", "response": "b"}]
-_STAGE2 = [
-    {"model": "m1", "ranking": "1. Response A", "parsed_ranking": {"ranking": ["Response A"]}}
-]
-_AGG = [{"model": "m1", "borda_score": 1.0, "rank": 1, "vote_count": 1}]
+def _stage1():
+    return [{"model": "m1", "response": "a"}, {"model": "m2", "response": "b"}]
+
+
+def _stage2():
+    return [
+        {"model": "m1", "ranking": "1. Response A", "parsed_ranking": {"ranking": ["Response A"]}}
+    ]
+
+
+def _agg():
+    return [{"model": "m1", "borda_score": 1.0, "rank": 1, "vote_count": 1}]
 
 
 @pytest.mark.asyncio
 async def test_failure_surfaces_status_and_detail(monkeypatch):
     monkeypatch.setattr(council_mod, "query_model_with_status", _failure_status())
     result, usage, verdict = await council_mod.stage3_synthesize_final(
-        "q", _STAGE1, _STAGE2, _AGG
+        "q", _stage1(), _stage2(), _agg()
     )
     text = result["response"]
     # Backward-compatible prefix retained…
@@ -63,17 +70,18 @@ async def test_timeout_failure_names_timeout(monkeypatch):
         _failure_status(status="timeout", error="Timeout after 90.0s"),
     )
     result, usage, verdict = await council_mod.stage3_synthesize_final(
-        "q", _STAGE1, _STAGE2, _AGG
+        "q", _stage1(), _stage2(), _agg()
     )
     assert result["error_status"] == "timeout"
     assert "Timeout" in result["response"]
+    assert result["error_detail"] == "Timeout after 90.0s"
 
 
 @pytest.mark.asyncio
 async def test_success_path_unchanged(monkeypatch):
     monkeypatch.setattr(council_mod, "query_model_with_status", _ok_status())
     result, usage, verdict = await council_mod.stage3_synthesize_final(
-        "q", _STAGE1, _STAGE2, _AGG
+        "q", _stage1(), _stage2(), _agg()
     )
     assert result["response"] == "SYNTHESIS: all good"
     assert "error_status" not in result

--- a/tests/test_stage3_error_surfacing.py
+++ b/tests/test_stage3_error_surfacing.py
@@ -1,0 +1,80 @@
+"""Stage-3 chairman failures must surface the underlying error (#397).
+
+During the 2026-07-02 OpenRouter billing outage, every chairman call failed in
+~70–260ms but verify only showed 'Error: Unable to generate final synthesis.'
+— the 402 was swallowed (query_model collapses all failures to None), so a
+billing outage was misdiagnosed as a dead model. Stage 3 must report status +
+error detail on failure.
+"""
+
+import pytest
+
+from llm_council import council as council_mod
+
+
+def _failure_status(status="auth_error", error="Payment required (402): insufficient credits"):
+    async def fake(model, messages, disable_tools=False, timeout=120.0, **kw):
+        return {"status": status, "error": error, "latency_ms": 81}
+
+    return fake
+
+
+def _ok_status(content="SYNTHESIS: all good"):
+    async def fake(model, messages, disable_tools=False, timeout=120.0, **kw):
+        return {
+            "status": "ok",
+            "content": content,
+            "latency_ms": 900,
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+
+    return fake
+
+
+_STAGE1 = [{"model": "m1", "response": "a"}, {"model": "m2", "response": "b"}]
+_STAGE2 = [
+    {"model": "m1", "ranking": "1. Response A", "parsed_ranking": {"ranking": ["Response A"]}}
+]
+_AGG = [{"model": "m1", "borda_score": 1.0, "rank": 1, "vote_count": 1}]
+
+
+@pytest.mark.asyncio
+async def test_failure_surfaces_status_and_detail(monkeypatch):
+    monkeypatch.setattr(council_mod, "query_model_with_status", _failure_status())
+    result, usage, verdict = await council_mod.stage3_synthesize_final(
+        "q", _STAGE1, _STAGE2, _AGG
+    )
+    text = result["response"]
+    # Backward-compatible prefix retained…
+    assert text.startswith("Error: Unable to generate final synthesis")
+    # …but the status and the underlying error are now visible.
+    assert "auth_error" in text
+    assert "402" in text
+    # And structured fields for programmatic consumers.
+    assert result["error_status"] == "auth_error"
+    assert "402" in result["error_detail"]
+
+
+@pytest.mark.asyncio
+async def test_timeout_failure_names_timeout(monkeypatch):
+    monkeypatch.setattr(
+        council_mod,
+        "query_model_with_status",
+        _failure_status(status="timeout", error="Timeout after 90.0s"),
+    )
+    result, usage, verdict = await council_mod.stage3_synthesize_final(
+        "q", _STAGE1, _STAGE2, _AGG
+    )
+    assert result["error_status"] == "timeout"
+    assert "Timeout" in result["response"]
+
+
+@pytest.mark.asyncio
+async def test_success_path_unchanged(monkeypatch):
+    monkeypatch.setattr(council_mod, "query_model_with_status", _ok_status())
+    result, usage, verdict = await council_mod.stage3_synthesize_final(
+        "q", _STAGE1, _STAGE2, _AGG
+    )
+    assert result["response"] == "SYNTHESIS: all good"
+    assert "error_status" not in result
+    assert usage["prompt_tokens"] == 10


### PR DESCRIPTION
Diagnosis revision: the #397 instant chairman failures were the **OpenRouter billing outage** (now resolved — re-test `fe40ad47` shows stage 3 running fully). The real code defect: `query_model` collapses every failure into `None`, so the outage was undiagnosable.

Fix: stage 3 uses `query_model_with_status`; failures now surface the status + detail in the synthesis text, structured `error_status`/`error_detail` fields, and a warning log. Success path unchanged.

3 new tests; suite 3001 green.

Closes #397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)