### PR TITLE
feat(mcp): ADR-045 P1 — Tasks core layer (store, capability ids, kill-switch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **MCP Tasks core layer (ADR-045 Phase 1, #404)** — groundwork for the MCP 2026-07-28 Tasks primitive (long-running deliberations that survive client disconnects): a durable `TaskStore` under `.council/tasks/` (24h expiry, size-capped eviction, in-memory fallback), 128-bit capability task ids with no enumeration API, a `LLM_COUNCIL_MCP_TASKS` kill-switch, and SDK feature-detection. The MCP wiring itself is **blocked pending the stable SDK v2** (targeted 2026-07-28 alongside the spec; the current pin is `mcp<1.27`) — synchronous tool behaviour is byte-identical until then.
+
 ### Fixed
 
 - **Stage-3 chairman failures no longer swallow the underlying error (#397)** — `stage3_synthesize_final` used `query_model`, which collapses every failure (billing 402, auth, rate-limit, timeout) into `None`, so the fallback emitted only 'Error: Unable to generate final synthesis.' During the 2026-07-02 OpenRouter billing outage this made an infra failure look like a dead chairman model. Stage 3 now uses the status-preserving call and surfaces the failure class and detail in the synthesis text (`… (auth_error: Payment required (402): …)`), in structured `error_status`/`error_detail` fields, and in a warning log.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,9 @@ Bias (ADR-015/018)
 - `bias_audit.py` (ADR-015) — per-session indicators: length↔score correlation (pure-Python Pearson), reviewer calibration, position bias. **These are anomaly indicators, not statistically robust proof** — with N=4–5 models there are only 4–5 data points (≥30 needed for significance), and a single ordering can't separate position effects from quality.
 - `bias_persistence.py` (ADR-018 P1) — JSONL store, `ConsentLevel` (OFF→RESEARCH). `bias_aggregation.py` (ADR-018 P2-3) — cross-session pooled correlation w/ CIs (Fisher-z), confidence tiers, temporal trends, anomaly flagging. Surfaced via `llm-council bias-report`.
 
+MCP 2026-07-28 adoption (ADR-045, Phase 1 core)
+- `mcp_tasks.py` — SDK-independent Tasks layer: `TaskStore` (durable `.council/tasks/`, 24h expiry, size-capped eviction, in-memory fallback), 128-bit capability task ids (no enumeration API — the id IS the authz), `LLM_COUNCIL_MCP_TASKS` kill-switch, and `sdk_supports_tasks()` feature-detection. **Blocked-pending-SDK:** the repo pins `mcp<1.27`; Tasks ships in SDK 2.x (stable v2 targeted 2026-07-28) — `maybe_expose_tasks` is a documented no-op until the pin bump, so sync tools stay byte-identical.
+
 Observability & telemetry
 - `observability/` (ADR-030 metrics export — StatsD/Prometheus/NoOp), `telemetry.py` / `telemetry_client.py`, `webhooks/`.
 
@@ -106,6 +109,7 @@ Single Pydantic source of truth consolidating ADR-020/022/023/026/030/031. Prior
 | `LLM_COUNCIL_PERFORMANCE_SELECTION` | ADR-044 P1: blend the live performance index into model selection (default off; auditable route receipt on change) |
 | `LLM_COUNCIL_EARLY_CONSENSUS` | ADR-044 P2: cancel remaining Stage-2 reviewers once the Borda leader is mathematically unassailable (default off = shadow mode, which only logs would-have-saved) |
 | `LLM_COUNCIL_GRADUATED_DEPTH` | ADR-044 P3: graduated deliberation depth ladder single→mini→full with consensus-gated escalation + budget veto (default off) |
+| `LLM_COUNCIL_MCP_TASKS` | ADR-045 P1 kill-switch: disable MCP Tasks exposure even on a task-capable SDK (default enabled-when-supported) |
 | `LLM_COUNCIL_MODEL_INTELLIGENCE=true` | Enable dynamic model selection (ADR-026) |
 | `LLM_COUNCIL_OFFLINE=true` | Force offline / static provider |
 | `LLM_COUNCIL_DISCOVERY_ENABLED` / `_INTERVAL` (300) / `_MIN_CANDIDATES` (3) | Background discovery (ADR-028) |

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -619,6 +619,11 @@ async def audit(
 
 def main():
     """Entry point for the llm-council command."""
+    # ADR-045 P1: feature-detected Tasks exposure — no-op on SDKs < 2.x
+    # (sync tools stay byte-identical); activates after the stable-v2 pin bump.
+    from .mcp_tasks import maybe_expose_tasks
+
+    maybe_expose_tasks(mcp)
     mcp.run()
 
 

--- a/src/llm_council/mcp_tasks.py
+++ b/src/llm_council/mcp_tasks.py
@@ -110,6 +110,9 @@ class TaskStore:
             return
         try:
             path.write_text(json.dumps(task))
+            # A successful disk write is authoritative: drop any memory copy
+            # so reads can never see a stale divergent state (no split-brain).
+            self._memory.pop(task_id, None)
         except Exception as exc:
             logger.debug("task write failed (%s); using memory", exc)
             self._memory[task_id] = task
@@ -147,33 +150,48 @@ class TaskStore:
         self._write(task_id, task)
 
     def complete(self, task_id: str, result: Dict[str, Any]) -> None:
-        task = self.get(task_id) or {"kind": "unknown", "created_at": time.time()}
+        task = self.get(task_id)
+        if task is None:
+            # Never create/resurrect a task for an unknown or expired id —
+            # capability ids must not be forgeable via state-transition calls.
+            logger.debug("complete() for unknown/expired task %s ignored", task_id)
+            return
         task["status"] = "complete"
         task["result"] = result
         self._write(task_id, task)
 
     def fail(self, task_id: str, error_status: str, error_detail: str) -> None:
-        task = self.get(task_id) or {"kind": "unknown", "created_at": time.time()}
+        task = self.get(task_id)
+        if task is None:
+            logger.debug("fail() for unknown/expired task %s ignored", task_id)
+            return
         task["status"] = "failed"
         task["error_status"] = error_status
         task["error_detail"] = error_detail
         self._write(task_id, task)
 
     def get(self, task_id: str) -> Optional[Dict[str, Any]]:
-        """Retrieve by capability id; expired tasks are reaped on access."""
+        """Retrieve by capability id; expired tasks are reaped on access.
+
+        Memory is checked FIRST: it is only ever populated when a disk write
+        failed, so a memory entry is by construction newer than any disk copy
+        (split-brain prevention — successful disk writes purge it).
+        """
+        if task_id in self._memory:
+            return self._memory[task_id]
         path = self._path(task_id)
         if path is None:
-            return self._memory.get(task_id)
+            return None
         try:
             if not path.exists():
-                return self._memory.get(task_id)
+                return None
             if time.time() - path.stat().st_mtime > self._ttl:
                 path.unlink(missing_ok=True)
                 return None
             return json.loads(path.read_text())
         except Exception as exc:
             logger.debug("task read failed (%s)", exc)
-            return self._memory.get(task_id)
+            return None
 
 
 def maybe_expose_tasks(server: Any) -> bool:

--- a/src/llm_council/mcp_tasks.py
+++ b/src/llm_council/mcp_tasks.py
@@ -53,9 +53,10 @@ def new_task_id() -> str:
 def sdk_supports_tasks() -> bool:
     """Feature-detect Tasks support in the installed ``mcp`` SDK.
 
-    Tasks ships in SDK 2.x (beta 2.0.0b1 for the 2026-07-28 RC; stable v2
-    targeted for 2026-07-28). Detection is by capability, not version string,
-    so it lights up on whatever release actually carries the types. Never
+    Detection is by capability, not version string, so it lights up on
+    whatever release actually carries the types — note mcp 1.26 already ships
+    the EXPERIMENTAL SEP-1686 types (within our ``<1.27`` pin), while the
+    stable primitive lands in SDK 2.x alongside the 2026-07-28 spec. Never
     raises.
     """
     try:
@@ -255,8 +256,11 @@ def maybe_expose_tasks(server: Any) -> bool:
     if not sdk_supports_tasks():
         logger.debug("mcp SDK lacks Tasks support (pin < 2.x); sync-only mode")
         return False
-    logger.warning(
-        "mcp SDK reports Tasks support but exposure wiring is not yet "
-        "implemented (ADR-045 P1 follow-up: bump pin + wire after stable v2)"
+    # mcp 1.26 within the current pin already advertises the EXPERIMENTAL
+    # types, so this path is routine — log at info, not warning, to avoid
+    # noise on every server start.
+    logger.info(
+        "mcp SDK reports Tasks types but exposure wiring is deferred to the "
+        "stable SDK v2 pin bump (ADR-045 P1 follow-up, spec final 2026-07-28)"
     )
     return False

--- a/src/llm_council/mcp_tasks.py
+++ b/src/llm_council/mcp_tasks.py
@@ -1,0 +1,199 @@
+"""MCP Tasks support layer (ADR-045 Phase 1, #404).
+
+The MCP 2026-07-28 specification promotes the Tasks primitive (SEP-1686,
+experimental since 2025-11-25) for long-running operations — purpose-built for
+30–600s council deliberations that outlive client transports.
+
+This module is the **SDK-independent core**: a durable task store with
+capability-id semantics, expiry/eviction, and a kill-switch — all per the
+ADR-045 council-review feedback. The actual MCP wiring is feature-detected:
+the repo pins ``mcp>=1.22,<1.27`` while Tasks ships in SDK 2.x (stable v2 is
+scheduled alongside the spec on 2026-07-28), so ``sdk_supports_tasks()``
+returns False today and the server keeps its synchronous behaviour
+byte-identical. When the stable v2 pin lands, exposure activates via
+``maybe_expose_tasks`` without touching the sync path.
+
+Security model (council feedback): a task id is a **capability** — 128 bits of
+randomness returned only to the creating client; retrieval requires it, and
+the store deliberately has no enumeration API.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS = 24 * 3600  # council feedback: 24h expiry
+DEFAULT_MAX_TASKS = 200  # size-capped eviction
+
+
+def mcp_tasks_enabled() -> bool:
+    """Kill-switch (council feedback): ``LLM_COUNCIL_MCP_TASKS=false`` disables
+    task exposure even on a task-capable SDK. Default enabled-when-supported."""
+    return os.getenv("LLM_COUNCIL_MCP_TASKS", "true").lower() not in (
+        "false",
+        "0",
+        "no",
+    )
+
+
+def new_task_id() -> str:
+    """A capability id: 128 bits of CSPRNG randomness, hex-encoded."""
+    return secrets.token_hex(16)
+
+
+def sdk_supports_tasks() -> bool:
+    """Feature-detect Tasks support in the installed ``mcp`` SDK.
+
+    Tasks ships in SDK 2.x (beta 2.0.0b1 for the 2026-07-28 RC; stable v2
+    targeted for 2026-07-28). Detection is by capability, not version string,
+    so it lights up on whatever release actually carries the types. Never
+    raises.
+    """
+    try:
+        import mcp.types as mcp_types  # type: ignore
+
+        return hasattr(mcp_types, "Task") or hasattr(mcp_types, "CreateTaskResult")
+    except Exception:
+        return False
+
+
+class TaskStore:
+    """Durable store for long-running deliberation results.
+
+    On-disk under ``.council/tasks/`` (same durability class as transcripts),
+    one JSON file per task keyed by the capability id. Falls back to an
+    in-memory dict when the directory is unusable — degrading to
+    within-process semantics, never crashing (council feedback).
+    """
+
+    def __init__(
+        self,
+        base_dir: Optional[Path] = None,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+        max_tasks: int = DEFAULT_MAX_TASKS,
+    ) -> None:
+        self._ttl = ttl_seconds
+        self._max_tasks = max_tasks
+        self._memory: Dict[str, Dict[str, Any]] = {}
+        self._dir: Optional[Path] = None
+        try:
+            directory = base_dir if base_dir is not None else Path(".council") / "tasks"
+            directory.mkdir(parents=True, exist_ok=True)
+            probe = directory / ".probe"
+            probe.write_text("")
+            probe.unlink()
+            self._dir = directory
+        except Exception as exc:
+            logger.warning(
+                "task store directory unusable (%s); falling back to in-memory "
+                "(tasks will not survive the process)",
+                exc,
+            )
+
+    # -- internals ----------------------------------------------------------
+
+    def _path(self, task_id: str) -> Optional[Path]:
+        return (self._dir / f"{task_id}.json") if self._dir is not None else None
+
+    def _write(self, task_id: str, task: Dict[str, Any]) -> None:
+        path = self._path(task_id)
+        if path is None:
+            self._memory[task_id] = task
+            return
+        try:
+            path.write_text(json.dumps(task))
+        except Exception as exc:
+            logger.debug("task write failed (%s); using memory", exc)
+            self._memory[task_id] = task
+
+    def _evict(self) -> None:
+        if self._dir is None:
+            while len(self._memory) > self._max_tasks:
+                self._memory.pop(next(iter(self._memory)))
+            return
+        try:
+            files = sorted(self._dir.glob("*.json"), key=lambda f: f.stat().st_mtime)
+            for f in files[: max(0, len(files) - self._max_tasks)]:
+                f.unlink(missing_ok=True)
+        except Exception as exc:
+            logger.debug("task eviction failed (ignored): %s", exc)
+
+    # -- public API (no enumeration by design) ------------------------------
+
+    def create(self, kind: str) -> str:
+        """Create a pending task; returns its capability id."""
+        task_id = new_task_id()
+        self._write(
+            task_id,
+            {"kind": kind, "status": "pending", "created_at": time.time()},
+        )
+        self._evict()
+        return task_id
+
+    def set_progress(self, task_id: str, progress: Dict[str, Any]) -> None:
+        task = self.get(task_id)
+        if task is None:
+            return
+        task["status"] = "running"
+        task["progress"] = progress
+        self._write(task_id, task)
+
+    def complete(self, task_id: str, result: Dict[str, Any]) -> None:
+        task = self.get(task_id) or {"kind": "unknown", "created_at": time.time()}
+        task["status"] = "complete"
+        task["result"] = result
+        self._write(task_id, task)
+
+    def fail(self, task_id: str, error_status: str, error_detail: str) -> None:
+        task = self.get(task_id) or {"kind": "unknown", "created_at": time.time()}
+        task["status"] = "failed"
+        task["error_status"] = error_status
+        task["error_detail"] = error_detail
+        self._write(task_id, task)
+
+    def get(self, task_id: str) -> Optional[Dict[str, Any]]:
+        """Retrieve by capability id; expired tasks are reaped on access."""
+        path = self._path(task_id)
+        if path is None:
+            return self._memory.get(task_id)
+        try:
+            if not path.exists():
+                return self._memory.get(task_id)
+            if time.time() - path.stat().st_mtime > self._ttl:
+                path.unlink(missing_ok=True)
+                return None
+            return json.loads(path.read_text())
+        except Exception as exc:
+            logger.debug("task read failed (%s)", exc)
+            return self._memory.get(task_id)
+
+
+def maybe_expose_tasks(server: Any) -> bool:
+    """Activate MCP task exposure iff the SDK supports it AND the kill-switch
+    allows it. Returns whether exposure happened.
+
+    NOTE (blocked-pending-SDK): with the current pin (``mcp<1.27``) this is
+    always a no-op — the Tasks primitive ships in SDK 2.x (stable targeted
+    2026-07-28). When the pin is bumped, implement the wiring here: register
+    task-augmented variants of ``consult_council``/``verify`` backed by a
+    ``TaskStore``, leaving the synchronous tools untouched.
+    """
+    if not mcp_tasks_enabled():
+        logger.info("MCP tasks disabled by LLM_COUNCIL_MCP_TASKS")
+        return False
+    if not sdk_supports_tasks():
+        logger.debug("mcp SDK lacks Tasks support (pin < 2.x); sync-only mode")
+        return False
+    logger.warning(
+        "mcp SDK reports Tasks support but exposure wiring is not yet "
+        "implemented (ADR-045 P1 follow-up: bump pin + wire after stable v2)"
+    )
+    return False

--- a/src/llm_council/mcp_tasks.py
+++ b/src/llm_council/mcp_tasks.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import secrets
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -84,6 +85,8 @@ class TaskStore:
         self._max_tasks = max_tasks
         self._memory: Dict[str, Dict[str, Any]] = {}
         self._dir: Optional[Path] = None
+        # Reentrant: state transitions call get() internally while holding it.
+        self._lock = threading.RLock()
         try:
             directory = base_dir if base_dir is not None else Path(".council") / "tasks"
             directory.mkdir(parents=True, exist_ok=True)
@@ -109,13 +112,26 @@ class TaskStore:
             self._memory[task_id] = task
             return
         try:
-            path.write_text(json.dumps(task))
+            # Atomic write (round-2): tmp + os.replace so a concurrent reader
+            # never sees a torn/partial JSON file.
+            tmp = path.with_name(path.name + ".tmp")
+            tmp.write_text(json.dumps(task))
+            os.replace(tmp, path)
             # A successful disk write is authoritative: drop any memory copy
             # so reads can never see a stale divergent state (no split-brain).
             self._memory.pop(task_id, None)
         except Exception as exc:
             logger.debug("task write failed (%s); using memory", exc)
             self._memory[task_id] = task
+
+    def _expired(self, task: Dict[str, Any]) -> bool:
+        # TTL is measured from created_at (round-2): frequent progress writes
+        # must not immortalize a task the way an mtime-based check would.
+        # A record with no parseable created_at is treated as expired.
+        created = task.get("created_at")
+        if not isinstance(created, (int, float)):
+            return True
+        return time.time() - created > self._ttl
 
     def _evict(self) -> None:
         if self._dir is None:
@@ -134,41 +150,50 @@ class TaskStore:
     def create(self, kind: str) -> str:
         """Create a pending task; returns its capability id."""
         task_id = new_task_id()
-        self._write(
-            task_id,
-            {"kind": kind, "status": "pending", "created_at": time.time()},
-        )
-        self._evict()
+        with self._lock:
+            self._write(
+                task_id,
+                {"kind": kind, "status": "pending", "created_at": time.time()},
+            )
+            self._evict()
         return task_id
 
     def set_progress(self, task_id: str, progress: Dict[str, Any]) -> None:
-        task = self.get(task_id)
-        if task is None:
-            return
-        task["status"] = "running"
-        task["progress"] = progress
-        self._write(task_id, task)
+        with self._lock:
+            task = self.get(task_id)
+            if task is None:
+                return
+            if task.get("status") in ("complete", "failed"):
+                # Terminal states are final (round-2): late progress (e.g.
+                # racing a cancellation) must not revert them to "running".
+                logger.debug("set_progress() on terminal task %s ignored", task_id)
+                return
+            task["status"] = "running"
+            task["progress"] = progress
+            self._write(task_id, task)
 
     def complete(self, task_id: str, result: Dict[str, Any]) -> None:
-        task = self.get(task_id)
-        if task is None:
-            # Never create/resurrect a task for an unknown or expired id —
-            # capability ids must not be forgeable via state-transition calls.
-            logger.debug("complete() for unknown/expired task %s ignored", task_id)
-            return
-        task["status"] = "complete"
-        task["result"] = result
-        self._write(task_id, task)
+        with self._lock:
+            task = self.get(task_id)
+            if task is None:
+                # Never create/resurrect a task for an unknown or expired id —
+                # capability ids must not be forgeable via state-transition calls.
+                logger.debug("complete() for unknown/expired task %s ignored", task_id)
+                return
+            task["status"] = "complete"
+            task["result"] = result
+            self._write(task_id, task)
 
     def fail(self, task_id: str, error_status: str, error_detail: str) -> None:
-        task = self.get(task_id)
-        if task is None:
-            logger.debug("fail() for unknown/expired task %s ignored", task_id)
-            return
-        task["status"] = "failed"
-        task["error_status"] = error_status
-        task["error_detail"] = error_detail
-        self._write(task_id, task)
+        with self._lock:
+            task = self.get(task_id)
+            if task is None:
+                logger.debug("fail() for unknown/expired task %s ignored", task_id)
+                return
+            task["status"] = "failed"
+            task["error_status"] = error_status
+            task["error_detail"] = error_detail
+            self._write(task_id, task)
 
     def get(self, task_id: str) -> Optional[Dict[str, Any]]:
         """Retrieve by capability id; expired tasks are reaped on access.
@@ -177,21 +202,27 @@ class TaskStore:
         failed, so a memory entry is by construction newer than any disk copy
         (split-brain prevention — successful disk writes purge it).
         """
-        if task_id in self._memory:
-            return self._memory[task_id]
-        path = self._path(task_id)
-        if path is None:
-            return None
-        try:
-            if not path.exists():
+        with self._lock:
+            if task_id in self._memory:
+                task = self._memory[task_id]
+                if self._expired(task):
+                    self._memory.pop(task_id, None)
+                    return None
+                return task
+            path = self._path(task_id)
+            if path is None:
                 return None
-            if time.time() - path.stat().st_mtime > self._ttl:
-                path.unlink(missing_ok=True)
+            try:
+                if not path.exists():
+                    return None
+                task = json.loads(path.read_text())
+                if self._expired(task):
+                    path.unlink(missing_ok=True)
+                    return None
+                return task
+            except Exception as exc:
+                logger.debug("task read failed (%s)", exc)
                 return None
-            return json.loads(path.read_text())
-        except Exception as exc:
-            logger.debug("task read failed (%s)", exc)
-            return None
 
 
 def maybe_expose_tasks(server: Any) -> bool:

--- a/src/llm_council/mcp_tasks.py
+++ b/src/llm_council/mcp_tasks.py
@@ -134,11 +134,18 @@ class TaskStore:
         return time.time() - created > self._ttl
 
     def _evict(self) -> None:
+        # Memory entries are capped unconditionally (round-3): even with a
+        # usable directory, per-write disk failures fall back to memory and
+        # must not accumulate unbounded.
+        while len(self._memory) > self._max_tasks:
+            self._memory.pop(next(iter(self._memory)))
         if self._dir is None:
-            while len(self._memory) > self._max_tasks:
-                self._memory.pop(next(iter(self._memory)))
             return
         try:
+            # Size-cap eviction deliberately orders by mtime (least recently
+            # UPDATED goes first) — distinct from TTL, which is absolute from
+            # created_at. An active long-running task should survive the size
+            # cap; the TTL still bounds its total lifetime.
             files = sorted(self._dir.glob("*.json"), key=lambda f: f.stat().st_mtime)
             for f in files[: max(0, len(files) - self._max_tasks)]:
                 f.unlink(missing_ok=True)
@@ -180,6 +187,10 @@ class TaskStore:
                 # capability ids must not be forgeable via state-transition calls.
                 logger.debug("complete() for unknown/expired task %s ignored", task_id)
                 return
+            if task.get("status") in ("complete", "failed"):
+                # Terminal states are first-writer-wins (round-3).
+                logger.debug("complete() on terminal task %s ignored", task_id)
+                return
             task["status"] = "complete"
             task["result"] = result
             self._write(task_id, task)
@@ -189,6 +200,9 @@ class TaskStore:
             task = self.get(task_id)
             if task is None:
                 logger.debug("fail() for unknown/expired task %s ignored", task_id)
+                return
+            if task.get("status") in ("complete", "failed"):
+                logger.debug("fail() on terminal task %s ignored", task_id)
                 return
             task["status"] = "failed"
             task["error_status"] = error_status

--- a/tests/test_mcp_tasks.py
+++ b/tests/test_mcp_tasks.py
@@ -3,6 +3,7 @@
 import json
 import time
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -172,3 +173,32 @@ class TestCouncilRound2Findings:
         store.complete(tid, {"ok": 1})
         store.set_progress(tid, {"stage": 2})  # late progress after completion
         assert store.get(tid)["status"] == "complete"
+
+
+class TestCouncilRound3Findings:
+    def test_terminal_states_are_first_writer_wins(self, tmp_path):
+        store = TaskStore(base_dir=tmp_path)
+        tid = store.create(kind="k")
+        store.fail(tid, "timeout", "deadline exceeded")
+        store.complete(tid, {"late": True})  # must not overwrite failed
+        assert store.get(tid)["status"] == "failed"
+        tid2 = store.create(kind="k")
+        store.complete(tid2, {"ok": 1})
+        store.fail(tid2, "late", "ignored")  # must not overwrite complete
+        assert store.get(tid2)["status"] == "complete"
+
+    def test_memory_fallback_entries_are_capped_even_with_dir_set(self, tmp_path):
+        # Per-write disk failures fall back to memory while _dir is set;
+        # those entries must still respect max_tasks.
+        store = TaskStore(base_dir=tmp_path, max_tasks=3)
+        real_write_text = Path.write_text
+
+        def failing_write(self, *a, **kw):
+            if self.parent == tmp_path and self.name.endswith(".tmp"):
+                raise OSError("disk full")
+            return real_write_text(self, *a, **kw)
+
+        with mock.patch.object(Path, "write_text", failing_write):
+            for _ in range(6):
+                store.create(kind="k")
+        assert len(store._memory) <= 3

--- a/tests/test_mcp_tasks.py
+++ b/tests/test_mcp_tasks.py
@@ -59,11 +59,12 @@ class TestTaskStore:
         store = TaskStore(base_dir=tmp_path, ttl_seconds=1)
         tid = store.create(kind="verify")
         store.complete(tid, {"ok": True})
-        # Backdate the file well past the TTL.
+        # Backdate created_at well past the TTL (round-2: TTL is measured
+        # from created_at, not file mtime).
         f = next(tmp_path.glob("*.json"))
-        old = time.time() - 10
-        import os
-        os.utime(f, (old, old))
+        data = json.loads(f.read_text())
+        data["created_at"] = time.time() - 10
+        f.write_text(json.dumps(data))
         assert store.get(tid) is None  # expired
         assert not f.exists()  # reaped on access
 
@@ -116,12 +117,12 @@ class TestCouncilRound1Findings:
         assert list(tmp_path.glob("*.json")) == []
 
     def test_expired_task_cannot_be_resurrected(self, tmp_path):
-        import os
         store = TaskStore(base_dir=tmp_path, ttl_seconds=1)
         tid = store.create(kind="k")
         f = next(tmp_path.glob("*.json"))
-        old = time.time() - 10
-        os.utime(f, (old, old))
+        data = json.loads(f.read_text())
+        data["created_at"] = time.time() - 10
+        f.write_text(json.dumps(data))
         store.complete(tid, {"late": True})  # arrives after expiry
         assert store.get(tid) is None
 
@@ -143,3 +144,31 @@ class TestCouncilRound1Findings:
         monkeypatch.undo()
         task = store.get(tid)
         assert task["status"] == "complete"  # memory (newer) wins over stale disk
+
+
+class TestCouncilRound2Findings:
+    def test_memory_tasks_expire_too(self, tmp_path):
+        target = tmp_path / "blocked"
+        target.write_text("not a dir")  # force memory mode
+        store = TaskStore(base_dir=target, ttl_seconds=1)
+        tid = store.create(kind="k")
+        # Backdate the in-memory created_at past the TTL.
+        store._memory[tid]["created_at"] = time.time() - 10
+        assert store.get(tid) is None
+
+    def test_ttl_measured_from_created_at_not_mtime(self, tmp_path):
+        # Frequent progress writes must not immortalize a task.
+        store = TaskStore(base_dir=tmp_path, ttl_seconds=1)
+        tid = store.create(kind="k")
+        f = next(tmp_path.glob("*.json"))
+        data = json.loads(f.read_text())
+        data["created_at"] = time.time() - 10  # created long ago
+        f.write_text(json.dumps(data))  # fresh mtime, stale created_at
+        assert store.get(tid) is None
+
+    def test_progress_cannot_revert_completed_task(self, tmp_path):
+        store = TaskStore(base_dir=tmp_path)
+        tid = store.create(kind="k")
+        store.complete(tid, {"ok": 1})
+        store.set_progress(tid, {"stage": 2})  # late progress after completion
+        assert store.get(tid)["status"] == "complete"

--- a/tests/test_mcp_tasks.py
+++ b/tests/test_mcp_tasks.py
@@ -98,11 +98,23 @@ class TestSdkDetection:
     def test_detection_returns_bool_and_never_raises(self):
         assert isinstance(sdk_supports_tasks(), bool)
 
-    def test_current_pin_lacks_tasks(self):
-        # Repo pins mcp <1.27; the Tasks primitive ships in SDK 2.x. If this
-        # starts returning True after the stable-v2 bump, wire the exposure
-        # (see mcp_tasks.maybe_expose_tasks note).
-        assert sdk_supports_tasks() is False
+    def test_detection_matches_installed_sdk(self):
+        # Environment-agnostic: mcp 1.26+ already ships the EXPERIMENTAL
+        # SEP-1686 Task types (CI resolves 1.26 within the <1.27 pin; older
+        # local envs may lack them), so detection must simply mirror the
+        # installed SDK — never a hardcoded expectation.
+        import mcp.types as mcp_types
+
+        expected = hasattr(mcp_types, "Task") or hasattr(mcp_types, "CreateTaskResult")
+        assert sdk_supports_tasks() is expected
+
+    def test_maybe_expose_tasks_is_noop_pending_stable_sdk(self):
+        # THE invariant: regardless of what the installed SDK advertises
+        # (experimental types in 1.26, beta 2.0.0b1, …), exposure stays a
+        # no-op until the stable-v2 pin bump wires it deliberately.
+        from llm_council.mcp_tasks import maybe_expose_tasks
+
+        assert maybe_expose_tasks(object()) is False
 
 
 class TestCouncilRound1Findings:

--- a/tests/test_mcp_tasks.py
+++ b/tests/test_mcp_tasks.py
@@ -101,3 +101,45 @@ class TestSdkDetection:
         # starts returning True after the stable-v2 bump, wire the exposure
         # (see mcp_tasks.maybe_expose_tasks note).
         assert sdk_supports_tasks() is False
+
+
+class TestCouncilRound1Findings:
+    def test_complete_on_unknown_id_is_noop_no_phantom(self, tmp_path):
+        # #423 round-1: complete()/fail() must NOT create/resurrect a task for
+        # an unknown or expired id (the capability id would become forgeable).
+        store = TaskStore(base_dir=tmp_path)
+        ghost = "f" * 32
+        store.complete(ghost, {"ok": 1})
+        assert store.get(ghost) is None
+        store.fail(ghost, "error", "detail")
+        assert store.get(ghost) is None
+        assert list(tmp_path.glob("*.json")) == []
+
+    def test_expired_task_cannot_be_resurrected(self, tmp_path):
+        import os
+        store = TaskStore(base_dir=tmp_path, ttl_seconds=1)
+        tid = store.create(kind="k")
+        f = next(tmp_path.glob("*.json"))
+        old = time.time() - 10
+        os.utime(f, (old, old))
+        store.complete(tid, {"late": True})  # arrives after expiry
+        assert store.get(tid) is None
+
+    def test_no_split_brain_memory_wins_after_disk_failure(self, tmp_path, monkeypatch):
+        # #423 round-1: if a mid-lifecycle disk write fails and falls back to
+        # memory, subsequent reads must see the NEWER memory state, not the
+        # stale disk copy.
+        store = TaskStore(base_dir=tmp_path)
+        tid = store.create(kind="k")  # lands on disk as 'pending'
+        original_write_text = Path.write_text
+
+        def failing_write(self, *a, **kw):
+            if self.parent == tmp_path and self.suffix == ".json":
+                raise OSError("disk full")
+            return original_write_text(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "write_text", failing_write)
+        store.complete(tid, {"ok": 1})  # disk write fails -> memory fallback
+        monkeypatch.undo()
+        task = store.get(tid)
+        assert task["status"] == "complete"  # memory (newer) wins over stale disk

--- a/tests/test_mcp_tasks.py
+++ b/tests/test_mcp_tasks.py
@@ -1,0 +1,103 @@
+"""ADR-045 P1: MCP task store + capability ids + kill-switch (#404)."""
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from llm_council.mcp_tasks import (
+    TaskStore,
+    mcp_tasks_enabled,
+    new_task_id,
+    sdk_supports_tasks,
+)
+
+
+class TestKillSwitch:
+    def test_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("LLM_COUNCIL_MCP_TASKS", raising=False)
+        assert mcp_tasks_enabled() is True
+
+    def test_kill_switch(self, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_MCP_TASKS", "false")
+        assert mcp_tasks_enabled() is False
+
+
+class TestCapabilityIds:
+    def test_128_bit_hex(self):
+        tid = new_task_id()
+        assert len(tid) == 32  # 128 bits as hex
+        int(tid, 16)  # parses as hex
+
+    def test_unique(self):
+        assert len({new_task_id() for _ in range(100)}) == 100
+
+
+class TestTaskStore:
+    def test_round_trip(self, tmp_path):
+        store = TaskStore(base_dir=tmp_path)
+        tid = store.create(kind="consult_council")
+        store.set_progress(tid, {"stage": 1, "message": "collecting"})
+        store.complete(tid, {"synthesis": "answer", "usage": {"total_tokens": 5}})
+        task = store.get(tid)
+        assert task["status"] == "complete"
+        assert task["result"]["synthesis"] == "answer"
+        assert task["kind"] == "consult_council"
+
+    def test_get_unknown_id_returns_none(self, tmp_path):
+        store = TaskStore(base_dir=tmp_path)
+        assert store.get("0" * 32) is None
+
+    def test_no_enumeration_api(self, tmp_path):
+        # Capability semantics: retrieval requires the id; no list method.
+        store = TaskStore(base_dir=tmp_path)
+        assert not hasattr(store, "list")
+        assert not hasattr(store, "list_tasks")
+
+    def test_expiry(self, tmp_path):
+        store = TaskStore(base_dir=tmp_path, ttl_seconds=1)
+        tid = store.create(kind="verify")
+        store.complete(tid, {"ok": True})
+        # Backdate the file well past the TTL.
+        f = next(tmp_path.glob("*.json"))
+        old = time.time() - 10
+        import os
+        os.utime(f, (old, old))
+        assert store.get(tid) is None  # expired
+        assert not f.exists()  # reaped on access
+
+    def test_eviction_caps_task_count(self, tmp_path):
+        store = TaskStore(base_dir=tmp_path, max_tasks=3)
+        ids = [store.create(kind="k") for _ in range(5)]
+        files = list(tmp_path.glob("*.json"))
+        assert len(files) <= 3
+        # Newest survive.
+        assert store.get(ids[-1]) is not None
+
+    def test_fail_marks_failed(self, tmp_path):
+        store = TaskStore(base_dir=tmp_path)
+        tid = store.create(kind="verify")
+        store.fail(tid, "auth_error", "Payment required (402)")
+        task = store.get(tid)
+        assert task["status"] == "failed"
+        assert task["error_status"] == "auth_error"
+
+    def test_unwritable_dir_falls_back_to_memory(self, tmp_path, monkeypatch):
+        target = tmp_path / "blocked"
+        target.write_text("not a dir")  # a FILE where the dir should be
+        store = TaskStore(base_dir=target)
+        tid = store.create(kind="k")  # must not raise
+        store.complete(tid, {"ok": 1})
+        assert store.get(tid)["status"] == "complete"
+
+
+class TestSdkDetection:
+    def test_detection_returns_bool_and_never_raises(self):
+        assert isinstance(sdk_supports_tasks(), bool)
+
+    def test_current_pin_lacks_tasks(self):
+        # Repo pins mcp <1.27; the Tasks primitive ships in SDK 2.x. If this
+        # starts returning True after the stable-v2 bump, wire the exposure
+        # (see mcp_tasks.maybe_expose_tasks note).
+        assert sdk_supports_tasks() is False


### PR DESCRIPTION
Child of epic #407. SDK research first (per plan): Tasks = SEP-1686 (experimental since spec 2025-11-25); mcp SDK **2.0.0b1** supports the 2026-07-28 RC; **stable v2 targeted 2026-07-28**. We do not pin a beta in a published package → this PR ships the SDK-independent core, with the wiring as a documented no-op until the stable pin bump:

- `TaskStore`: durable `.council/tasks/` (24h TTL reaped on access, size-capped eviction, in-memory fallback) — all council-feedback items from ADR-045.
- 128-bit capability task ids; **no enumeration API** (the id is the authz).
- `LLM_COUNCIL_MCP_TASKS` kill-switch; `sdk_supports_tasks()` capability detection; `maybe_expose_tasks` startup hook (no-op on `mcp<2`, keeping sync tools byte-identical — tested).
- Follow-up (dated): bump the pin + implement exposure wiring once stable v2 ships on 2026-07-28.

13 new tests; suite 3014 green.

Closes #404. Epic: #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)