### PR TITLE
Release v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-07-03
+
+**MCP 2026-07-28 Adoption (ADR-045)** — epic [#407](https://github.com/amiable-dev/llm-council/issues/407). Early, correct adoption of the MCP 2026-07-28 spec cycle: a durable Tasks core (SDK wiring gated on the stable v2 SDK), SEP-2127 Server Card discovery, and a stateless-deployment audit with a two-instance smoke suite. Post-spec re-checks tracked in [#425](https://github.com/amiable-dev/llm-council/issues/425). Also ships the #397 chairman error-surfacing fix.
+
 ### Added
 
 - **Stateless-deployment audit + two-instance smoke (ADR-045 Phase 3, #406)** — full inventory of MCP-path state that outlives a request (`docs/adr-045-p3-state-inventory.md`): the durable `TaskStore` is the load-bearing cross-instance contract and is now pinned by a two-instance smoke suite (lifecycle split across instances, two-process concurrency, torn-read guard). Per-instance circuit breakers/metrics/caches are documented as deliberate (optimality, not correctness). One true defect fixed: the layer-event accumulator was unbounded in long-lived processes — now a ring buffer (`MAX_LAYER_EVENTS=1000`).

--- a/docs/adr/ADR-045-mcp-2026-adoption.md
+++ b/docs/adr/ADR-045-mcp-2026-adoption.md
@@ -1,6 +1,6 @@
 # ADR-045: MCP 2026-07-28 Specification Adoption (Tasks, Server Card, Stateless Transport)
 
-**Status:** Draft 2026-07-03
+**Status:** Implemented 2026-07-03 (P1 MCP wiring blocked-pending-SDK v2 — #425)
 **Date:** 2026-07-03
 **Decision Makers:** Chris Joseph, LLM Council
 **Council Review:** 2026-07-03 (4 models, balanced) — feedback incorporated: task authz, task-state persistence/expiry, phase independence, rollback semantics

--- a/server-card.json
+++ b/server-card.json
@@ -3,7 +3,7 @@
   "name": "io.github.amiable-dev/llm-council",
   "title": "LLM Council",
   "description": "Multi-model deliberation council with anonymized peer review, exposed as MCP tools.",
-  "version": "0.24.42.dev1+ga0a569b20.d20260602",
+  "version": "0.29.0",
   "websiteUrl": "https://github.com/amiable-dev/llm-council",
   "repository": {
     "source": "github",


### PR DESCRIPTION
## v0.29.0 — MCP 2026-07-28 Adoption (ADR-045, epic #407)

- **P1 Tasks core** (#404, PR #423): durable `TaskStore` (.council/tasks/, created_at TTL, atomic writes, terminal first-writer-wins), 128-bit capability ids, `LLM_COUNCIL_MCP_TASKS` kill-switch, SDK feature-detection; MCP wiring blocked-pending-SDK v2 (#425)
- **P2 Server Card** (#405, PR #424): SEP-2127 card generated from the live tool registry; served at `/server-card` + `/.well-known/mcp/server-card.json`; `llm-council server-card` CLI; static card for registry submission; RC-schema validated, final-schema re-check in #425
- **P3 stateless audit** (#406, PR #426): state inventory doc, two-instance smoke suite, bounded layer-event buffer, frontier-tier validation fix
- **#397 fix** (PR #403): stage-3 chairman errors surface error_status/error_detail instead of being swallowed

CHANGELOG consolidated; ADR-045 status → Implemented; static card stamped 0.29.0.

**Tag v0.29.0 will be pushed after merge (version confirmation pending).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)