### PR TITLE
Release v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-07-03
+
+**Streaming Deliberation (ADR-046)** — epic [#412](https://github.com/amiable-dev/llm-council/issues/412). The 30–600s spinner becomes a live deliberation view: rich per-model SSE events in a versioned envelope, opt-in chairman token streaming that assembles the identical final result, per-reviewer MCP progress, and the enabling `council.py` split (101K→44K, below the Council review cap). Non-streaming paths are byte-identical throughout.
+
 ### Added
 
 - **MCP progress surface (ADR-046 P3, #411)** — per-reviewer stage-2 progress ("<model> reviewed (n/N)") now reaches MCP `ctx.report_progress` (and the HTTP progress channel), wired only when a progress consumer exists — consumer-less runs stay byte-identical (test-pinned). `consult_council` and `verify` tool descriptions document the progress semantics.

--- a/docs/adr/ADR-046-streaming-deliberation.md
+++ b/docs/adr/ADR-046-streaming-deliberation.md
@@ -1,6 +1,6 @@
 # ADR-046: Streaming Deliberation
 
-**Status:** Draft 2026-07-03
+**Status:** Implemented 2026-07-03 (epic #412, v0.30.0)
 **Date:** 2026-07-03
 **Decision Makers:** Chris Joseph, LLM Council
 **Council Review:** 2026-07-03 (4 models, balanced) — feedback incorporated: event schemas, per-phase DoD, ADR-045 fallback

--- a/server-card.json
+++ b/server-card.json
@@ -3,7 +3,7 @@
   "name": "io.github.amiable-dev/llm-council",
   "title": "LLM Council",
   "description": "Multi-model deliberation council with anonymized peer review, exposed as MCP tools.",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "websiteUrl": "https://github.com/amiable-dev/llm-council",
   "repository": {
     "source": "github",


### PR DESCRIPTION
## v0.30.0 — Streaming Deliberation (ADR-046, epic #412)

- **P0** (#408, PR #428): council.py split below the review cap (101K → 44K + 3 modules), verbatim moves, full back-compat
- **P1** (#409, PR #430): rich SSE stage events (stage1.response / stage2.review / consensus.early_termination / stage3.start) in a versioned envelope (v/session_id/ts/seq) — Council gate PASS 0.95
- **P2** (#410, PR #431): chairman token streaming (`stream_tokens=true` → `synthesis.delta`), same-final-result equality-tested, honest UNKNOWN cost on streams
- **P3** (#411, PR #432): per-reviewer MCP progress + documented progress semantics

Non-streaming paths byte-identical throughout (test-pinned). ADR-046 status → Implemented; static card stamped 0.30.0. Follow-ups: #429 (rankings), #425 (MCP post-spec).

**Tag v0.30.0 will be pushed after merge (version confirmation pending).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)