### PR TITLE
feat(verify): ADR-047 P1 — unclear_reason disambiguation (#413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **UNCLEAR disambiguation (ADR-047 P1, #413)** — `VerifyResponse.unclear_reason` splits exit-code-2 into machine-readable causes: `infra_failure` (chairman call errored per #403 `error_status` — retry after checking billing/auth), `low_confidence` (deliberation completed below threshold — accept-and-audit per policy), `timeout` (ADR-040 global deadline — re-tier or reduce scope). Exit code stays 2 (compat, additive field); surfaced in the MCP verify output table with routing hints; `None` on pass/fail and on non-deliberated cap results (where the `error` marker governs).
+
 ## [0.30.0] - 2026-07-03
 
 **Streaming Deliberation (ADR-046)** — epic [#412](https://github.com/amiable-dev/llm-council/issues/412). The 30–600s spinner becomes a live deliberation view: rich per-model SSE events in a versioned envelope, opt-in chairman token streaming that assembles the identical final result, per-reviewer MCP progress, and the enabling `council.py` split (101K→44K, below the Council review cap). Non-streaming paths are byte-identical throughout.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ Verification (ADR-034/040/041) — `verification/api.py`
 - **Durable partial state:** `partial_state` is updated after each stage and survives `CancelledError`, so a timeout still returns `completed_stages`. `VerifyResponse` carries `timeout_fired`, `completed_stages`, and (ADR-041) `timing` / `input_metrics`.
 - **Per-tier input caps** `TIER_MAX_CHARS` (quick 15K, balanced 30K, high/reasoning 50K). Per-file truncation (#342) is surfaced as an `expansion_warnings` entry rather than silently dropped; `reasoning`/`high` can read a full 50K file.
 - Performance tracker is wired on success only, wrapped in try/except so telemetry never fails verification.
+- **UNCLEAR disambiguation (ADR-047 P1, #413):** `unclear_reason ∈ {infra_failure, low_confidence, timeout}` on every unclear verdict (`derive_unclear_reason` in `verdict_extractor.py`; timeout checked first, then #403 `error_status`, else low_confidence). Exit code stays 2 — automation routes on the reason: retry infra, accept-and-audit low confidence, re-tier timeouts. None when `error` marker is set (non-deliberated cap results).
 
 ## Key design decisions
 

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -431,6 +431,13 @@ async def verify(
     the verification stages (evidence expansion, council collection, ranking,
     verdict) — best-effort, never affects the verdict.
 
+    UNCLEAR disambiguation (ADR-047 P1): an unclear verdict carries
+    `unclear_reason` — infra_failure (chairman call errored: check
+    billing/auth then RETRY, do not treat as a review), low_confidence
+    (deliberation completed below threshold: accept-and-audit per policy
+    when blocking issues are empty), or timeout (re-tier or reduce scope).
+    Exit code stays 2 for all three; the reason is the routing signal.
+
     Args:
         snapshot_id: Git commit SHA to verify (7-40 hex characters).
         target_paths: Optional list of specific file paths to verify.

--- a/src/llm_council/verification/api.py
+++ b/src/llm_council/verification/api.py
@@ -47,6 +47,7 @@ from llm_council.verification.transcript import (
 from llm_council.verification.verdict_extractor import (
     build_verification_result,
     extract_rubric_scores_from_rankings,
+    derive_unclear_reason,
     extract_verdict_from_synthesis,
     calculate_confidence_from_agreement,
 )
@@ -581,6 +582,8 @@ async def _run_verification_pipeline(
     verdict = verification_output["verdict"]
     confidence = verification_output["confidence"]
     exit_code = _verdict_to_exit_code(verdict)
+    # ADR-047 P1 (#413): disambiguate UNCLEAR for automation.
+    unclear_reason = derive_unclear_reason(verdict, stage3_result)
 
     # ADR-041: Build timing summary
     total_elapsed_ms = int((time.monotonic() - pipeline_start) * 1000)
@@ -618,6 +621,7 @@ async def _run_verification_pipeline(
         "verdict": verdict,
         "confidence": confidence,
         "exit_code": exit_code,
+        "unclear_reason": unclear_reason,
         "rubric_scores": verification_output["rubric_scores"],
         "blocking_issues": verification_output["blocking_issues"],
         "rationale": verification_output["rationale"],
@@ -835,6 +839,7 @@ async def run_verification(
                 "verdict": "unclear",
                 "confidence": salvaged_confidence,
                 "exit_code": 2,
+                "unclear_reason": "timeout",  # ADR-047 P1 (#413)
                 "rubric_scores": salvaged_rubric,
                 "blocking_issues": [],
                 "rationale": (

--- a/src/llm_council/verification/formatting.py
+++ b/src/llm_council/verification/formatting.py
@@ -88,6 +88,17 @@ def format_verification_result(result: Dict[str, Any]) -> str:
     confidence = result.get("confidence", 0.0)
     lines.append(f"| Confidence | {confidence:.2f} |")
 
+    # ADR-047 P1 (#413): machine-readable UNCLEAR cause
+    unclear_reason = result.get("unclear_reason")
+    if unclear_reason:
+        hints = {
+            "infra_failure": "chairman call errored — check billing/auth, then retry",
+            "low_confidence": "deliberation completed below threshold — accept-and-audit per policy",
+            "timeout": "global deadline fired — re-tier or reduce scope",
+        }
+        hint = hints.get(unclear_reason, "")
+        lines.append(f"| Unclear reason | {unclear_reason} ({hint}) |")
+
     # Rubric scores
     rubric_scores = result.get("rubric_scores", {})
     for key, display_name in RUBRIC_DIMENSIONS:

--- a/src/llm_council/verification/schemas.py
+++ b/src/llm_council/verification/schemas.py
@@ -311,6 +311,20 @@ class VerifyResponse(BaseModel):
         default=None,
         description="Non-verdict error marker (e.g. 'input_too_large'); None for a real verdict",
     )
+    # ADR-047 P1 (#413): machine-readable UNCLEAR cause. None unless
+    # verdict == "unclear" (and None on non-deliberated cap results, where
+    # the `error` marker governs). Values: infra_failure | low_confidence
+    # | timeout. Exit code stays 2 for compat — this field is additive.
+    unclear_reason: Optional[str] = Field(
+        default=None,
+        description=(
+            "Why the verdict is unclear: infra_failure (chairman call errored"
+            " — retry after checking billing/auth), low_confidence"
+            " (deliberation completed below threshold — accept-and-audit per"
+            " policy), timeout (global deadline — re-tier or reduce scope)."
+            " None for pass/fail."
+        ),
+    )
     # ADR-040: Timeout guardrail fields
     timeout_fired: bool = Field(
         default=False,

--- a/src/llm_council/verification/verdict_extractor.py
+++ b/src/llm_council/verification/verdict_extractor.py
@@ -397,8 +397,9 @@ def build_verification_result(
     if verdict in ("fail", "unclear"):
         blocking_issues = extract_blocking_issues(stage3_result)
 
-    # Get rationale from synthesis
-    rationale = stage3_result.get("response", "No synthesis available.")
+    # Get rationale from synthesis (None-coalesced like the sibling
+    # extractors — a missing/None stage3_result must not raise, #434 review)
+    rationale = (stage3_result or {}).get("response") or "No synthesis available."
 
     return {
         "verdict": verdict,

--- a/src/llm_council/verification/verdict_extractor.py
+++ b/src/llm_council/verification/verdict_extractor.py
@@ -407,3 +407,30 @@ def build_verification_result(
         "blocking_issues": blocking_issues,
         "rationale": rationale,
     }
+
+
+def derive_unclear_reason(
+    verdict: str,
+    stage3_result: Any,
+    timeout_fired: bool = False,
+) -> Optional[str]:
+    """ADR-047 P1: machine-readable cause for an UNCLEAR verdict (#413).
+
+    Returns one of {"infra_failure", "low_confidence", "timeout"} when the
+    verdict is "unclear", else None. Lets automation apply distinct policies
+    (retry infra, accept-and-audit low confidence, re-tier timeouts) instead
+    of treating every exit-code-2 identically.
+
+    - timeout: the ADR-040 global deadline fired (checked first — a starved
+      chairman is a scheduling problem, not an infra one)
+    - infra_failure: the chairman call itself errored (#403 error_status —
+      billing/auth/rate-limit/transport)
+    - low_confidence: deliberation completed; confidence below threshold
+    """
+    if verdict != "unclear":
+        return None
+    if timeout_fired:
+        return "timeout"
+    if isinstance(stage3_result, dict) and stage3_result.get("error_status"):
+        return "infra_failure"
+    return "low_confidence"

--- a/tests/test_unclear_reason.py
+++ b/tests/test_unclear_reason.py
@@ -98,3 +98,17 @@ class TestTimeoutPathSetsReason:
         assert result["verdict"] == "unclear"
         assert result["unclear_reason"] == "timeout"
         assert result["exit_code"] == 2  # compat: exit code unchanged
+
+
+class TestCouncilRound1:
+    def test_build_verification_result_survives_none_stage3(self):
+        # #434 r1: rationale extraction used a bare .get on stage3_result —
+        # None (chairman never produced a dict) raised AttributeError while
+        # every sibling extractor already None-coalesces.
+        from llm_council.verification.verdict_extractor import (
+            build_verification_result,
+        )
+
+        out = build_verification_result([], [], None, confidence_threshold=0.7)
+        assert out["verdict"] == "unclear"
+        assert isinstance(out["rationale"], str)

--- a/tests/test_unclear_reason.py
+++ b/tests/test_unclear_reason.py
@@ -1,0 +1,100 @@
+"""ADR-047 P1: unclear_reason disambiguation (#413).
+
+UNCLEAR conflated three unlike causes; callers need machine-readable
+disambiguation: infra_failure (chairman errored, #403), low_confidence
+(deliberated but below threshold), timeout (global deadline).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llm_council.verification.verdict_extractor import derive_unclear_reason
+
+
+class TestDeriveUnclearReason:
+    def test_none_for_pass_and_fail(self):
+        assert derive_unclear_reason("pass", {}) is None
+        assert derive_unclear_reason("fail", {"error_status": "auth_error"}) is None
+
+    def test_timeout_wins(self):
+        assert derive_unclear_reason("unclear", {}, timeout_fired=True) == "timeout"
+
+    def test_infra_failure_from_stage3_error_status(self):
+        stage3 = {"response": "Error: ...", "error_status": "auth_error",
+                  "error_detail": "Payment required (402)"}
+        assert derive_unclear_reason("unclear", stage3) == "infra_failure"
+
+    def test_low_confidence_otherwise(self):
+        stage3 = {"response": "The verdict is unclear..."}
+        assert derive_unclear_reason("unclear", stage3) == "low_confidence"
+
+    def test_non_dict_stage3_is_low_confidence(self):
+        assert derive_unclear_reason("unclear", None) == "low_confidence"
+
+
+class TestSchemaField:
+    def test_verify_response_carries_unclear_reason(self):
+        from llm_council.verification.schemas import VerifyResponse
+
+        resp = VerifyResponse(
+            verification_id="v1",
+            verdict="unclear",
+            confidence=0.4,
+            exit_code=2,
+            rationale="r",
+            transcript_location="/tmp/t",
+            unclear_reason="low_confidence",
+        )
+        assert resp.unclear_reason == "low_confidence"
+        # Default None (pass/fail results)
+        resp2 = VerifyResponse(
+            verification_id="v2",
+            verdict="pass",
+            confidence=0.9,
+            exit_code=0,
+            rationale="r",
+            transcript_location="/tmp/t",
+        )
+        assert resp2.unclear_reason is None
+
+
+class TestTimeoutPathSetsReason:
+    @pytest.mark.asyncio
+    async def test_timeout_result_carries_timeout_reason(self):
+        from llm_council.verification.api import VerifyRequest, run_verification
+
+        request = VerifyRequest(snapshot_id="abc1234", tier="quick")
+
+        async def hanging_pipeline(*args, **kwargs):
+            await asyncio.sleep(9999)
+
+        with (
+            patch("llm_council.verification.api.VerificationContextManager") as mock_ctx_mgr,
+            patch(
+                "llm_council.verification.api._build_verification_prompt",
+                new_callable=AsyncMock,
+                return_value=("short prompt", {"kept": [], "warnings": []}),
+            ),
+            patch(
+                "llm_council.verification.api._run_verification_pipeline",
+                side_effect=hanging_pipeline,
+            ),
+            patch(
+                "llm_council.verification.api.asyncio.wait_for",
+                side_effect=asyncio.TimeoutError(),
+            ),
+        ):
+            mock_ctx = MagicMock()
+            mock_ctx.context_id = "test-ctx"
+            mock_ctx_mgr.return_value.__enter__ = MagicMock(return_value=mock_ctx)
+            mock_ctx_mgr.return_value.__exit__ = MagicMock(return_value=False)
+            mock_store = MagicMock()
+            mock_store.create_verification_directory.return_value = "/tmp/test"
+
+            result = await run_verification(request, mock_store)
+
+        assert result["verdict"] == "unclear"
+        assert result["unclear_reason"] == "timeout"
+        assert result["exit_code"] == 2  # compat: exit code unchanged


### PR DESCRIPTION
Closes #413

## Summary
Splits UNCLEAR (exit code 2) into machine-readable causes on `VerifyResponse.unclear_reason`:

| Reason | Detection | Automation policy |
|---|---|---|
| `infra_failure` | #403 `error_status` on the stage-3 result | check billing/auth, retry — never treat as a review |
| `low_confidence` | deliberation completed, confidence < threshold | accept-and-audit when blocking==[] |
| `timeout` | ADR-040 `timeout_fired` (checked first) | re-tier or reduce scope |

- Exit code **stays 2** — compat preserved, field is additive (ADR-047 mitigation).
- `None` on pass/fail and on non-deliberated cap results (the #357 `error` marker governs there).
- Surfaced in the MCP verify output table with routing hints; tool description documents the semantics; loop guidance (memory) updated to consume it.

## Tests
7 new (derivation × 5 incl. timeout-wins + non-dict stage3; schema default; timeout-path integration). Suite 3072 green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)