### PR TITLE
feat(verify): ADR-047 P2 — confidence calibration (#414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Confidence calibration (ADR-047 P2, #414)** — `llm-council calibration-report` reproducibly analyzes the verify transcript corpus (`.council/logs`): the current corpus shows the anomaly the ADR predicted — 42/42 FAIL verdicts carry ZERO blocking issues at mean confidence 0.965. `--fit` fits a monotonic (isotonic/PAV) mapping from human dispositions (`.council/calibration/dispositions.jsonl`) and persists it; every VerifyResponse now carries `confidence_calibrated` alongside raw `confidence` (identity mapping until fitted). The PASS threshold consumes the calibrated value only behind `LLM_COUNCIL_CALIBRATED_CONFIDENCE` (default off — flag-off byte-identical, test-pinned).
 - **UNCLEAR disambiguation (ADR-047 P1, #413)** — `VerifyResponse.unclear_reason` splits exit-code-2 into machine-readable causes: `infra_failure` (chairman call errored per #403 `error_status` — retry after checking billing/auth), `low_confidence` (deliberation completed below threshold — accept-and-audit per policy), `timeout` (ADR-040 global deadline — re-tier or reduce scope). Exit code stays 2 (compat, additive field); surfaced in the MCP verify output table with routing hints; `None` on pass/fail and on non-deliberated cap results (where the `error` marker governs).
 
 ## [0.30.0] - 2026-07-03

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ Verification (ADR-034/040/041) — `verification/api.py`
 - **Durable partial state:** `partial_state` is updated after each stage and survives `CancelledError`, so a timeout still returns `completed_stages`. `VerifyResponse` carries `timeout_fired`, `completed_stages`, and (ADR-041) `timing` / `input_metrics`.
 - **Per-tier input caps** `TIER_MAX_CHARS` (quick 15K, balanced 30K, high/reasoning 50K). Per-file truncation (#342) is surfaced as an `expansion_warnings` entry rather than silently dropped; `reasoning`/`high` can read a full 50K file.
 - Performance tracker is wired on success only, wrapped in try/except so telemetry never fails verification.
+- **Confidence calibration (ADR-047 P2, #414):** `verification/calibration.py` — corpus loader/analyzer over `.council/logs`, PAV isotonic fit against human dispositions (`.council/calibration/dispositions.jsonl` → `mapping.json`), piecewise-linear `CalibrationMapping` (identity fallback, monotonicity enforced on load). `confidence_calibrated` reported on every response; PASS threshold uses it ONLY behind `LLM_COUNCIL_CALIBRATED_CONFIDENCE` (default off). CLI: `llm-council calibration-report [--fit]`.
 - **UNCLEAR disambiguation (ADR-047 P1, #413):** `unclear_reason ∈ {infra_failure, low_confidence, timeout}` on every unclear verdict (`derive_unclear_reason` in `verdict_extractor.py`; timeout checked first, then #403 `error_status`, else low_confidence). Exit code stays 2 — automation routes on the reason: retry infra, accept-and-audit low confidence, re-tier timeouts. None when `error` marker is set (non-deliberated cap results).
 
 ## Key design decisions
@@ -117,6 +118,7 @@ Single Pydantic source of truth consolidating ADR-020/022/023/026/030/031. Prior
 | `LLM_COUNCIL_PERFORMANCE_SELECTION` | ADR-044 P1: blend the live performance index into model selection (default off; auditable route receipt on change) |
 | `LLM_COUNCIL_EARLY_CONSENSUS` | ADR-044 P2: cancel remaining Stage-2 reviewers once the Borda leader is mathematically unassailable (default off = shadow mode, which only logs would-have-saved) |
 | `LLM_COUNCIL_GRADUATED_DEPTH` | ADR-044 P3: graduated deliberation depth ladder single→mini→full with consensus-gated escalation + budget veto (default off) |
+| `LLM_COUNCIL_CALIBRATED_CONFIDENCE` | ADR-047 P2: PASS threshold uses calibrated confidence from the fitted mapping (default off; calibrated value always reported) |
 | `LLM_COUNCIL_MCP_TASKS` | ADR-045 P1 kill-switch: disable MCP Tasks exposure even on a task-capable SDK (default enabled-when-supported) |
 | `LLM_COUNCIL_MODEL_INTELLIGENCE=true` | Enable dynamic model selection (ADR-026) |
 | `LLM_COUNCIL_OFFLINE=true` | Force offline / static provider |

--- a/src/llm_council/cli.py
+++ b/src/llm_council/cli.py
@@ -37,6 +37,55 @@ def _is_fail_backend() -> bool:
         return True
 
 
+def calibration_report(
+    logs: str,
+    fit: bool,
+    dispositions: str,
+    output: str,
+    output_format: str,
+) -> None:
+    """ADR-047 P2: reproducible confidence-calibration analysis + optional fit."""
+    import json as _json
+    from pathlib import Path
+
+    from .verification.calibration import (
+        analyze_corpus,
+        fit_from_dispositions,
+        load_corpus,
+        load_dispositions,
+    )
+
+    records = load_corpus(Path(logs))
+    summary = analyze_corpus(records)
+    disp = load_dispositions(Path(dispositions))
+    summary["dispositions_recorded"] = len(disp)
+
+    if fit:
+        mapping = fit_from_dispositions(records, disp)
+        if mapping.is_identity:
+            summary["fit"] = "skipped — no (confidence, disposition) pairs"
+        else:
+            out_path = Path(output)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(mapping.to_json())
+            summary["fit"] = f"mapping with {len(mapping.points)} points -> {out_path}"
+
+    if output_format == "json":
+        sys.stdout.write(_json.dumps(summary, indent=2) + "\n")
+        return
+    sys.stdout.write(f"Calibration corpus: {summary['n']} results from {logs}\n")
+    sys.stdout.write(f"Verdicts: {summary.get('verdicts')}\n")
+    sys.stdout.write(f"Mean confidence by verdict: {summary.get('mean_confidence')}\n")
+    zb = summary.get("zero_blocking_fail_rate")
+    sys.stdout.write(
+        f"Zero-blocking FAIL rate: {zb} ({summary.get('zero_blocking_fails')} results) "
+        "- FAILs with no blocking issue are the over-confidence anomaly (ADR-047)\n"
+    )
+    sys.stdout.write(f"Human dispositions recorded: {summary['dispositions_recorded']}\n")
+    if "fit" in summary:
+        sys.stdout.write(f"Fit: {summary['fit']}\n")
+
+
 def main():
     """Main CLI entry point - dispatches to MCP or HTTP server."""
     parser = argparse.ArgumentParser(
@@ -151,6 +200,35 @@ def main():
         help="Write to a file instead of stdout (default: stdout)",
     )
 
+    # Calibration report (ADR-047 P2)
+    cal_parser = subparsers.add_parser(
+        "calibration-report",
+        help="Analyze verify-confidence calibration from .council/logs (ADR-047 P2)",
+    )
+    cal_parser.add_argument(
+        "--logs", type=str, default=".council/logs", help="Transcript logs directory"
+    )
+    cal_parser.add_argument(
+        "--fit",
+        action="store_true",
+        help="Fit a monotonic mapping from recorded dispositions and write it",
+    )
+    cal_parser.add_argument(
+        "--dispositions",
+        type=str,
+        default=".council/calibration/dispositions.jsonl",
+        help="JSONL of {verification_id, upheld} human dispositions",
+    )
+    cal_parser.add_argument(
+        "--output",
+        type=str,
+        default=".council/calibration/mapping.json",
+        help="Where --fit writes the mapping",
+    )
+    cal_parser.add_argument(
+        "--format", choices=["text", "json"], default="text", dest="cal_format"
+    )
+
     # Gate command (CI/CD quality gate)
     gate_parser = subparsers.add_parser(
         "gate",
@@ -209,6 +287,14 @@ def main():
             target=args.target,
             force=args.force,
             list_only=args.list_only,
+        )
+    elif args.command == "calibration-report":
+        calibration_report(
+            logs=args.logs,
+            fit=args.fit,
+            dispositions=args.dispositions,
+            output=args.output,
+            output_format=args.cal_format,
         )
     elif args.command == "server-card":
         import json as _json

--- a/src/llm_council/verification/api.py
+++ b/src/llm_council/verification/api.py
@@ -44,6 +44,10 @@ from llm_council.verification.transcript import (
     TranscriptStore,
     create_transcript_store,
 )
+from llm_council.verification.calibration import (
+    calibrated_confidence_enabled,
+    load_mapping,
+)
 from llm_council.verification.verdict_extractor import (
     build_verification_result,
     extract_rubric_scores_from_rankings,
@@ -568,7 +572,11 @@ async def _run_verification_pipeline(
 
     await report_progress("Finalizing verification result...")
 
-    # Extract verdict and scores from council output
+    # Extract verdict and scores from council output.
+    # ADR-047 P2 (#414): load the persisted calibration mapping (identity when
+    # none fitted). The threshold consumes it only behind the flag; the
+    # calibrated value is REPORTED either way.
+    calibration_mapping = load_mapping()
     verification_output = build_verification_result(
         stage1_results,
         stage2_results,
@@ -577,10 +585,19 @@ async def _run_verification_pipeline(
         # #355: prefer the chairman's structured BINARY verdict over a regex
         # over the synthesis prose. ``verdict_result`` is parsed in Stage 3.
         verdict_result=verdict_result,
+        calibrate=(
+            calibration_mapping.calibrate if calibrated_confidence_enabled() else None
+        ),
     )
 
     verdict = verification_output["verdict"]
     confidence = verification_output["confidence"]
+    confidence_calibrated = verification_output.get("confidence_calibrated")
+    if confidence_calibrated is None:
+        try:
+            confidence_calibrated = calibration_mapping.calibrate(confidence)
+        except Exception:
+            confidence_calibrated = None  # calibration never fails a run
     exit_code = _verdict_to_exit_code(verdict)
     # ADR-047 P1 (#413): disambiguate UNCLEAR for automation.
     unclear_reason = derive_unclear_reason(verdict, stage3_result)
@@ -620,6 +637,7 @@ async def _run_verification_pipeline(
         "verification_id": verification_id,
         "verdict": verdict,
         "confidence": confidence,
+        "confidence_calibrated": confidence_calibrated,
         "exit_code": exit_code,
         "unclear_reason": unclear_reason,
         "rubric_scores": verification_output["rubric_scores"],

--- a/src/llm_council/verification/calibration.py
+++ b/src/llm_council/verification/calibration.py
@@ -81,16 +81,21 @@ def load_corpus(logs_dir: Optional[Path] = None) -> List[CalibrationRecord]:
 def analyze_corpus(records: List[CalibrationRecord]) -> Dict[str, Any]:
     """Reproducible corpus summary — the ADR-036 P2 calibration-report slice."""
     by_verdict: Dict[str, List[float]] = {}
+    verdict_counts: Dict[str, int] = {}
     zero_blocking_fails = 0
     for r in records:
+        # Count EVERY record's verdict — a null-confidence result must not
+        # vanish from the histogram (#435 review); confidence stats
+        # separately use only records that carry one.
+        verdict_counts[r.verdict] = verdict_counts.get(r.verdict, 0) + 1
         if r.confidence is not None:
             by_verdict.setdefault(r.verdict, []).append(r.confidence)
         if r.verdict == "fail" and r.blocking_count == 0:
             zero_blocking_fails += 1
-    fails = sum(1 for r in records if r.verdict == "fail")
+    fails = verdict_counts.get("fail", 0)
     summary: Dict[str, Any] = {
         "n": len(records),
-        "verdicts": {v: len(cs) for v, cs in by_verdict.items()},
+        "verdicts": verdict_counts,
         "mean_confidence": {
             v: round(sum(cs) / len(cs), 3) for v, cs in by_verdict.items() if cs
         },
@@ -201,7 +206,17 @@ def load_dispositions(path: Optional[Path] = None) -> Dict[str, bool]:
                 continue
             try:
                 row = json.loads(line)
-                out[str(row["verification_id"])] = bool(row["upheld"])
+                upheld = row["upheld"]
+                # Strict boolean only: bool("false") is True — coercing a
+                # string would silently INVERT the disposition (#435 review).
+                if not isinstance(upheld, bool):
+                    logger.warning(
+                        "disposition for %s has non-boolean upheld=%r; skipped",
+                        row.get("verification_id"),
+                        upheld,
+                    )
+                    continue
+                out[str(row["verification_id"])] = upheld
             except Exception:
                 continue
     except OSError:

--- a/src/llm_council/verification/calibration.py
+++ b/src/llm_council/verification/calibration.py
@@ -67,7 +67,9 @@ def load_corpus(logs_dir: Optional[Path] = None) -> List[CalibrationRecord]:
             records.append(
                 CalibrationRecord(
                     verification_id=data.get("verification_id", result_file.parent.name),
-                    verdict=data.get("verdict", "unclear"),
+                    # Normalize case defensively — the pipeline always writes
+                    # lowercase, but the anomaly stats key on exact match.
+                    verdict=str(data.get("verdict", "unclear")).lower(),
                     confidence=data.get("confidence"),
                     blocking_count=len(data.get("blocking_issues") or []),
                     timeout_fired=bool(data.get("timeout_fired")),
@@ -198,6 +200,14 @@ def fit_from_dispositions(
         if r.confidence is None or r.verification_id not in dispositions:
             continue
         pairs.append((r.confidence, 1.0 if dispositions[r.verification_id] else 0.0))
+    if 0 < len(pairs) < 10:
+        # ADR-047: modest-N observational data — the mapping is still fitted
+        # (flag-gated adoption is the guard), but operators should know.
+        logger.warning(
+            "calibration fitted from only %d disposition pairs; treat as "
+            "PRELIMINARY (ADR-047 validates before flag-on)",
+            len(pairs),
+        )
     return CalibrationMapping(points=pav_fit(pairs))
 
 

--- a/src/llm_council/verification/calibration.py
+++ b/src/llm_council/verification/calibration.py
@@ -1,0 +1,220 @@
+"""Confidence calibration from the verify transcript corpus (ADR-047 P2, #414).
+
+Operational evidence (2026-07): on real code with zero blocking issues,
+verify confidence pins at 0.90–1.00 for FAIL — over-confident rejections
+that human disposition routinely overrode. This module makes confidence
+mean something:
+
+- ``analyze_corpus`` — reproducible summary over ``.council/logs`` (verdict/
+  confidence distributions, the zero-blocking-FAIL anomaly rate).
+- ``fit_from_dispositions`` — a simple monotonic (isotonic / PAV) mapping
+  from raw confidence to observed P(verdict upheld), fitted against human
+  dispositions recorded in ``.council/calibration/dispositions.jsonl``
+  (``{"verification_id": ..., "upheld": true|false}`` per line).
+- ``CalibrationMapping`` — piecewise-linear, monotonic, JSON-persisted at
+  ``.council/calibration/mapping.json``; identity when absent.
+
+Both confidences are surfaced on every response (``confidence`` raw,
+``confidence_calibrated``). The PASS threshold uses the calibrated value
+ONLY behind ``LLM_COUNCIL_CALIBRATED_CONFIDENCE=true`` (default off —
+flag-off behaviour byte-identical) until the mapping is validated
+(ADR-047 mitigation; modest-N observational data).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAPPING_PATH = Path(".council") / "calibration" / "mapping.json"
+DEFAULT_DISPOSITIONS_PATH = Path(".council") / "calibration" / "dispositions.jsonl"
+DEFAULT_LOGS_DIR = Path(".council") / "logs"
+
+
+def calibrated_confidence_enabled() -> bool:
+    """Flag gate: PASS thresholding uses calibrated confidence (default off)."""
+    return os.getenv("LLM_COUNCIL_CALIBRATED_CONFIDENCE", "false").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+
+
+@dataclass
+class CalibrationRecord:
+    """One verify outcome from the transcript corpus."""
+
+    verification_id: str
+    verdict: str
+    confidence: Optional[float]
+    blocking_count: int
+    timeout_fired: bool
+
+
+def load_corpus(logs_dir: Optional[Path] = None) -> List[CalibrationRecord]:
+    """Read every ``result.json`` under the transcript logs. Soft-fail per file."""
+    directory = logs_dir if logs_dir is not None else DEFAULT_LOGS_DIR
+    records: List[CalibrationRecord] = []
+    for result_file in sorted(directory.glob("*/result.json")):
+        try:
+            data = json.loads(result_file.read_text())
+            records.append(
+                CalibrationRecord(
+                    verification_id=data.get("verification_id", result_file.parent.name),
+                    verdict=data.get("verdict", "unclear"),
+                    confidence=data.get("confidence"),
+                    blocking_count=len(data.get("blocking_issues") or []),
+                    timeout_fired=bool(data.get("timeout_fired")),
+                )
+            )
+        except Exception as exc:
+            logger.debug("skipping unreadable transcript %s (%s)", result_file, exc)
+    return records
+
+
+def analyze_corpus(records: List[CalibrationRecord]) -> Dict[str, Any]:
+    """Reproducible corpus summary — the ADR-036 P2 calibration-report slice."""
+    by_verdict: Dict[str, List[float]] = {}
+    zero_blocking_fails = 0
+    for r in records:
+        if r.confidence is not None:
+            by_verdict.setdefault(r.verdict, []).append(r.confidence)
+        if r.verdict == "fail" and r.blocking_count == 0:
+            zero_blocking_fails += 1
+    fails = sum(1 for r in records if r.verdict == "fail")
+    summary: Dict[str, Any] = {
+        "n": len(records),
+        "verdicts": {v: len(cs) for v, cs in by_verdict.items()},
+        "mean_confidence": {
+            v: round(sum(cs) / len(cs), 3) for v, cs in by_verdict.items() if cs
+        },
+        # THE anomaly this ADR exists for: FAIL verdicts carrying no blocking
+        # issue at all — high-confidence rejections with nothing to reject.
+        "zero_blocking_fail_rate": round(zero_blocking_fails / fails, 3) if fails else None,
+        "zero_blocking_fails": zero_blocking_fails,
+    }
+    return summary
+
+
+def pav_fit(pairs: List[Tuple[float, float]]) -> List[Tuple[float, float]]:
+    """Pool-adjacent-violators isotonic regression.
+
+    Args:
+        pairs: (raw_confidence, outcome) with outcome in [0, 1].
+
+    Returns:
+        Monotonic (x, y) breakpoints sorted by x (mean x/y per pooled block).
+    """
+    if not pairs:
+        return []
+    data = sorted(pairs)
+    # blocks: [sum_y, count, sum_x]
+    blocks: List[List[float]] = []
+    for x, y in data:
+        blocks.append([y, 1, x])
+        # Pool while the mean of the last block is below its predecessor's.
+        while len(blocks) > 1 and blocks[-2][0] / blocks[-2][1] > blocks[-1][0] / blocks[-1][1]:
+            y2, n2, x2 = blocks.pop()
+            blocks[-1][0] += y2
+            blocks[-1][1] += n2
+            blocks[-1][2] += x2
+    return [(round(sx / n, 4), round(sy / n, 4)) for sy, n, sx in blocks]
+
+
+@dataclass
+class CalibrationMapping:
+    """Piecewise-linear monotonic map raw→calibrated confidence."""
+
+    points: List[Tuple[float, float]]  # sorted by x; empty => identity
+
+    @classmethod
+    def identity(cls) -> "CalibrationMapping":
+        return cls(points=[])
+
+    @property
+    def is_identity(self) -> bool:
+        return not self.points
+
+    def calibrate(self, confidence: float) -> float:
+        if not self.points:
+            return round(max(0.0, min(1.0, confidence)), 2)
+        pts = self.points
+        if confidence <= pts[0][0]:
+            return round(max(0.0, min(1.0, pts[0][1])), 2)
+        if confidence >= pts[-1][0]:
+            return round(max(0.0, min(1.0, pts[-1][1])), 2)
+        for (x0, y0), (x1, y1) in zip(pts, pts[1:]):
+            if x0 <= confidence <= x1:
+                if x1 == x0:
+                    return round(max(0.0, min(1.0, y1)), 2)
+                t = (confidence - x0) / (x1 - x0)
+                return round(max(0.0, min(1.0, y0 + t * (y1 - y0))), 2)
+        return round(max(0.0, min(1.0, confidence)), 2)  # pragma: no cover
+
+    def to_json(self) -> str:
+        return json.dumps({"version": 1, "points": self.points})
+
+    @classmethod
+    def from_json(cls, text: str) -> "CalibrationMapping":
+        data = json.loads(text)
+        points = [(float(x), float(y)) for x, y in data.get("points", [])]
+        # Enforce monotonicity on load — a corrupt mapping must not invert.
+        xs = [p[0] for p in points]
+        ys = [p[1] for p in points]
+        if xs != sorted(xs) or ys != sorted(ys):
+            raise ValueError("calibration mapping must be monotonic")
+        return cls(points=points)
+
+
+def fit_from_dispositions(
+    records: List[CalibrationRecord],
+    dispositions: Dict[str, bool],
+) -> CalibrationMapping:
+    """Fit the mapping against human dispositions.
+
+    ``dispositions`` maps verification_id → whether the council's verdict was
+    UPHELD by the eventual human decision (True) or overridden (False).
+    Calibrated confidence estimates P(verdict upheld | raw confidence).
+    """
+    pairs: List[Tuple[float, float]] = []
+    for r in records:
+        if r.confidence is None or r.verification_id not in dispositions:
+            continue
+        pairs.append((r.confidence, 1.0 if dispositions[r.verification_id] else 0.0))
+    return CalibrationMapping(points=pav_fit(pairs))
+
+
+def load_dispositions(path: Optional[Path] = None) -> Dict[str, bool]:
+    """Read the dispositions JSONL; soft-fail to empty."""
+    p = path if path is not None else DEFAULT_DISPOSITIONS_PATH
+    out: Dict[str, bool] = {}
+    try:
+        for line in p.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+                out[str(row["verification_id"])] = bool(row["upheld"])
+            except Exception:
+                continue
+    except OSError:
+        pass
+    return out
+
+
+def load_mapping(path: Optional[Path] = None) -> CalibrationMapping:
+    """Load the persisted mapping; identity when absent/corrupt (soft-fail)."""
+    p = path if path is not None else DEFAULT_MAPPING_PATH
+    try:
+        return CalibrationMapping.from_json(p.read_text())
+    except Exception as exc:
+        if p.exists():
+            logger.warning("calibration mapping unreadable (%s); using identity", exc)
+        return CalibrationMapping.identity()

--- a/src/llm_council/verification/calibration.py
+++ b/src/llm_council/verification/calibration.py
@@ -118,11 +118,17 @@ def pav_fit(pairs: List[Tuple[float, float]]) -> List[Tuple[float, float]]:
     """
     if not pairs:
         return []
-    data = sorted(pairs)
+    # Pre-aggregate tied x values (#435 r2): sorted() orders ties by y
+    # ascending, so the strictly-greater merge below never pooled them —
+    # leaving duplicate x breakpoints whose FIRST y won at lookup time.
+    grouped: Dict[float, List[float]] = {}
+    for x, y in pairs:
+        grouped.setdefault(x, []).append(y)
+    data = sorted((x, sum(ys), len(ys)) for x, ys in grouped.items())
     # blocks: [sum_y, count, sum_x]
     blocks: List[List[float]] = []
-    for x, y in data:
-        blocks.append([y, 1, x])
+    for x, sum_y, n in data:
+        blocks.append([sum_y, n, x * n])
         # Pool while the mean of the last block is below its predecessor's.
         while len(blocks) > 1 and blocks[-2][0] / blocks[-2][1] > blocks[-1][0] / blocks[-1][1]:
             y2, n2, x2 = blocks.pop()
@@ -217,7 +223,8 @@ def load_dispositions(path: Optional[Path] = None) -> Dict[str, bool]:
                     )
                     continue
                 out[str(row["verification_id"])] = upheld
-            except Exception:
+            except Exception as exc:
+                logger.warning("unparseable disposition line skipped (%s)", exc)
                 continue
     except OSError:
         pass

--- a/src/llm_council/verification/formatting.py
+++ b/src/llm_council/verification/formatting.py
@@ -88,6 +88,11 @@ def format_verification_result(result: Dict[str, Any]) -> str:
     confidence = result.get("confidence", 0.0)
     lines.append(f"| Confidence | {confidence:.2f} |")
 
+    # ADR-047 P2 (#414): show calibrated confidence when it diverges from raw
+    confidence_calibrated = result.get("confidence_calibrated")
+    if confidence_calibrated is not None and confidence_calibrated != confidence:
+        lines.append(f"| Confidence (calibrated) | {confidence_calibrated:.2f} |")
+
     # ADR-047 P1 (#413): machine-readable UNCLEAR cause
     unclear_reason = result.get("unclear_reason")
     if unclear_reason:

--- a/src/llm_council/verification/schemas.py
+++ b/src/llm_council/verification/schemas.py
@@ -311,6 +311,19 @@ class VerifyResponse(BaseModel):
         default=None,
         description="Non-verdict error marker (e.g. 'input_too_large'); None for a real verdict",
     )
+    # ADR-047 P2 (#414): calibrated confidence — raw stays in `confidence`.
+    confidence_calibrated: Optional[float] = Field(
+        default=None,
+        ge=0,
+        le=1,
+        description=(
+            "Confidence after the persisted monotonic calibration mapping"
+            " (.council/calibration/mapping.json; identity when absent, so it"
+            " equals the raw value until a mapping is fitted). The PASS"
+            " threshold uses this ONLY when LLM_COUNCIL_CALIBRATED_CONFIDENCE"
+            " is enabled (default off)."
+        ),
+    )
     # ADR-047 P1 (#413): machine-readable UNCLEAR cause. None unless
     # verdict == "unclear" (and None on non-deliberated cap results, where
     # the `error` marker governs). Values: infra_failure | low_confidence

--- a/src/llm_council/verification/verdict_extractor.py
+++ b/src/llm_council/verification/verdict_extractor.py
@@ -352,6 +352,7 @@ def build_verification_result(
     stage3_result: Dict[str, Any],
     confidence_threshold: float = 0.7,
     verdict_result: Optional[Any] = None,
+    calibrate: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """
     Build complete verification result from council stages.
@@ -381,7 +382,10 @@ def build_verification_result(
         verdict, confidence = structured_verdict
         # An explicit approval whose self-reported confidence is below the gate
         # threshold is the only case we soften to "unclear".
-        if verdict == "pass" and confidence < confidence_threshold:
+        # ADR-047 P2 (#414): behind the flag, the gate compares the CALIBRATED
+        # confidence (raw is always reported alongside).
+        effective = calibrate(confidence) if calibrate is not None else confidence
+        if verdict == "pass" and effective < confidence_threshold:
             verdict = "unclear"
     else:
         # Fallback: legacy regex extraction over the synthesis prose.
@@ -389,7 +393,8 @@ def build_verification_result(
         agreement_confidence = calculate_confidence_from_agreement(stage2_results, verdict)
         # Weighted average of synthesis confidence and reviewer agreement.
         confidence = round((base_confidence * 0.4) + (agreement_confidence * 0.6), 2)
-        if verdict == "pass" and confidence < confidence_threshold:
+        effective = calibrate(confidence) if calibrate is not None else confidence
+        if verdict == "pass" and effective < confidence_threshold:
             verdict = "unclear"
 
     # Extract blocking issues (only for fail/unclear)
@@ -404,6 +409,9 @@ def build_verification_result(
     return {
         "verdict": verdict,
         "confidence": confidence,
+        # ADR-047 P2: None when no calibrator was applied here — the API
+        # layer fills it from the persisted mapping for reporting either way.
+        "confidence_calibrated": calibrate(confidence) if calibrate is not None else None,
         "rubric_scores": rubric_scores,
         "blocking_issues": blocking_issues,
         "rationale": rationale,

--- a/tests/test_confidence_calibration.py
+++ b/tests/test_confidence_calibration.py
@@ -210,3 +210,31 @@ class TestCouncilRound1:
         ]
         summary = analyze_corpus(rec)
         assert summary["verdicts"] == {"unclear": 1, "fail": 1}
+
+
+class TestCouncilRound2:
+    def test_tied_confidence_values_pool_to_mean(self):
+        # #435 r2: sorted() orders ties by y ascending, so the >-only merge
+        # never pooled tied x values — calibrate(0.9) returned the FIRST tied
+        # y (0.0) instead of the mean. Real corpora cluster at 0.95/1.0.
+        points = pav_fit([(0.9, 0.0), (0.9, 1.0)])
+        assert points == [(0.9, 0.5)]
+
+    def test_ties_then_monotonic_sequence(self):
+        points = pav_fit([(0.5, 0.0), (0.9, 1.0), (0.9, 0.0), (1.0, 1.0)])
+        xs = [x for x, _ in points]
+        ys = [y for _, y in points]
+        assert xs == sorted(xs) and len(set(xs)) == len(xs)  # unique x
+        assert ys == sorted(ys)  # monotonic
+
+    def test_unparseable_disposition_lines_logged(self, tmp_path, caplog):
+        import logging
+
+        from llm_council.verification.calibration import load_dispositions
+
+        p = tmp_path / "d.jsonl"
+        p.write_text('{broken\n{"verification_id": "v1", "upheld": true}\n')
+        with caplog.at_level(logging.WARNING, logger="llm_council.verification.calibration"):
+            d = load_dispositions(p)
+        assert d == {"v1": True}
+        assert any("disposition" in r.message for r in caplog.records)

--- a/tests/test_confidence_calibration.py
+++ b/tests/test_confidence_calibration.py
@@ -183,3 +183,30 @@ class TestSchemaField:
             confidence_calibrated=0.62,
         )
         assert resp.confidence_calibrated == 0.62
+
+
+class TestCouncilRound1:
+    def test_string_false_disposition_not_coerced_to_true(self, tmp_path):
+        # #435 r1: bool("false") is True — a string disposition would be
+        # silently INVERTED. Non-boolean values must be skipped, not coerced.
+        from llm_council.verification.calibration import load_dispositions
+
+        p = tmp_path / "d.jsonl"
+        p.write_text(
+            '{"verification_id": "v1", "upheld": "false"}\n'
+            '{"verification_id": "v2", "upheld": false}\n'
+            '{"verification_id": "v3", "upheld": true}\n'
+        )
+        d = load_dispositions(p)
+        assert "v1" not in d  # string skipped, never inverted
+        assert d == {"v2": False, "v3": True}
+
+    def test_verdict_counts_include_confidence_less_records(self):
+        # #435 r1: the verdict histogram counted only records WITH a
+        # confidence — a null-confidence result vanished from the counts.
+        rec = [
+            CalibrationRecord("v1", "unclear", None, 0, True),
+            CalibrationRecord("v2", "fail", 0.9, 1, False),
+        ]
+        summary = analyze_corpus(rec)
+        assert summary["verdicts"] == {"unclear": 1, "fail": 1}

--- a/tests/test_confidence_calibration.py
+++ b/tests/test_confidence_calibration.py
@@ -1,0 +1,185 @@
+"""ADR-047 P2: confidence calibration (#414).
+
+Reproducible corpus analysis, monotonic PAV fit, both confidences surfaced,
+flag-off byte-identical.
+"""
+
+import json
+
+import pytest
+
+from llm_council.verification.calibration import (
+    CalibrationMapping,
+    CalibrationRecord,
+    analyze_corpus,
+    calibrated_confidence_enabled,
+    fit_from_dispositions,
+    load_corpus,
+    load_mapping,
+    pav_fit,
+)
+
+
+def _write_result(tmp_path, vid, verdict, confidence, blocking=0):
+    d = tmp_path / vid
+    d.mkdir()
+    (d / "result.json").write_text(
+        json.dumps(
+            {
+                "verification_id": vid,
+                "verdict": verdict,
+                "confidence": confidence,
+                "blocking_issues": [{"severity": "major", "description": "x"}] * blocking,
+            }
+        )
+    )
+
+
+class TestCorpus:
+    def test_load_and_analyze(self, tmp_path):
+        _write_result(tmp_path, "a1", "fail", 0.95, blocking=0)
+        _write_result(tmp_path, "a2", "fail", 1.0, blocking=0)
+        _write_result(tmp_path, "a3", "pass", 0.9)
+        _write_result(tmp_path, "a4", "unclear", 0.4)
+        records = load_corpus(tmp_path)
+        assert len(records) == 4
+        summary = analyze_corpus(records)
+        assert summary["n"] == 4
+        assert summary["verdicts"]["fail"] == 2
+        # THE anomaly: FAILs with zero blocking issues
+        assert summary["zero_blocking_fail_rate"] == 1.0
+
+    def test_unreadable_files_skipped(self, tmp_path):
+        d = tmp_path / "bad"
+        d.mkdir()
+        (d / "result.json").write_text("{not json")
+        assert load_corpus(tmp_path) == []
+
+
+class TestPav:
+    def test_monotonic_output(self):
+        # Violating sequence gets pooled: outcomes dip in the middle.
+        pairs = [(0.2, 0.0), (0.4, 1.0), (0.6, 0.0), (0.8, 1.0)]
+        points = pav_fit(pairs)
+        ys = [y for _, y in points]
+        assert ys == sorted(ys)
+
+    def test_already_monotonic_preserved(self):
+        pairs = [(0.2, 0.0), (0.5, 0.5), (0.9, 1.0)]
+        assert pav_fit(pairs) == [(0.2, 0.0), (0.5, 0.5), (0.9, 1.0)]
+
+    def test_empty(self):
+        assert pav_fit([]) == []
+
+
+class TestMapping:
+    def test_identity_when_no_points(self):
+        m = CalibrationMapping.identity()
+        assert m.is_identity
+        assert m.calibrate(0.73) == 0.73
+
+    def test_interpolation_and_clamping(self):
+        m = CalibrationMapping(points=[(0.5, 0.2), (1.0, 0.8)])
+        assert m.calibrate(0.3) == 0.2  # below range clamps to first y
+        assert m.calibrate(1.0) == 0.8
+        assert m.calibrate(0.75) == 0.5  # linear midpoint
+
+    def test_json_round_trip(self):
+        m = CalibrationMapping(points=[(0.5, 0.2), (1.0, 0.8)])
+        m2 = CalibrationMapping.from_json(m.to_json())
+        assert m2.points == m.points
+
+    def test_corrupt_non_monotonic_rejected(self):
+        with pytest.raises(ValueError):
+            CalibrationMapping.from_json(
+                json.dumps({"version": 1, "points": [[0.5, 0.9], [1.0, 0.1]]})
+            )
+
+    def test_load_mapping_identity_fallback(self, tmp_path):
+        assert load_mapping(tmp_path / "missing.json").is_identity
+
+
+class TestFit:
+    def test_fit_from_dispositions(self):
+        records = [
+            CalibrationRecord("v1", "fail", 0.95, 0, False),
+            CalibrationRecord("v2", "fail", 1.0, 0, False),
+            CalibrationRecord("v3", "pass", 0.9, 0, False),
+            CalibrationRecord("v4", "fail", 0.6, 1, False),
+        ]
+        # High-confidence FAILs overridden by humans; others upheld.
+        dispositions = {"v1": False, "v2": False, "v3": True, "v4": True}
+        m = fit_from_dispositions(records, dispositions)
+        assert not m.is_identity
+        # Outcomes anti-correlate with confidence here, so the isotonic
+        # (non-decreasing) fit pools everything to the global uphold rate —
+        # a raw 1.0 is deflated to 0.5, exactly the honest calibration.
+        assert m.calibrate(1.0) == 0.5
+
+    def test_records_without_disposition_ignored(self):
+        records = [CalibrationRecord("v1", "fail", 0.9, 0, False)]
+        assert fit_from_dispositions(records, {}).is_identity
+
+
+class TestFlagGate:
+    def test_default_off(self, monkeypatch):
+        monkeypatch.delenv("LLM_COUNCIL_CALIBRATED_CONFIDENCE", raising=False)
+        assert calibrated_confidence_enabled() is False
+
+    def test_flag_off_verdict_byte_identical(self):
+        # build_verification_result without a calibrator: threshold uses raw.
+        from llm_council.verification.verdict_extractor import (
+            build_verification_result,
+        )
+
+        stage3 = {"response": "VERDICT: PASS — looks good."}
+        out = build_verification_result([], [], stage3, confidence_threshold=0.7)
+        out2 = build_verification_result(
+            [], [], stage3, confidence_threshold=0.7, calibrate=None
+        )
+        assert out == out2
+
+    def test_flag_on_threshold_uses_calibrated(self):
+        # A pass at raw 0.75 with a deflating calibrator (0.75 -> 0.5) must
+        # soften to unclear when the calibrator is applied.
+        from llm_council.verification.verdict_extractor import (
+            build_verification_result,
+        )
+
+        mapping = CalibrationMapping(points=[(0.0, 0.0), (1.0, 0.65)])
+
+        class FakeVerdict:
+            verdict_type = None
+
+        # Use the legacy path: synthesis says pass; agreement confidence 0.5
+        # (no stage2) blended with base => compute raw first.
+        stage3 = {"response": "VERDICT: PASS — approved."}
+        raw = build_verification_result([], [], stage3, confidence_threshold=0.7)
+        calibrated = build_verification_result(
+            [], [], stage3, confidence_threshold=0.7, calibrate=mapping.calibrate
+        )
+        if raw["verdict"] == "pass":
+            # Deflated below 0.7 => softened.
+            assert calibrated["verdict"] == "unclear"
+        else:
+            # Raw already below threshold: calibrator can't resurrect it.
+            assert calibrated["verdict"] == raw["verdict"]
+        assert calibrated["confidence_calibrated"] == mapping.calibrate(
+            raw["confidence"]
+        )
+
+
+class TestSchemaField:
+    def test_verify_response_carries_calibrated(self):
+        from llm_council.verification.schemas import VerifyResponse
+
+        resp = VerifyResponse(
+            verification_id="v1",
+            verdict="pass",
+            confidence=0.9,
+            exit_code=0,
+            rationale="r",
+            transcript_location="/tmp/t",
+            confidence_calibrated=0.62,
+        )
+        assert resp.confidence_calibrated == 0.62


### PR DESCRIPTION
Closes #414

## Summary
Makes verify confidence mean something (ADR-047 §P2 / ADR-036 §P2 slice):

- **Reproducible analysis**: `llm-council calibration-report` over `.council/logs`. Run against the live corpus (51 results) it quantifies the anomaly this ADR exists for: **42/42 FAIL verdicts carry zero blocking issues at mean confidence 0.965**.
- **Monotonic fit**: `--fit` runs pool-adjacent-violators isotonic regression against human dispositions (`.council/calibration/dispositions.jsonl`: `{verification_id, upheld}`) → persisted piecewise-linear mapping (`mapping.json`), monotonicity enforced on load.
- **Both confidences surfaced**: `confidence` (raw) + `confidence_calibrated` on every response (identity until a mapping is fitted); MCP table shows calibrated only when it diverges.
- **Flag-gated PASS**: threshold consumes calibrated only behind `LLM_COUNCIL_CALIBRATED_CONFIDENCE` (default off; flag-off byte-identical, test-pinned) — per the ADR's modest-N mitigation.

## Tests
16 new (corpus load/analyze, PAV monotonicity/pooling, mapping interpolation/clamping/round-trip/corrupt-rejection, fit incl. anti-correlated pooling semantics, flag gate both ways, schema). Suite 3089 green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)