### PR TITLE
Release v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-07-03
+
+**Verifier Calibration & Judge Reliability (ADR-047)** — epic [#417](https://github.com/amiable-dev/llm-council/issues/417). The verify gate becomes trustworthy: UNCLEAR verdicts carry machine-readable causes, confidence is calibrated against observed outcomes (both values surfaced), a shadow-first screening judge cuts gate cost for easy changes, and reviewer agreement is decomposed for position-confound amplification. Everything additive; all behavior changes flag-gated default-off.
+
 ### Added
 
 - **Reviewer-agreement decomposition (ADR-047 P4, #416)** — `llm-council bias-report --amplification` decomposes each session's reviewer agreement over the ADR-015/018 store: an `agreement_index` (share of score variance between models vs between reviewers) crossed with `position_alignment` (does the consensus track display order?). High agreement WITH high position alignment flags an amplification suspect — the council converged along the position confound, not quality. Strictly report-only (pure functions, no writes, no gating — test-pinned); ADR-015 small-N caveats apply.

--- a/docs/adr/ADR-047-verifier-calibration.md
+++ b/docs/adr/ADR-047-verifier-calibration.md
@@ -1,6 +1,6 @@
 # ADR-047: Verifier Calibration & Judge Reliability
 
-**Status:** Draft 2026-07-03
+**Status:** Implemented 2026-07-03 (epic #417, v0.31.0)
 **Date:** 2026-07-03
 **Decision Makers:** Chris Joseph, LLM Council
 **Council Review:** 2026-07-03 (4 models, balanced) — feedback incorporated: screening thresholds defined, blocking-path invariant operationalized, DoD covers P3/P4, reference consistency

--- a/server-card.json
+++ b/server-card.json
@@ -3,7 +3,7 @@
   "name": "io.github.amiable-dev/llm-council",
   "title": "LLM Council",
   "description": "Multi-model deliberation council with anonymized peer review, exposed as MCP tools.",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "websiteUrl": "https://github.com/amiable-dev/llm-council",
   "repository": {
     "source": "github",


### PR DESCRIPTION
## v0.31.0 — Verifier Calibration & Judge Reliability (ADR-047, epic #417)

- **P1** (#413, PR #434): `unclear_reason ∈ {infra_failure, low_confidence, timeout}` — exit code stays 2; automation routes on the reason
- **P2** (#414, PR #435): confidence calibration — `llm-council calibration-report`, PAV isotonic fit from human dispositions, `confidence_calibrated` on every response, flag-gated PASS use. Corpus evidence: 42/42 zero-blocking FAILs at mean confidence 0.965
- **P3** (#415, PR #436): screening judge — off/shadow/active, blocking-capable NEVER screened (module-enforced), decisions logged with scores
- **P4** (#416, PR #437): reviewer-agreement decomposition, report-only — Council PASS 1.0

ADR-047 status → Implemented; static card stamped 0.31.0.

**Tag v0.31.0 will be pushed after merge (version confirmation pending).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)