### PR TITLE
feat(bench): ADR-048 P1 — golden dataset + drift harness (#418)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,40 @@
+# ADR-048: nightly quality benchmark — NEVER per-PR (each run costs real
+# API spend). Explicit caps per council feedback; monthly guard enforced
+# by the harness from persisted run artefacts.
+name: Nightly Bench
+on:
+  schedule:
+    - cron: "17 3 * * *"  # 03:17 UTC nightly
+  workflow_dispatch: {}
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    # Guard against fork surprises; secrets gate the spend anyway.
+    if: github.repository == 'amiable-dev/llm-council'
+    env:
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      LLM_COUNCIL_BENCH_MAX_USD: "2.00"
+      LLM_COUNCIL_BENCH_MONTHLY_USD: "30.00"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Restore bench spend ledger
+        uses: actions/cache@v4
+        with:
+          path: .council/bench/runs
+          key: bench-runs-${{ github.run_id }}
+          restore-keys: bench-runs-
+      - run: pip install -e .
+      - name: Run bench (capped)
+        run: llm-council bench run --format md | tee bench-report.md
+      - name: Upload report + run artefact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-report
+          path: |
+            bench-report.md
+            .council/bench/runs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Golden-dataset drift harness (ADR-048 P1, #418)** — `llm-council bench run|baseline|report` executes the versioned dataset (`bench/dataset/v1/`, 20 original items across four domains, governance doc included) against the council and checks expected-quality envelopes (any-of key-content groups + consensus score floors, never exact-string). Hard per-run spend cap (`LLM_COUNCIL_BENCH_MAX_USD`, $2 default) with graceful partial abort, month-to-date guard (`LLM_COUNCIL_BENCH_MONTHLY_USD`, $30 default) from persisted run artefacts, committed-baseline regression detection, exit codes 0/1/2, and a nightly (never per-PR) workflow with explicit caps. Harness fully unit-tested with mocked councils — zero live spend in CI.
+
 ## [0.31.0] - 2026-07-03
 
 **Verifier Calibration & Judge Reliability (ADR-047)** — epic [#417](https://github.com/amiable-dev/llm-council/issues/417). The verify gate becomes trustworthy: UNCLEAR verdicts carry machine-readable causes, confidence is calibrated against observed outcomes (both values surfaced), a shadow-first screening judge cuts gate cost for easy changes, and reviewer agreement is decomposed for position-confound amplification. Everything additive; all behavior changes flag-gated default-off.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,9 @@ Cost & token accounting (ADR-011, Phase 1–4)
 - `openrouter.py` `query_model` now captures `cost`/`cached_tokens`; `council.py` aggregates per-stage **and** per-model (`_add_cost_to_usage` → `_build_usage_summary`, shared by both entry points) into `metadata["usage"] = {by_stage, by_model, total}` — each carries `cost_usd`/`cached_tokens`. **Never presents an estimate as a bill** (`cost_source` distinguishes). Cost accounting never fails a run (soft-fail).
 - `cost_summary.py` `format_cost_summary` renders usage with **progressive disclosure**: one dense line by default, full per-model/per-stage breakdown only under `include_details`. Surfaced in MCP `consult_council` ("Cost & Tokens") and as a typed `usage` field on the HTTP `CouncilResponse`. Releases: one version bump per epic, not per PR (git-tag/setuptools-scm; `publish.yml` triggers on tag only).
 
+Bench (ADR-048)
+- `bench/harness.py` (P1, #418) — golden-dataset drift regression: `bench/dataset/v1/` (20 items, envelopes = any-of `must_contain` groups + `min_score` consensus floor; governance in `bench/dataset/GOVERNANCE.md`), per-run cap enforced against ACTUALS with graceful partial abort (exit 2), monthly guard summed from `.council/bench/runs/*.json`, baseline snapshot + regression compare (exit 1 on drift). `council_runner` is injectable — CI tests never spend. Nightly workflow `.github/workflows/bench.yml`; NEVER per-PR.
+
 Bias (ADR-015/018, ADR-047 P4)
 - `bias_audit.py` (ADR-015) — per-session indicators: length↔score correlation (pure-Python Pearson), reviewer calibration, position bias. **These are anomaly indicators, not statistically robust proof** — with N=4–5 models there are only 4–5 data points (≥30 needed for significance), and a single ordering can't separate position effects from quality.
 - `bias_amplification.py` (ADR-047 P4, #416) — reviewer-agreement decomposition: `agreement_index` × `position_alignment` per session; high agreement that tracks display order = amplification suspect (multi-agent judges can AMPLIFY shared bias, not cancel it). Report-only by contract (pure, no writes — test-pinned); surfaced via `llm-council bias-report --amplification`.
@@ -120,6 +123,7 @@ Single Pydantic source of truth consolidating ADR-020/022/023/026/030/031. Prior
 | `LLM_COUNCIL_PERFORMANCE_SELECTION` | ADR-044 P1: blend the live performance index into model selection (default off; auditable route receipt on change) |
 | `LLM_COUNCIL_EARLY_CONSENSUS` | ADR-044 P2: cancel remaining Stage-2 reviewers once the Borda leader is mathematically unassailable (default off = shadow mode, which only logs would-have-saved) |
 | `LLM_COUNCIL_GRADUATED_DEPTH` | ADR-044 P3: graduated deliberation depth ladder single→mini→full with consensus-gated escalation + budget veto (default off) |
+| `LLM_COUNCIL_BENCH_MAX_USD` (2.00) / `_BENCH_MONTHLY_USD` (30.00) | ADR-048 bench spend caps (per-run graceful abort; month-to-date refusal) |
 | `LLM_COUNCIL_SCREENING` (off\|shadow\|active) / `_SCREEN_MAX_CHARS` (5000) / `_SCREEN_MIN_SCORE` (9) | ADR-047 P3 screening pre-gate (default off; shadow logs only; active short-circuits unanimous passes — never blocking-capable requests) |
 | `LLM_COUNCIL_CALIBRATED_CONFIDENCE` | ADR-047 P2: PASS threshold uses calibrated confidence from the fitted mapping (default off; calibrated value always reported) |
 | `LLM_COUNCIL_MCP_TASKS` | ADR-045 P1 kill-switch: disable MCP Tasks exposure even on a task-capable SDK (default enabled-when-supported) |

--- a/README.md
+++ b/README.md
@@ -313,6 +313,18 @@ Any MCP client can use the server by running:
 llm-council
 ```
 
+### Quality Benchmark (`llm-council bench`)
+
+A golden dataset (`bench/dataset/v1/`, 20 items across coding/reasoning/factual/judgment) guards council quality against drift (ADR-048). **Every run costs real API spend** — it runs nightly/on-demand, never per-PR:
+
+```bash
+llm-council bench run [--items id1,id2] [--max-usd 2.00]   # exit 0 ok / 1 drift / 2 aborted-partial
+llm-council bench baseline --set                            # snapshot the last run as baseline
+llm-council bench report [--format md|json]                 # render the last run + baseline deltas
+```
+
+Caps: `LLM_COUNCIL_BENCH_MAX_USD` per run (default $2.00, enforced against actuals mid-run with graceful partial abort) and `LLM_COUNCIL_BENCH_MONTHLY_USD` month-to-date guard (default $30, from run artefacts under `.council/bench/runs/`). Dataset governance: [`bench/dataset/GOVERNANCE.md`](bench/dataset/GOVERNANCE.md).
+
 ### Streaming Deliberation (SSE)
 
 `GET /v1/council/stream?prompt=...` streams the deliberation live (ADR-046). Beyond the coarse stage events, the stream now emits **rich per-model events**, each wrapped in a versioned envelope (`v: 1`, `session_id`, `ts`, monotonic `seq`):

--- a/bench/dataset/GOVERNANCE.md
+++ b/bench/dataset/GOVERNANCE.md
@@ -1,0 +1,39 @@
+# Bench Dataset Governance (ADR-048)
+
+The golden dataset under `bench/dataset/vN/` guards council quality against
+silent drift. Rules (per ADR-048 council feedback):
+
+1. **Versioned in-repo, changed only by PR review.** `v1/` is immutable in
+   spirit: fixes to typos are fine; changing an item's substance means a new
+   item id (or a new `v2/` when the set is re-baselined).
+2. **Original or verifiably licensed.** Every item carries `provenance`.
+   No copied benchmark questions, no PII, ever.
+3. **Envelope changes require justification.** A PR that widens or moves an
+   item's `envelope` must include a note explaining the new expected range —
+   no silent goal-post moves.
+4. **Balanced domains.** Items span coding / reasoning / factual / judgment;
+   additions should keep the spread roughly even.
+5. **Assertions are key-content, not exact-string.** `must_contain` holds
+   any-of groups (every group needs at least one case-insensitive hit) so
+   phrasing freedom never fails a correct answer.
+
+## Item schema
+
+```json
+{
+  "id": "domain-short-slug",
+  "domain": "coding|reasoning|factual|judgment",
+  "prompt": "...",
+  "envelope": {"must_contain": [["either", "or"], ["required"]], "min_score": 0.3},
+  "provenance": "original, authored ... (date)",
+  "rationale": "why this item earns its API spend"
+}
+```
+
+## Spend
+
+Runs cost real money: nightly/scheduled or on-demand only, **never per-PR**.
+Caps: `LLM_COUNCIL_BENCH_MAX_USD` per run (default $2.00, enforced before
+each item and against actuals after), `LLM_COUNCIL_BENCH_MONTHLY_USD`
+month-to-date guard (default $30, summed from run artefacts under
+`.council/bench/runs/`).

--- a/bench/dataset/v1/code-big-o.json
+++ b/bench/dataset/v1/code-big-o.json
@@ -1,0 +1,19 @@
+{
+  "id": "code-big-o",
+  "domain": "coding",
+  "prompt": "What is the time complexity of checking membership in a Python list vs a set, and why does the difference matter for a 10-million-item lookup loop?",
+  "envelope": {
+    "must_contain": [
+      [
+        "O(n)"
+      ],
+      [
+        "O(1)",
+        "hash"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical coding task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/code-fizzbuzz-variant.json
+++ b/bench/dataset/v1/code-fizzbuzz-variant.json
@@ -1,0 +1,19 @@
+{
+  "id": "code-fizzbuzz-variant",
+  "domain": "coding",
+  "prompt": "Write a Python function `classify(n)` that returns 'fizz' for multiples of 3, 'buzz' for multiples of 5, 'fizzbuzz' for both, and the number as a string otherwise. Include edge case behaviour for 0 and negatives in a short docstring.",
+  "envelope": {
+    "must_contain": [
+      [
+        "fizzbuzz"
+      ],
+      [
+        "def classify",
+        "classify(n)"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical coding task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/code-off-by-one.json
+++ b/bench/dataset/v1/code-off-by-one.json
@@ -1,0 +1,18 @@
+{
+  "id": "code-off-by-one",
+  "domain": "coding",
+  "prompt": "This Python loop is meant to sum the first n positive integers but returns the wrong value: `total=0`\nfor i in range(n): total += i`. Identify the bug and give the corrected loop.",
+  "envelope": {
+    "must_contain": [
+      [
+        "range(1, n + 1)",
+        "range(1,n+1)",
+        "n + 1",
+        "i + 1"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical coding task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/code-race-condition.json
+++ b/bench/dataset/v1/code-race-condition.json
@@ -1,0 +1,19 @@
+{
+  "id": "code-race-condition",
+  "domain": "coding",
+  "prompt": "Two asyncio tasks increment a shared counter 1000 times each without a lock. Explain whether the final count is deterministic in CPython asyncio and why.",
+  "envelope": {
+    "must_contain": [
+      [
+        "await",
+        "yield",
+        "suspension",
+        "context switch",
+        "atomic"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical coding task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/code-sql-injection.json
+++ b/bench/dataset/v1/code-sql-injection.json
@@ -1,0 +1,19 @@
+{
+  "id": "code-sql-injection",
+  "domain": "coding",
+  "prompt": "Explain why building SQL with f-strings from user input is dangerous in Python, and show the parameterized-query alternative using sqlite3.",
+  "envelope": {
+    "must_contain": [
+      [
+        "injection"
+      ],
+      [
+        "?",
+        "parameter"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical coding task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/fact-http-verbs.json
+++ b/bench/dataset/v1/fact-http-verbs.json
@@ -1,0 +1,18 @@
+{
+  "id": "fact-http-verbs",
+  "domain": "factual",
+  "prompt": "Which HTTP method is defined as idempotent but not safe: GET, POST, PUT, or PATCH? Explain the distinction briefly.",
+  "envelope": {
+    "must_contain": [
+      [
+        "PUT"
+      ],
+      [
+        "idempotent"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical factual task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/fact-semver.json
+++ b/bench/dataset/v1/fact-semver.json
@@ -1,0 +1,15 @@
+{
+  "id": "fact-semver",
+  "domain": "factual",
+  "prompt": "Under semantic versioning, which version component must change for a backwards-incompatible API change?",
+  "envelope": {
+    "must_contain": [
+      [
+        "major"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical factual task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/fact-tcp-handshake.json
+++ b/bench/dataset/v1/fact-tcp-handshake.json
@@ -1,0 +1,23 @@
+{
+  "id": "fact-tcp-handshake",
+  "domain": "factual",
+  "prompt": "Name the three messages of the TCP three-way handshake in order.",
+  "envelope": {
+    "must_contain": [
+      [
+        "SYN"
+      ],
+      [
+        "SYN-ACK",
+        "SYN/ACK",
+        "SYN ACK"
+      ],
+      [
+        "ACK"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical factual task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/fact-tls-purpose.json
+++ b/bench/dataset/v1/fact-tls-purpose.json
@@ -1,0 +1,21 @@
+{
+  "id": "fact-tls-purpose",
+  "domain": "factual",
+  "prompt": "What two core guarantees does TLS provide to an HTTP connection? One short sentence each.",
+  "envelope": {
+    "must_contain": [
+      [
+        "encrypt",
+        "confidential"
+      ],
+      [
+        "authent",
+        "integrity",
+        "identity"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical factual task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/fact-unicode-utf8.json
+++ b/bench/dataset/v1/fact-unicode-utf8.json
@@ -1,0 +1,16 @@
+{
+  "id": "fact-unicode-utf8",
+  "domain": "factual",
+  "prompt": "How many bytes does UTF-8 use to encode the euro sign (U+20AC), and why more than one?",
+  "envelope": {
+    "must_contain": [
+      [
+        "3",
+        "three"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical factual task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/judge-estimate-padding.json
+++ b/bench/dataset/v1/judge-estimate-padding.json
@@ -1,0 +1,21 @@
+{
+  "id": "judge-estimate-padding",
+  "domain": "judgment",
+  "prompt": "Your team consistently delivers at 2x its estimates. Should management simply double all estimates? Give the strongest argument against.",
+  "envelope": {
+    "must_contain": [
+      [
+        "incentive",
+        "pad",
+        "goodhart",
+        "parkinson",
+        "behaviour",
+        "behavior",
+        "trust"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical judgment task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/judge-feature-flag-debt.json
+++ b/bench/dataset/v1/judge-feature-flag-debt.json
@@ -1,0 +1,24 @@
+{
+  "id": "judge-feature-flag-debt",
+  "domain": "judgment",
+  "prompt": "A codebase has 200 stale feature flags. Describe the main risk this creates and a policy to prevent recurrence.",
+  "envelope": {
+    "must_contain": [
+      [
+        "complexity",
+        "dead code",
+        "interaction",
+        "risk"
+      ],
+      [
+        "expiry",
+        "owner",
+        "cleanup",
+        "remove"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical judgment task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/judge-oncall-alert.json
+++ b/bench/dataset/v1/judge-oncall-alert.json
@@ -1,0 +1,24 @@
+{
+  "id": "judge-oncall-alert",
+  "domain": "judgment",
+  "prompt": "An alert fires nightly at 3am and has been a false positive for 30 consecutive nights. What should the on-call team do and why is silencing-without-fixing dangerous?",
+  "envelope": {
+    "must_contain": [
+      [
+        "threshold",
+        "fix",
+        "tune",
+        "root cause"
+      ],
+      [
+        "alert fatigue",
+        "desensit",
+        "real incident",
+        "miss"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical judgment task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/judge-postmortem-blame.json
+++ b/bench/dataset/v1/judge-postmortem-blame.json
@@ -1,0 +1,19 @@
+{
+  "id": "judge-postmortem-blame",
+  "domain": "judgment",
+  "prompt": "Why do blameless postmortems surface more accurate root causes than blame-oriented reviews? Two sentences.",
+  "envelope": {
+    "must_contain": [
+      [
+        "fear",
+        "hide",
+        "honest",
+        "psychological safety",
+        "withhold"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical judgment task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/judge-rewrite-vs-refactor.json
+++ b/bench/dataset/v1/judge-rewrite-vs-refactor.json
@@ -1,0 +1,20 @@
+{
+  "id": "judge-rewrite-vs-refactor",
+  "domain": "judgment",
+  "prompt": "A 100K-line legacy service has 60% test coverage and steady feature demand. Argue briefly for refactor-in-place over a big-bang rewrite, naming the two biggest risks of the rewrite.",
+  "envelope": {
+    "must_contain": [
+      [
+        "risk"
+      ],
+      [
+        "incremental",
+        "refactor",
+        "strangler"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical judgment task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/reason-anchoring.json
+++ b/bench/dataset/v1/reason-anchoring.json
@@ -1,0 +1,15 @@
+{
+  "id": "reason-anchoring",
+  "domain": "reasoning",
+  "prompt": "A store marks a jacket 'was $400, now $200'. Name the cognitive bias this exploits and describe it in one sentence.",
+  "envelope": {
+    "must_contain": [
+      [
+        "anchor"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical reasoning task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/reason-bat-ball.json
+++ b/bench/dataset/v1/reason-bat-ball.json
@@ -1,0 +1,17 @@
+{
+  "id": "reason-bat-ball",
+  "domain": "reasoning",
+  "prompt": "A bat and a ball cost $1.10 together. The bat costs $1.00 more than the ball. How much does the ball cost? Show the algebra.",
+  "envelope": {
+    "must_contain": [
+      [
+        "0.05",
+        "5 cents",
+        "five cents"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical reasoning task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/reason-birthday.json
+++ b/bench/dataset/v1/reason-birthday.json
@@ -1,0 +1,15 @@
+{
+  "id": "reason-birthday",
+  "domain": "reasoning",
+  "prompt": "Roughly how many people are needed in a room for a >50% chance two share a birthday? Explain the intuition briefly.",
+  "envelope": {
+    "must_contain": [
+      [
+        "23"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical reasoning task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/reason-monty-hall.json
+++ b/bench/dataset/v1/reason-monty-hall.json
@@ -1,0 +1,20 @@
+{
+  "id": "reason-monty-hall",
+  "domain": "reasoning",
+  "prompt": "In the Monty Hall problem, should you switch doors after the host reveals a goat, and what is the probability of winning if you do?",
+  "envelope": {
+    "must_contain": [
+      [
+        "switch"
+      ],
+      [
+        "2/3",
+        "two-thirds",
+        "66"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical reasoning task with an unambiguous expected core"
+}

--- a/bench/dataset/v1/reason-transitive.json
+++ b/bench/dataset/v1/reason-transitive.json
@@ -1,0 +1,16 @@
+{
+  "id": "reason-transitive",
+  "domain": "reasoning",
+  "prompt": "If all bloops are razzies and no razzies are lazzies, can a bloop be a lazzy? Answer and explain in two sentences.",
+  "envelope": {
+    "must_contain": [
+      [
+        "no",
+        "cannot"
+      ]
+    ],
+    "min_score": 0.3
+  },
+  "provenance": "original, authored for llm-council bench v1 (2026-07-03)",
+  "rationale": "canonical reasoning task with an unambiguous expected core"
+}

--- a/src/llm_council/bench/__init__.py
+++ b/src/llm_council/bench/__init__.py
@@ -1,0 +1,14 @@
+"""Council quality benchmark harness (ADR-048)."""
+
+from .harness import (  # noqa: F401
+    BenchItem,
+    BenchRun,
+    ItemResult,
+    check_envelope,
+    compare_to_baseline,
+    format_report,
+    load_dataset,
+    month_to_date_spend,
+    run_bench,
+    set_baseline,
+)

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -135,8 +135,13 @@ def check_envelope(item: BenchItem, synthesis: str, score: Optional[float]) -> L
         if not any(str(opt).lower() in text for opt in options):
             failures.append(f"missing_any_of:{options}")
     min_score = item.envelope.get("min_score")
-    if min_score is not None and score is not None and score < float(min_score):
-        failures.append(f"score_below_floor({score}<{min_score})")
+    if min_score is not None:
+        if score is None:
+            # A floor with no observable score IS drift (#439 r2): the
+            # council stopped producing the signal the envelope guards.
+            failures.append("score_unavailable")
+        elif score < float(min_score):
+            failures.append(f"score_below_floor({score}<{min_score})")
     return failures
 
 
@@ -224,6 +229,7 @@ async def run_bench(
     # NOTE (by design): the cap is checked BETWEEN items, never mid-item —
     # a single item may overshoot; the abort is graceful, not mid-completion.
     cap_charged = 0.0
+    any_unknown = False
     for item in items:
         if cap_charged >= cap:
             run.aborted = (
@@ -246,6 +252,10 @@ async def run_bench(
                 )
             )
             run.items_run += 1
+            # An erroring item may already have spent (#439 r2): charge the
+            # conservative default so failures cannot bypass the cap.
+            cap_charged = round(cap_charged + bench_unknown_item_usd(), 6)
+            any_unknown = True
             continue
         latency_ms = int((time.monotonic() - started) * 1000)
         synthesis = result.get("synthesis", "")
@@ -254,7 +264,8 @@ async def run_bench(
         failures = check_envelope(item, synthesis, score)
         run.total_cost_usd = round(run.total_cost_usd + cost, 6)
         cap_charged = round(cap_charged + (cost if cost_known else bench_unknown_item_usd()), 6)
-        run.cost_known = run.cost_known or cost_known
+        if not cost_known:
+            any_unknown = True
         run.items_run += 1
         if not failures:
             run.items_passed += 1
@@ -271,6 +282,8 @@ async def run_bench(
             )
         )
 
+    # 'fully known' means EVERY executed item reported a cost (#439 r2).
+    run.cost_known = run.items_run > 0 and not any_unknown
     _persist_run(run, runs_dir)
     return run
 

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -45,6 +45,17 @@ def bench_max_usd() -> float:
         return 2.00
 
 
+def bench_unknown_item_usd() -> float:
+    """Conservative cap charge for items whose provider reported no cost
+    (#439 review): counting unknown as $0 would make worst-case spend
+    unbounded. Charged against CAP ACCOUNTING only — reported spend stays
+    actuals, never fabricated (ADR-011)."""
+    try:
+        return float(os.getenv("LLM_COUNCIL_BENCH_UNKNOWN_ITEM_USD", "0.10"))
+    except ValueError:
+        return 0.10
+
+
 def bench_monthly_usd() -> float:
     try:
         return float(os.getenv("LLM_COUNCIL_BENCH_MONTHLY_USD", "30.00"))
@@ -209,11 +220,16 @@ async def run_bench(
         async def council_runner(prompt: str) -> Dict[str, Any]:  # pragma: no cover
             return await run_council_with_fallback(prompt, bypass_cache=True)
 
+    # Cap accounting = actuals + conservative charges for unknown-cost items.
+    # NOTE (by design): the cap is checked BETWEEN items, never mid-item —
+    # a single item may overshoot; the abort is graceful, not mid-completion.
+    cap_charged = 0.0
     for item in items:
-        if run.total_cost_usd >= cap:
+        if cap_charged >= cap:
             run.aborted = (
-                f"per_run_cap: actual spend ${run.total_cost_usd:.2f} >= "
-                f"${cap:.2f} (LLM_COUNCIL_BENCH_MAX_USD) after "
+                f"per_run_cap: charged spend ${cap_charged:.2f} >= "
+                f"${cap:.2f} (LLM_COUNCIL_BENCH_MAX_USD; actuals "
+                f"${run.total_cost_usd:.2f} + unknown-cost charges) after "
                 f"{run.items_run}/{run.items_total} items"
             )
             break
@@ -237,6 +253,7 @@ async def run_bench(
         cost, cost_known = _extract_cost(result)
         failures = check_envelope(item, synthesis, score)
         run.total_cost_usd = round(run.total_cost_usd + cost, 6)
+        cap_charged = round(cap_charged + (cost if cost_known else bench_unknown_item_usd()), 6)
         run.cost_known = run.cost_known or cost_known
         run.items_run += 1
         if not failures:
@@ -295,7 +312,8 @@ def compare_to_baseline(
     path = baseline_path if baseline_path is not None else DEFAULT_BASELINE_PATH
     try:
         baseline = json.loads(path.read_text())
-    except OSError:
+    except (OSError, json.JSONDecodeError):
+        # Absent OR corrupt baseline (#439 review): report, never crash.
         return {"baseline": None}
     regressions = []
     for r in run.results:

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -91,6 +91,10 @@ class BenchRun:
     items_passed: int
     total_cost_usd: float
     cost_known: bool
+    # Cap-accounting figure: actuals + conservative unknown-cost charges.
+    # The monthly guard sums THIS, not raw actuals (#439 r3) — unknown-cost
+    # runs must not erode the guard.
+    cap_charged_usd: float = 0.0
     aborted: Optional[str] = None  # reason string when partial
     results: List[ItemResult] = field(default_factory=list)
 
@@ -155,7 +159,10 @@ def month_to_date_spend(runs_dir: Optional[Path] = None) -> float:
             try:
                 data = json.loads(f.read_text())
                 if str(data.get("started_at", "")).startswith(prefix):
-                    total += float(data.get("total_cost_usd", 0.0))
+                    total += max(
+                        float(data.get("total_cost_usd", 0.0)),
+                        float(data.get("cap_charged_usd", 0.0)),
+                    )
             except Exception:
                 continue
     except OSError:
@@ -284,6 +291,7 @@ async def run_bench(
 
     # 'fully known' means EVERY executed item reported a cost (#439 r2).
     run.cost_known = run.items_run > 0 and not any_unknown
+    run.cap_charged_usd = cap_charged
     _persist_run(run, runs_dir)
     return run
 
@@ -302,7 +310,13 @@ def _persist_run(run: BenchRun, runs_dir: Optional[Path] = None) -> None:
 
 
 def set_baseline(run: BenchRun, baseline_path: Optional[Path] = None) -> Path:
-    """Snapshot the run as the committed baseline."""
+    """Snapshot the run as the committed baseline.
+
+    Refuses aborted/partial runs (#439 r3): a truncated run would bake an
+    artificially narrow item set into the drift reference.
+    """
+    if run.aborted:
+        raise ValueError(f"refusing to baseline an aborted run: {run.aborted}")
     path = baseline_path if baseline_path is not None else DEFAULT_BASELINE_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -1,0 +1,342 @@
+"""Golden-dataset drift regression harness (ADR-048 P1, #418).
+
+Runs the versioned dataset (``bench/dataset/vN/``) against a configured
+council, checks each result against its expected-quality envelope, and
+compares aggregates to a committed baseline snapshot.
+
+Cost discipline (ADR-048 council feedback — every run spends real money):
+- hard per-run cap ``LLM_COUNCIL_BENCH_MAX_USD`` (default $2.00): checked
+  against ACTUALS after every item; the run aborts gracefully at the cap
+  with partial results marked partial (exit 2)
+- month-to-date guard ``LLM_COUNCIL_BENCH_MONTHLY_USD`` (default $30):
+  summed from run artefacts under ``.council/bench/runs/``; a run is
+  refused before it starts when the month's spend already exceeds it
+- runs are on-demand / scheduled only, NEVER per-PR
+
+Exit codes: 0 within envelope, 1 drift beyond envelope, 2 aborted/partial.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DATASET_DIR = Path("bench") / "dataset" / "v1"
+DEFAULT_BASELINE_PATH = Path("bench") / "baseline.json"
+DEFAULT_RUNS_DIR = Path(".council") / "bench" / "runs"
+
+EXIT_OK = 0
+EXIT_DRIFT = 1
+EXIT_ABORTED = 2
+
+
+def bench_max_usd() -> float:
+    try:
+        return float(os.getenv("LLM_COUNCIL_BENCH_MAX_USD", "2.00"))
+    except ValueError:
+        return 2.00
+
+
+def bench_monthly_usd() -> float:
+    try:
+        return float(os.getenv("LLM_COUNCIL_BENCH_MONTHLY_USD", "30.00"))
+    except ValueError:
+        return 30.00
+
+
+@dataclass
+class BenchItem:
+    id: str
+    domain: str
+    prompt: str
+    envelope: Dict[str, Any]
+
+
+@dataclass
+class ItemResult:
+    item_id: str
+    domain: str
+    ok: bool
+    failures: List[str] = field(default_factory=list)
+    score: Optional[float] = None
+    cost_usd: float = 0.0
+    cost_known: bool = False
+    latency_ms: int = 0
+
+
+@dataclass
+class BenchRun:
+    started_at: str
+    items_total: int
+    items_run: int
+    items_passed: int
+    total_cost_usd: float
+    cost_known: bool
+    aborted: Optional[str] = None  # reason string when partial
+    results: List[ItemResult] = field(default_factory=list)
+
+    @property
+    def exit_code(self) -> int:
+        if self.aborted:
+            return EXIT_ABORTED
+        if self.items_passed < self.items_run:
+            return EXIT_DRIFT
+        return EXIT_OK
+
+
+def load_dataset(dataset_dir: Optional[Path] = None) -> List[BenchItem]:
+    """Load and validate the dataset; raises on malformed items (fail fast —
+    a broken dataset must not silently shrink coverage)."""
+    directory = dataset_dir if dataset_dir is not None else DEFAULT_DATASET_DIR
+    items: List[BenchItem] = []
+    for f in sorted(directory.glob("*.json")):
+        data = json.loads(f.read_text())
+        for key in ("id", "domain", "prompt", "envelope"):
+            if key not in data:
+                raise ValueError(f"dataset item {f.name} missing '{key}'")
+        items.append(
+            BenchItem(
+                id=data["id"],
+                domain=data["domain"],
+                prompt=data["prompt"],
+                envelope=data["envelope"],
+            )
+        )
+    if not items:
+        raise ValueError(f"no dataset items found under {directory}")
+    return items
+
+
+def check_envelope(item: BenchItem, synthesis: str, score: Optional[float]) -> List[str]:
+    """Return envelope violations (empty == within envelope)."""
+    failures: List[str] = []
+    text = (synthesis or "").lower()
+    for group in item.envelope.get("must_contain", []):
+        options = group if isinstance(group, list) else [group]
+        if not any(str(opt).lower() in text for opt in options):
+            failures.append(f"missing_any_of:{options}")
+    min_score = item.envelope.get("min_score")
+    if min_score is not None and score is not None and score < float(min_score):
+        failures.append(f"score_below_floor({score}<{min_score})")
+    return failures
+
+
+def month_to_date_spend(runs_dir: Optional[Path] = None) -> float:
+    """Sum bench spend recorded this calendar month from run artefacts."""
+    directory = runs_dir if runs_dir is not None else DEFAULT_RUNS_DIR
+    prefix = datetime.now(timezone.utc).strftime("%Y-%m")
+    total = 0.0
+    try:
+        for f in directory.glob("*.json"):
+            try:
+                data = json.loads(f.read_text())
+                if str(data.get("started_at", "")).startswith(prefix):
+                    total += float(data.get("total_cost_usd", 0.0))
+            except Exception:
+                continue
+    except OSError:
+        pass
+    return total
+
+
+def _extract_score(result: Dict[str, Any]) -> Optional[float]:
+    """Top consensus average_score from the council metadata, if present."""
+    try:
+        rankings = result.get("metadata", {}).get("aggregate_rankings") or []
+        if rankings:
+            top = rankings[0].get("average_score")
+            return float(top) if top is not None else None
+    except Exception:
+        pass
+    return None
+
+
+def _extract_cost(result: Dict[str, Any]) -> tuple:
+    try:
+        total = result.get("metadata", {}).get("usage", {}).get("total", {})
+        return float(total.get("cost_usd", 0.0) or 0.0), bool(total.get("cost_known"))
+    except Exception:
+        return 0.0, False
+
+
+async def run_bench(
+    *,
+    dataset_dir: Optional[Path] = None,
+    items_filter: Optional[List[str]] = None,
+    max_usd: Optional[float] = None,
+    runs_dir: Optional[Path] = None,
+    council_runner: Any = None,
+) -> BenchRun:
+    """Execute the bench. ``council_runner`` is injectable for tests
+    (async callable prompt -> council result dict); the default runs the
+    real council — REAL SPEND."""
+    cap = max_usd if max_usd is not None else bench_max_usd()
+    monthly_cap = bench_monthly_usd()
+    items = load_dataset(dataset_dir)
+    if items_filter:
+        wanted = set(items_filter)
+        items = [i for i in items if i.id in wanted]
+
+    run = BenchRun(
+        started_at=datetime.now(timezone.utc).isoformat(),
+        items_total=len(items),
+        items_run=0,
+        items_passed=0,
+        total_cost_usd=0.0,
+        cost_known=False,
+    )
+
+    mtd = month_to_date_spend(runs_dir)
+    if mtd >= monthly_cap:
+        run.aborted = (
+            f"monthly_guard: month-to-date bench spend ${mtd:.2f} >= "
+            f"${monthly_cap:.2f} (LLM_COUNCIL_BENCH_MONTHLY_USD)"
+        )
+        _persist_run(run, runs_dir)
+        return run
+
+    if council_runner is None:
+        from llm_council.council import run_council_with_fallback
+
+        async def council_runner(prompt: str) -> Dict[str, Any]:  # pragma: no cover
+            return await run_council_with_fallback(prompt, bypass_cache=True)
+
+    for item in items:
+        if run.total_cost_usd >= cap:
+            run.aborted = (
+                f"per_run_cap: actual spend ${run.total_cost_usd:.2f} >= "
+                f"${cap:.2f} (LLM_COUNCIL_BENCH_MAX_USD) after "
+                f"{run.items_run}/{run.items_total} items"
+            )
+            break
+        started = time.monotonic()
+        try:
+            result = await council_runner(item.prompt)
+        except Exception as exc:
+            run.results.append(
+                ItemResult(
+                    item_id=item.id,
+                    domain=item.domain,
+                    ok=False,
+                    failures=[f"council_error:{exc}"],
+                )
+            )
+            run.items_run += 1
+            continue
+        latency_ms = int((time.monotonic() - started) * 1000)
+        synthesis = result.get("synthesis", "")
+        score = _extract_score(result)
+        cost, cost_known = _extract_cost(result)
+        failures = check_envelope(item, synthesis, score)
+        run.total_cost_usd = round(run.total_cost_usd + cost, 6)
+        run.cost_known = run.cost_known or cost_known
+        run.items_run += 1
+        if not failures:
+            run.items_passed += 1
+        run.results.append(
+            ItemResult(
+                item_id=item.id,
+                domain=item.domain,
+                ok=not failures,
+                failures=failures,
+                score=score,
+                cost_usd=cost,
+                cost_known=cost_known,
+                latency_ms=latency_ms,
+            )
+        )
+
+    _persist_run(run, runs_dir)
+    return run
+
+
+def _persist_run(run: BenchRun, runs_dir: Optional[Path] = None) -> None:
+    """Persist the run artefact (also feeds the monthly guard). Soft-fail."""
+    directory = runs_dir if runs_dir is not None else DEFAULT_RUNS_DIR
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        stamp = run.started_at.replace(":", "-").split(".")[0]
+        payload = asdict(run)
+        payload["exit_code"] = run.exit_code
+        (directory / f"run-{stamp}.json").write_text(json.dumps(payload, indent=2))
+    except Exception as exc:
+        logger.warning("bench run artefact not persisted (%s)", exc)
+
+
+def set_baseline(run: BenchRun, baseline_path: Optional[Path] = None) -> Path:
+    """Snapshot the run as the committed baseline."""
+    path = baseline_path if baseline_path is not None else DEFAULT_BASELINE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "created_at": run.started_at,
+        "items": {
+            r.item_id: {"ok": r.ok, "score": r.score, "cost_usd": r.cost_usd}
+            for r in run.results
+        },
+        "pass_rate": round(run.items_passed / run.items_run, 3) if run.items_run else None,
+        "total_cost_usd": run.total_cost_usd,
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+    return path
+
+
+def compare_to_baseline(
+    run: BenchRun, baseline_path: Optional[Path] = None
+) -> Dict[str, Any]:
+    """Aggregate deltas vs the committed baseline; absent baseline => None."""
+    path = baseline_path if baseline_path is not None else DEFAULT_BASELINE_PATH
+    try:
+        baseline = json.loads(path.read_text())
+    except OSError:
+        return {"baseline": None}
+    regressions = []
+    for r in run.results:
+        base = baseline.get("items", {}).get(r.item_id)
+        if base and base.get("ok") and not r.ok:
+            regressions.append(r.item_id)
+    pass_rate = round(run.items_passed / run.items_run, 3) if run.items_run else None
+    return {
+        "baseline": baseline.get("created_at"),
+        "baseline_pass_rate": baseline.get("pass_rate"),
+        "pass_rate": pass_rate,
+        "regressions": regressions,
+    }
+
+
+def format_report(run: BenchRun, comparison: Dict[str, Any], fmt: str = "md") -> str:
+    if fmt == "json":
+        payload = asdict(run)
+        payload["exit_code"] = run.exit_code
+        payload["comparison"] = comparison
+        return json.dumps(payload, indent=2)
+    lines = ["# Bench Report (ADR-048)"]
+    lines.append(
+        f"Items: {run.items_passed}/{run.items_run} within envelope "
+        f"(of {run.items_total} selected) — exit code {run.exit_code}"
+    )
+    cost = f"${run.total_cost_usd:.4f}" if run.cost_known else f"~${run.total_cost_usd:.4f} (cost not fully known)"
+    lines.append(f"Spend: {cost} (per-run cap ${bench_max_usd():.2f})")
+    if run.aborted:
+        lines.append(f"ABORTED (partial results): {run.aborted}")
+    if comparison.get("baseline"):
+        lines.append(
+            f"Baseline {comparison['baseline']}: pass rate "
+            f"{comparison.get('baseline_pass_rate')} -> {comparison.get('pass_rate')}"
+        )
+        if comparison.get("regressions"):
+            lines.append(f"REGRESSIONS vs baseline: {', '.join(comparison['regressions'])}")
+    else:
+        lines.append("No committed baseline (run `llm-council bench baseline --set`).")
+    for r in run.results:
+        marker = "PASS" if r.ok else "FAIL"
+        detail = "" if r.ok else f" — {'; '.join(r.failures)}"
+        lines.append(f"- [{marker}] {r.item_id} ({r.domain}){detail}")
+    return "\n".join(lines)

--- a/src/llm_council/cli.py
+++ b/src/llm_council/cli.py
@@ -37,6 +37,83 @@ def _is_fail_backend() -> bool:
         return True
 
 
+def bench_command(
+    action: str,
+    dataset: str,
+    items: str,
+    max_usd,
+    set_flag: bool,
+    output_format: str,
+) -> int:
+    """ADR-048 bench CLI. Returns the process exit code (0/1/2)."""
+    import asyncio
+    import json as _json
+    from pathlib import Path
+
+    from .bench import harness
+
+    runs_dir = harness.DEFAULT_RUNS_DIR
+
+    def _latest_run():
+        artefacts = sorted(runs_dir.glob("run-*.json"))
+        if not artefacts:
+            sys.stdout.write("No bench runs recorded yet — run `llm-council bench run` first.\n")
+            return None
+        return _json.loads(artefacts[-1].read_text())
+
+    if action == "run":
+        items_filter = [i.strip() for i in items.split(",")] if items else None
+        run = asyncio.run(
+            harness.run_bench(
+                dataset_dir=Path(dataset),
+                items_filter=items_filter,
+                max_usd=max_usd,
+            )
+        )
+        comparison = harness.compare_to_baseline(run)
+        sys.stdout.write(harness.format_report(run, comparison, output_format) + "\n")
+        return run.exit_code
+
+    if action == "baseline":
+        data = _latest_run()
+        if data is None:
+            return 2
+        if not set_flag:
+            sys.stdout.write("Pass --set to snapshot the latest run as baseline.\n")
+            return 0
+        run = harness.BenchRun(
+            started_at=data["started_at"],
+            items_total=data["items_total"],
+            items_run=data["items_run"],
+            items_passed=data["items_passed"],
+            total_cost_usd=data["total_cost_usd"],
+            cost_known=data["cost_known"],
+            aborted=data.get("aborted"),
+            results=[harness.ItemResult(**r) for r in data.get("results", [])],
+        )
+        path = harness.set_baseline(run)
+        sys.stdout.write(f"Baseline written to {path}\n")
+        return 0
+
+    # report
+    data = _latest_run()
+    if data is None:
+        return 2
+    run = harness.BenchRun(
+        started_at=data["started_at"],
+        items_total=data["items_total"],
+        items_run=data["items_run"],
+        items_passed=data["items_passed"],
+        total_cost_usd=data["total_cost_usd"],
+        cost_known=data["cost_known"],
+        aborted=data.get("aborted"),
+        results=[harness.ItemResult(**r) for r in data.get("results", [])],
+    )
+    comparison = harness.compare_to_baseline(run)
+    sys.stdout.write(harness.format_report(run, comparison, output_format) + "\n")
+    return run.exit_code
+
+
 def calibration_report(
     logs: str,
     fit: bool,
@@ -205,6 +282,22 @@ def main():
         help="Write to a file instead of stdout (default: stdout)",
     )
 
+    # Bench harness (ADR-048)
+    bench_parser = subparsers.add_parser(
+        "bench",
+        help="Golden-dataset quality benchmark (ADR-048) — costs real API spend",
+    )
+    bench_parser.add_argument(
+        "action", choices=["run", "baseline", "report"],
+        help="run: execute the dataset; baseline: snapshot last run as baseline; report: render last run",
+    )
+    bench_parser.add_argument("--dataset", type=str, default="bench/dataset/v1")
+    bench_parser.add_argument("--items", type=str, default=None, help="Comma-separated item ids")
+    bench_parser.add_argument("--max-usd", type=float, default=None, dest="max_usd")
+    bench_parser.add_argument("--set", action="store_true", dest="set_baseline_flag",
+                              help="(baseline) write the snapshot")
+    bench_parser.add_argument("--format", choices=["md", "json"], default="md", dest="bench_format")
+
     # Calibration report (ADR-047 P2)
     cal_parser = subparsers.add_parser(
         "calibration-report",
@@ -293,6 +386,17 @@ def main():
             target=args.target,
             force=args.force,
             list_only=args.list_only,
+        )
+    elif args.command == "bench":
+        raise SystemExit(
+            bench_command(
+                action=args.action,
+                dataset=args.dataset,
+                items=args.items,
+                max_usd=args.max_usd,
+                set_flag=args.set_baseline_flag,
+                output_format=args.bench_format,
+            )
         )
     elif args.command == "calibration-report":
         calibration_report(

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -1,0 +1,224 @@
+"""ADR-048 P1: golden-dataset drift harness (#418).
+
+Unit-tested with mocked councils — NO live spend in CI. Spend-cap abort,
+monthly guard, envelope semantics, baseline drift, exit codes 0/1/2.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from llm_council.bench import (
+    BenchItem,
+    check_envelope,
+    compare_to_baseline,
+    format_report,
+    load_dataset,
+    month_to_date_spend,
+    run_bench,
+    set_baseline,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _fake_result(text, score=0.8, cost=0.01):
+    return {
+        "synthesis": text,
+        "metadata": {
+            "aggregate_rankings": [{"model": "m", "average_score": score}],
+            "usage": {"total": {"cost_usd": cost, "cost_known": True}},
+        },
+    }
+
+
+def _write_item(d, iid, must=(("hello",),), min_score=0.3):
+    (d / f"{iid}.json").write_text(
+        json.dumps(
+            {
+                "id": iid,
+                "domain": "factual",
+                "prompt": f"say hello ({iid})",
+                "envelope": {"must_contain": [list(g) for g in must], "min_score": min_score},
+            }
+        )
+    )
+
+
+class TestDataset:
+    def test_committed_v1_loads_and_validates(self):
+        items = load_dataset(REPO_ROOT / "bench" / "dataset" / "v1")
+        assert len(items) >= 20
+        domains = {i.domain for i in items}
+        assert domains == {"coding", "reasoning", "factual", "judgment"}
+
+    def test_malformed_item_fails_fast(self, tmp_path):
+        (tmp_path / "bad.json").write_text('{"id": "x"}')
+        with pytest.raises(ValueError, match="missing"):
+            load_dataset(tmp_path)
+
+    def test_empty_dataset_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="no dataset items"):
+            load_dataset(tmp_path)
+
+
+class TestEnvelope:
+    def test_any_of_groups(self):
+        item = BenchItem(
+            id="x", domain="factual", prompt="p",
+            envelope={"must_contain": [["fizz", "buzz"], ["required"]]},
+        )
+        assert check_envelope(item, "FIZZ and the REQUIRED word", None) == []
+        fails = check_envelope(item, "only fizz here", None)
+        assert len(fails) == 1 and "required" in fails[0]
+
+    def test_score_floor(self):
+        item = BenchItem(id="x", domain="f", prompt="p", envelope={"min_score": 0.5})
+        assert check_envelope(item, "text", 0.6) == []
+        assert check_envelope(item, "text", 0.4) != []
+        assert check_envelope(item, "text", None) == []  # unknown score never fails
+
+
+class TestRun:
+    @pytest.mark.asyncio
+    async def test_all_pass_exit_0(self, tmp_path):
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+        _write_item(d, "b")
+
+        async def runner(prompt):
+            return _fake_result("hello world")
+
+        run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs", council_runner=runner
+        )
+        assert run.exit_code == 0
+        assert run.items_passed == 2
+
+    @pytest.mark.asyncio
+    async def test_drift_exit_1(self, tmp_path):
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a", must=(("absent-token",),))
+
+        async def runner(prompt):
+            return _fake_result("does not contain it")
+
+        run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs", council_runner=runner
+        )
+        assert run.exit_code == 1
+
+    @pytest.mark.asyncio
+    async def test_spend_cap_aborts_gracefully_exit_2(self, tmp_path):
+        d = tmp_path / "ds"
+        d.mkdir()
+        for i in range(4):
+            _write_item(d, f"i{i}")
+
+        async def runner(prompt):
+            return _fake_result("hello", cost=0.60)  # 2 items cross a $1 cap
+
+        run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs",
+            council_runner=runner, max_usd=1.00,
+        )
+        assert run.exit_code == 2
+        assert run.aborted and "per_run_cap" in run.aborted
+        assert run.items_run == 2  # partial results kept
+        assert len(run.results) == 2
+
+    @pytest.mark.asyncio
+    async def test_monthly_guard_refuses_run(self, tmp_path, monkeypatch):
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+        runs = tmp_path / "runs"
+        runs.mkdir()
+        from datetime import datetime, timezone
+
+        stamp = datetime.now(timezone.utc).isoformat()
+        (runs / "run-old.json").write_text(
+            json.dumps({"started_at": stamp, "total_cost_usd": 31.0})
+        )
+
+        called = []
+
+        async def runner(prompt):
+            called.append(prompt)
+            return _fake_result("hello")
+
+        run = await run_bench(dataset_dir=d, runs_dir=runs, council_runner=runner)
+        assert run.exit_code == 2
+        assert "monthly_guard" in run.aborted
+        assert called == []  # zero spend
+
+    @pytest.mark.asyncio
+    async def test_council_error_marks_item_failed_not_crash(self, tmp_path):
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+
+        async def runner(prompt):
+            raise RuntimeError("gateway down")
+
+        run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs", council_runner=runner
+        )
+        assert run.exit_code == 1
+        assert "council_error" in run.results[0].failures[0]
+
+    @pytest.mark.asyncio
+    async def test_run_artefact_persisted(self, tmp_path):
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+
+        async def runner(prompt):
+            return _fake_result("hello", cost=0.02)
+
+        runs = tmp_path / "runs"
+        await run_bench(dataset_dir=d, runs_dir=runs, council_runner=runner)
+        artefacts = list(runs.glob("run-*.json"))
+        assert len(artefacts) == 1
+        assert month_to_date_spend(runs) == pytest.approx(0.02)
+
+
+class TestBaseline:
+    @pytest.mark.asyncio
+    async def test_baseline_round_trip_and_regressions(self, tmp_path):
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+
+        async def good(prompt):
+            return _fake_result("hello")
+
+        async def bad(prompt):
+            return _fake_result("nope")
+
+        base_run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs", council_runner=good
+        )
+        bp = set_baseline(base_run, tmp_path / "baseline.json")
+        drifted = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs", council_runner=bad
+        )
+        cmp = compare_to_baseline(drifted, bp)
+        assert cmp["regressions"] == ["a"]
+        text = format_report(drifted, cmp)
+        assert "REGRESSIONS" in text
+        assert "exit code 1" in text
+
+    def test_missing_baseline_reported(self, tmp_path):
+        from llm_council.bench.harness import BenchRun
+
+        run = BenchRun(
+            started_at="t", items_total=0, items_run=0,
+            items_passed=0, total_cost_usd=0.0, cost_known=False,
+        )
+        cmp = compare_to_baseline(run, tmp_path / "missing.json")
+        assert cmp == {"baseline": None}
+        assert "No committed baseline" in format_report(run, cmp)

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -77,7 +77,11 @@ class TestEnvelope:
         item = BenchItem(id="x", domain="f", prompt="p", envelope={"min_score": 0.5})
         assert check_envelope(item, "text", 0.6) == []
         assert check_envelope(item, "text", 0.4) != []
-        assert check_envelope(item, "text", None) == []  # unknown score never fails
+        # #439 r2: a floor with NO observable score is itself drift — the
+        # council stopped producing the signal the envelope guards.
+        assert check_envelope(item, "text", None) == ["score_unavailable"]
+        no_floor = BenchItem(id="y", domain="f", prompt="p", envelope={})
+        assert check_envelope(no_floor, "text", None) == []
 
 
 class TestRun:
@@ -262,3 +266,48 @@ class TestCouncilRound1:
         )
         cmp = compare_to_baseline(run, bp)
         assert cmp == {"baseline": None}
+
+
+class TestCouncilRound2:
+    @pytest.mark.asyncio
+    async def test_error_items_still_charge_the_cap(self, tmp_path, monkeypatch):
+        # #439 r2: an item that raises may already have spent (stage 1 ran,
+        # stage 3 raised) — errors must charge the conservative default, not
+        # bypass cap accounting.
+        monkeypatch.setenv("LLM_COUNCIL_BENCH_UNKNOWN_ITEM_USD", "0.50")
+        d = tmp_path / "ds"
+        d.mkdir()
+        for i in range(4):
+            _write_item(d, f"i{i}")
+
+        async def runner(prompt):
+            raise RuntimeError("mid-run failure")
+
+        run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs",
+            council_runner=runner, max_usd=1.00,
+        )
+        assert run.exit_code == 2  # cap abort after 2 error charges
+        assert run.items_run == 2
+
+    @pytest.mark.asyncio
+    async def test_cost_known_means_all_items_known(self, tmp_path):
+        # #439 r2: OR-accumulation flipped 'fully known' on the FIRST known
+        # item; the report claims 'not fully known' semantics.
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+        _write_item(d, "b")
+        calls = {"n": 0}
+
+        async def runner(prompt):
+            calls["n"] += 1
+            r = _fake_result("hello")
+            if calls["n"] == 2:
+                r["metadata"]["usage"]["total"] = {"cost_usd": 0.0}  # unknown
+            return r
+
+        run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs", council_runner=runner
+        )
+        assert run.cost_known is False  # one unknown item => NOT fully known

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -311,3 +311,41 @@ class TestCouncilRound2:
             dataset_dir=d, runs_dir=tmp_path / "runs", council_runner=runner
         )
         assert run.cost_known is False  # one unknown item => NOT fully known
+
+
+class TestCouncilRound3:
+    @pytest.mark.asyncio
+    async def test_monthly_ledger_counts_charged_not_just_actuals(self, tmp_path, monkeypatch):
+        # #439 r3: unknown-cost runs recorded $0 actuals, silently eroding
+        # the monthly guard; the ledger now sums the cap-charged figure.
+        monkeypatch.setenv("LLM_COUNCIL_BENCH_UNKNOWN_ITEM_USD", "0.50")
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+
+        async def runner(prompt):
+            r = _fake_result("hello")
+            r["metadata"]["usage"]["total"] = {}  # unknown cost
+            return r
+
+        runs = tmp_path / "runs"
+        await run_bench(dataset_dir=d, runs_dir=runs, council_runner=runner)
+        assert month_to_date_spend(runs) == pytest.approx(0.50)
+
+    @pytest.mark.asyncio
+    async def test_baseline_refuses_aborted_run(self, tmp_path):
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+        _write_item(d, "b")
+
+        async def runner(prompt):
+            return _fake_result("hello", cost=2.0)
+
+        run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs",
+            council_runner=runner, max_usd=1.0,
+        )
+        assert run.aborted
+        with pytest.raises(ValueError, match="aborted"):
+            set_baseline(run, tmp_path / "baseline.json")

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -222,3 +222,43 @@ class TestBaseline:
         cmp = compare_to_baseline(run, tmp_path / "missing.json")
         assert cmp == {"baseline": None}
         assert "No committed baseline" in format_report(run, cmp)
+
+
+class TestCouncilRound1:
+    @pytest.mark.asyncio
+    async def test_unknown_cost_items_charge_the_cap_conservatively(self, tmp_path, monkeypatch):
+        # #439 r1: items whose cost the provider didn't report counted $0
+        # against the cap — unbounded worst-case spend. Unknown-cost items
+        # now charge a conservative default against CAP ACCOUNTING ONLY
+        # (reported spend stays actuals — never fabricated).
+        monkeypatch.setenv("LLM_COUNCIL_BENCH_UNKNOWN_ITEM_USD", "0.50")
+        d = tmp_path / "ds"
+        d.mkdir()
+        for i in range(4):
+            _write_item(d, f"i{i}")
+
+        async def runner(prompt):
+            r = _fake_result("hello")
+            r["metadata"]["usage"]["total"] = {}  # no cost reported
+            return r
+
+        run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs",
+            council_runner=runner, max_usd=1.00,
+        )
+        # 2 x $0.50 conservative charges reach the $1 cap => abort partial.
+        assert run.exit_code == 2
+        assert run.items_run == 2
+        assert run.total_cost_usd == 0.0  # actuals never fabricated
+
+    def test_corrupt_baseline_reported_not_crash(self, tmp_path):
+        from llm_council.bench.harness import BenchRun
+
+        bp = tmp_path / "baseline.json"
+        bp.write_text("{corrupt")
+        run = BenchRun(
+            started_at="t", items_total=0, items_run=0,
+            items_passed=0, total_cost_usd=0.0, cost_known=False,
+        )
+        cmp = compare_to_baseline(run, bp)
+        assert cmp == {"baseline": None}


### PR DESCRIPTION
Closes #418

## Summary
ADR-048 §P1 complete:
- **Dataset v1**: 20 original items across coding/reasoning/factual/judgment with expected-quality envelopes (any-of key-content groups + consensus score floor — never exact-string); `bench/dataset/GOVERNANCE.md` codifies the council-feedback rules (PR-only changes, provenance, no silent goal-post moves).
- **Harness**: envelope checks, committed-baseline regression compare, run artefacts under `.council/bench/runs/`.
- **Spend discipline**: per-run cap enforced against ACTUALS with graceful partial abort (exit 2, partial results kept); month-to-date guard refuses a run before ANY spend; `council_runner` injectable so CI unit tests never touch the API.
- **CLI**: `llm-council bench run|baseline --set|report`, exit codes 0/1/2 per the ADR.
- **Nightly workflow**: schedule + manual dispatch only, explicit caps, spend-ledger cache — never per-PR.

## Tests
13, all mocked-council/no-spend: dataset validation (incl. the committed v1), envelope semantics, exit codes ×3, cap-abort partial, monthly-guard refusal, council-error containment, artefact persistence, baseline round-trip + regression detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)