### PR TITLE
feat(bench): ADR-048 P2 — quality-per-dollar matrix (#419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Quality-per-dollar config matrix (ADR-048 P2, #419)** — `llm-council bench matrix --configs solo-members,council,graduated` runs the same dataset across configurations (each member solo, full council, ADR-044 graduated depth) and renders the empirical "when does deliberation pay?" table from ADR-011 actuals. Unknown/zero cost renders `n/a` (never a fabricated ratio); solo configs skip consensus score floors by design; one broken config never aborts the rest. Methodology + caveats in `bench/METHODOLOGY.md`.
 - **Golden-dataset drift harness (ADR-048 P1, #418)** — `llm-council bench run|baseline|report` executes the versioned dataset (`bench/dataset/v1/`, 20 original items across four domains, governance doc included) against the council and checks expected-quality envelopes (any-of key-content groups + consensus score floors, never exact-string). Hard per-run spend cap (`LLM_COUNCIL_BENCH_MAX_USD`, $2 default) with graceful partial abort, month-to-date guard (`LLM_COUNCIL_BENCH_MONTHLY_USD`, $30 default) from persisted run artefacts, committed-baseline regression detection, exit codes 0/1/2, and a nightly (never per-PR) workflow with explicit caps. Harness fully unit-tested with mocked councils — zero live spend in CI.
 
 ## [0.31.0] - 2026-07-03

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Cost & token accounting (ADR-011, Phase 1–4)
 - `cost_summary.py` `format_cost_summary` renders usage with **progressive disclosure**: one dense line by default, full per-model/per-stage breakdown only under `include_details`. Surfaced in MCP `consult_council` ("Cost & Tokens") and as a typed `usage` field on the HTTP `CouncilResponse`. Releases: one version bump per epic, not per PR (git-tag/setuptools-scm; `publish.yml` triggers on tag only).
 
 Bench (ADR-048)
+- `bench/matrix.py` (P2, #419) — config matrix (solo:<model>/council/graduated) over the same dataset; `quality_per_dollar` = pass_rate/known-cost (None when cost unknown/zero — never fabricated); solo configs skip `min_score` floors (no consensus signal); per-config runs individually capped; methodology + caveats in `bench/METHODOLOGY.md`.
 - `bench/harness.py` (P1, #418) — golden-dataset drift regression: `bench/dataset/v1/` (20 items, envelopes = any-of `must_contain` groups + `min_score` consensus floor; governance in `bench/dataset/GOVERNANCE.md`), per-run cap enforced against ACTUALS with graceful partial abort (exit 2), monthly guard summed from `.council/bench/runs/*.json`, baseline snapshot + regression compare (exit 1 on drift). `council_runner` is injectable — CI tests never spend. Nightly workflow `.github/workflows/bench.yml`; NEVER per-PR.
 
 Bias (ADR-015/018, ADR-047 P4)

--- a/bench/METHODOLOGY.md
+++ b/bench/METHODOLOGY.md
@@ -1,0 +1,39 @@
+# Bench Methodology (ADR-048)
+
+## What is measured
+
+- **Quality**: pass rate against the dataset's expected-quality envelopes —
+  any-of key-content groups (never exact-string) plus, for council
+  configurations, a consensus `min_score` floor from the Borda-aggregated
+  peer review.
+- **Cost**: ADR-011 **actuals** (`cost_source=provider` where available).
+  `cost_known=false` figures are never presented as bills; quality-per-dollar
+  renders `n/a` rather than dividing by an estimate or zero.
+- **quality/$** = pass_rate / known_cost_usd.
+
+## Configurations
+
+| kind | what runs | score floor |
+|------|-----------|-------------|
+| `solo:<model>` | one member answers alone | skipped — no consensus signal exists |
+| `council` | full 3-stage deliberation | applied |
+| `graduated` | council with ADR-044 graduated depth flag on | applied |
+
+## Caveats (read before quoting numbers)
+
+1. **Judge bias**: envelope key-content checks are mechanical, but the
+   `min_score` floor inherits the council's own scoring; ADR-047 calibration
+   caveats apply (confidence/scores are being calibrated, not ground truth).
+2. **Small N**: the v1 dataset has 20 items; per-domain slices are 5 — treat
+   deltas under ~2 items as noise.
+3. **Fixed configuration**: results are only comparable within a run
+   (same models, same dataset version, same day); record
+   `bench/dataset/vN` + model pool + date when publishing.
+4. **Spend caps can truncate**: aborted/partial runs are marked and are not
+   comparable to complete runs; baselines refuse them.
+
+## Reproducing
+
+```bash
+llm-council bench matrix --configs solo-members,council,graduated --max-usd 2.00
+```

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -130,7 +130,12 @@ def load_dataset(dataset_dir: Optional[Path] = None) -> List[BenchItem]:
     return items
 
 
-def check_envelope(item: BenchItem, synthesis: str, score: Optional[float]) -> List[str]:
+def check_envelope(
+    item: BenchItem,
+    synthesis: str,
+    score: Optional[float],
+    apply_score_floor: bool = True,
+) -> List[str]:
     """Return envelope violations (empty == within envelope)."""
     failures: List[str] = []
     text = (synthesis or "").lower()
@@ -139,7 +144,7 @@ def check_envelope(item: BenchItem, synthesis: str, score: Optional[float]) -> L
         if not any(str(opt).lower() in text for opt in options):
             failures.append(f"missing_any_of:{options}")
     min_score = item.envelope.get("min_score")
-    if min_score is not None:
+    if min_score is not None and apply_score_floor:
         if score is None:
             # A floor with no observable score IS drift (#439 r2): the
             # council stopped producing the signal the envelope guards.
@@ -197,6 +202,7 @@ async def run_bench(
     max_usd: Optional[float] = None,
     runs_dir: Optional[Path] = None,
     council_runner: Any = None,
+    ignore_score_floor: bool = False,
 ) -> BenchRun:
     """Execute the bench. ``council_runner`` is injectable for tests
     (async callable prompt -> council result dict); the default runs the
@@ -268,7 +274,11 @@ async def run_bench(
         synthesis = result.get("synthesis", "")
         score = _extract_score(result)
         cost, cost_known = _extract_cost(result)
-        failures = check_envelope(item, synthesis, score)
+        # Solo matrix configs (ADR-048 P2) have no council consensus signal;
+        # min_score floors are skipped for them by explicit opt-in.
+        failures = check_envelope(
+            item, synthesis, score, apply_score_floor=not ignore_score_floor
+        )
         run.total_cost_usd = round(run.total_cost_usd + cost, 6)
         cap_charged = round(cap_charged + (cost if cost_known else bench_unknown_item_usd()), 6)
         if not cost_known:

--- a/src/llm_council/bench/matrix.py
+++ b/src/llm_council/bench/matrix.py
@@ -1,0 +1,152 @@
+"""Quality-per-dollar configuration matrix (ADR-048 P2, #419).
+
+Runs the same golden dataset across configurations — each council member
+solo, the full council, and (flag-on) ADR-044 graduated depth — and renders
+the empirical answer to "when does deliberation pay?" using ADR-011 actual
+costs. Methodology and caveats: ``bench/METHODOLOGY.md``.
+
+Scoring note: solo configurations produce no council consensus, so envelope
+``min_score`` floors are skipped for ``kind="solo"`` (documented in the
+methodology); key-content assertions apply to every configuration equally.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from .harness import run_bench
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MatrixConfig:
+    """One column of the matrix."""
+
+    name: str
+    kind: str  # "solo" | "council" | "graduated"
+    runner: Optional[Callable[..., Any]] = None  # injectable; real by default
+
+
+def quality_per_dollar(
+    *, pass_rate: float, cost_usd: float, cost_known: bool
+) -> Optional[float]:
+    """Pass-rate per dollar of KNOWN spend; None when it cannot be honest.
+
+    Unknown or zero cost yields None rather than a fabricated/infinite
+    figure — ADR-011: never present an estimate as a bill.
+    """
+    if not cost_known or cost_usd <= 0:
+        return None
+    return round(pass_rate / cost_usd, 3)
+
+
+def _default_runner(config: MatrixConfig) -> Callable[..., Any]:  # pragma: no cover
+    """Build the real runner for a config — REAL SPEND."""
+    if config.kind == "solo":
+        model = config.name.split(":", 1)[1]
+
+        async def solo_runner(prompt: str) -> Dict[str, Any]:
+            from llm_council.gateway_adapter import query_model_with_status
+
+            response = await query_model_with_status(
+                model, [{"role": "user", "content": prompt}], timeout=120.0
+            )
+            usage = (response or {}).get("usage") or {}
+            return {
+                "synthesis": (response or {}).get("content") or "",
+                "metadata": {
+                    "aggregate_rankings": [],
+                    "usage": {
+                        "total": {
+                            "cost_usd": usage.get("cost") or 0.0,
+                            "cost_known": usage.get("cost") is not None,
+                        }
+                    },
+                },
+            }
+
+        return solo_runner
+
+    async def council_runner(prompt: str) -> Dict[str, Any]:
+        import os
+
+        from llm_council.council import run_council_with_fallback
+
+        if config.kind == "graduated":
+            os.environ["LLM_COUNCIL_GRADUATED_DEPTH"] = "true"
+        return await run_council_with_fallback(prompt, bypass_cache=True)
+
+    return council_runner
+
+
+async def run_matrix(
+    configs: List[MatrixConfig],
+    *,
+    dataset_dir: Optional[Path] = None,
+    runs_dir: Optional[Path] = None,
+    max_usd: Optional[float] = None,
+    items_filter: Optional[List[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Run every configuration; each gets its own capped bench run.
+
+    A config whose runner errors on every item simply scores 0 — one broken
+    configuration never aborts the rest of the matrix.
+    """
+    rows: List[Dict[str, Any]] = []
+    for config in configs:
+        runner = config.runner or _default_runner(config)
+        run = await run_bench(
+            dataset_dir=dataset_dir,
+            runs_dir=runs_dir,
+            max_usd=max_usd,
+            items_filter=items_filter,
+            council_runner=runner,
+            ignore_score_floor=(config.kind == "solo"),
+        )
+        pass_rate = round(run.items_passed / run.items_run, 3) if run.items_run else 0.0
+        rows.append(
+            {
+                "config": config.name,
+                "kind": config.kind,
+                "items_run": run.items_run,
+                "pass_rate": pass_rate,
+                "cost_usd": run.total_cost_usd,
+                "cost_known": run.cost_known,
+                "quality_per_dollar": quality_per_dollar(
+                    pass_rate=pass_rate,
+                    cost_usd=run.total_cost_usd,
+                    cost_known=run.cost_known,
+                ),
+                "aborted": run.aborted,
+            }
+        )
+    return rows
+
+
+def format_matrix_table(rows: List[Dict[str, Any]]) -> str:
+    """Markdown quality-per-dollar table."""
+    lines = [
+        "# Quality per Dollar (ADR-048 P2)",
+        "",
+        "| config | kind | items | pass rate | cost (USD) | quality/$ |",
+        "|--------|------|-------|-----------|------------|-----------|",
+    ]
+    for r in rows:
+        cost = f"{r['cost_usd']:.4f}" if r["cost_known"] else f"~{r['cost_usd']:.4f} (unknown)"
+        qpd = r["quality_per_dollar"]
+        qpd_str = f"{qpd:.3f}" if qpd is not None else "n/a"
+        note = " (aborted)" if r.get("aborted") else ""
+        lines.append(
+            f"| {r['config']}{note} | {r['kind']} | {r['items_run']} "
+            f"| {r['pass_rate']:.0%} | {cost} | {qpd_str} |"
+        )
+    lines.append("")
+    lines.append(
+        "Methodology & caveats: bench/METHODOLOGY.md (fixed judge config, "
+        "ADR-047 calibration caveats, ADR-011 cost semantics)."
+    )
+    return "\n".join(lines)

--- a/src/llm_council/bench/matrix.py
+++ b/src/llm_council/bench/matrix.py
@@ -74,11 +74,22 @@ def _default_runner(config: MatrixConfig) -> Callable[..., Any]:  # pragma: no c
     async def council_runner(prompt: str) -> Dict[str, Any]:
         import os
 
-        from llm_council.council import run_council_with_fallback
+        import llm_council.council as council_mod
 
-        if config.kind == "graduated":
-            os.environ["LLM_COUNCIL_GRADUATED_DEPTH"] = "true"
-        return await run_council_with_fallback(prompt, bypass_cache=True)
+        if config.kind != "graduated":
+            return await council_mod.run_council_with_fallback(prompt, bypass_cache=True)
+        # Set the ADR-044 flag for THIS call only and always restore it —
+        # leaking it would silently turn every later matrix config into a
+        # graduated run, invalidating the comparison (#440 review).
+        previous = os.environ.get("LLM_COUNCIL_GRADUATED_DEPTH")
+        os.environ["LLM_COUNCIL_GRADUATED_DEPTH"] = "true"
+        try:
+            return await council_mod.run_council_with_fallback(prompt, bypass_cache=True)
+        finally:
+            if previous is None:
+                os.environ.pop("LLM_COUNCIL_GRADUATED_DEPTH", None)
+            else:
+                os.environ["LLM_COUNCIL_GRADUATED_DEPTH"] = previous
 
     return council_runner
 

--- a/src/llm_council/bench/matrix.py
+++ b/src/llm_council/bench/matrix.py
@@ -44,8 +44,19 @@ def quality_per_dollar(
     return round(pass_rate / cost_usd, 3)
 
 
-def _default_runner(config: MatrixConfig) -> Callable[..., Any]:  # pragma: no cover
-    """Build the real runner for a config — REAL SPEND."""
+def _default_runner(config: MatrixConfig) -> Callable[..., Any]:
+    """Build the real runner for a config — REAL SPEND.
+
+    Unknown kinds raise (#440 r2): a typo must never silently fall through
+    to the full-council runner and spend money on the wrong configuration.
+
+    Concurrency note: run_matrix executes configs strictly SEQUENTIALLY, so
+    the per-call env swap in the graduated runner has no concurrent reader;
+    running matrix configs concurrently would require threading the ADR-044
+    flag as a parameter instead.
+    """
+    if config.kind not in ("solo", "council", "graduated"):
+        raise ValueError(f"unknown matrix kind: {config.kind!r}")
     if config.kind == "solo":
         model = config.name.split(":", 1)[1]
 

--- a/src/llm_council/cli.py
+++ b/src/llm_council/cli.py
@@ -44,6 +44,7 @@ def bench_command(
     max_usd,
     set_flag: bool,
     output_format: str,
+    configs: str = "council",
 ) -> int:
     """ADR-048 bench CLI. Returns the process exit code (0/1/2)."""
     import asyncio
@@ -60,6 +61,42 @@ def bench_command(
             sys.stdout.write("No bench runs recorded yet — run `llm-council bench run` first.\n")
             return None
         return _json.loads(artefacts[-1].read_text())
+
+    if action == "matrix":
+        import json as _json2
+
+        from .bench.matrix import MatrixConfig, format_matrix_table, run_matrix
+
+        matrix_configs = []
+        for name in [c.strip() for c in configs.split(",") if c.strip()]:
+            if name == "solo-members":
+                from .council import _get_council_models
+
+                for model in _get_council_models():
+                    matrix_configs.append(
+                        MatrixConfig(name=f"solo:{model}", kind="solo")
+                    )
+            elif name.startswith("solo:"):
+                matrix_configs.append(MatrixConfig(name=name, kind="solo"))
+            elif name in ("council", "graduated"):
+                matrix_configs.append(MatrixConfig(name=name, kind=name))
+            else:
+                sys.stdout.write(f"Unknown matrix config: {name}\n")
+                return 2
+        items_filter = [i.strip() for i in items.split(",")] if items else None
+        rows = asyncio.run(
+            run_matrix(
+                matrix_configs,
+                dataset_dir=Path(dataset),
+                max_usd=max_usd,
+                items_filter=items_filter,
+            )
+        )
+        if output_format == "json":
+            sys.stdout.write(_json2.dumps(rows, indent=2) + "\n")
+        else:
+            sys.stdout.write(format_matrix_table(rows) + "\n")
+        return 0 if all(not r.get("aborted") for r in rows) else 2
 
     if action == "run":
         items_filter = [i.strip() for i in items.split(",")] if items else None
@@ -288,7 +325,7 @@ def main():
         help="Golden-dataset quality benchmark (ADR-048) — costs real API spend",
     )
     bench_parser.add_argument(
-        "action", choices=["run", "baseline", "report"],
+        "action", choices=["run", "baseline", "report", "matrix"],
         help="run: execute the dataset; baseline: snapshot last run as baseline; report: render last run",
     )
     bench_parser.add_argument("--dataset", type=str, default="bench/dataset/v1")
@@ -297,6 +334,10 @@ def main():
     bench_parser.add_argument("--set", action="store_true", dest="set_baseline_flag",
                               help="(baseline) write the snapshot")
     bench_parser.add_argument("--format", choices=["md", "json"], default="md", dest="bench_format")
+    bench_parser.add_argument(
+        "--configs", type=str, default="council",
+        help="(matrix) comma list: council, graduated, solo:<model>, solo-members",
+    )
 
     # Calibration report (ADR-047 P2)
     cal_parser = subparsers.add_parser(
@@ -396,6 +437,7 @@ def main():
                 max_usd=args.max_usd,
                 set_flag=args.set_baseline_flag,
                 output_format=args.bench_format,
+                configs=args.configs,
             )
         )
     elif args.command == "calibration-report":

--- a/tests/test_bench_matrix.py
+++ b/tests/test_bench_matrix.py
@@ -1,0 +1,102 @@
+"""ADR-048 P2: quality-per-dollar config matrix (#419). Mocked — no spend."""
+
+import json
+
+import pytest
+
+from llm_council.bench.matrix import (
+    MatrixConfig,
+    format_matrix_table,
+    quality_per_dollar,
+    run_matrix,
+)
+
+
+def _write_item(d, iid):
+    (d / f"{iid}.json").write_text(
+        json.dumps(
+            {
+                "id": iid,
+                "domain": "factual",
+                "prompt": "say hello",
+                "envelope": {"must_contain": [["hello"]], "min_score": 0.3},
+            }
+        )
+    )
+
+
+def _result(text, score=0.8, cost=0.02, known=True):
+    return {
+        "synthesis": text,
+        "metadata": {
+            "aggregate_rankings": [{"model": "m", "average_score": score}],
+            "usage": {"total": {"cost_usd": cost, "cost_known": known}},
+        },
+    }
+
+
+class TestQualityPerDollar:
+    def test_basic_math(self):
+        assert quality_per_dollar(pass_rate=1.0, cost_usd=0.50, cost_known=True) == 2.0
+
+    def test_unknown_cost_is_none(self):
+        assert quality_per_dollar(pass_rate=1.0, cost_usd=0.0, cost_known=False) is None
+
+    def test_zero_cost_known_is_none_not_infinity(self):
+        assert quality_per_dollar(pass_rate=1.0, cost_usd=0.0, cost_known=True) is None
+
+
+class TestMatrix:
+    @pytest.mark.asyncio
+    async def test_runs_each_config_and_tables(self, tmp_path):
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+
+        async def council(prompt):
+            return _result("hello from council", cost=0.10)
+
+        async def solo(prompt):
+            # Solo runs produce NO consensus score — floors must not apply.
+            r = _result("hello from solo", cost=0.01)
+            r["metadata"]["aggregate_rankings"] = []
+            return r
+
+        configs = [
+            MatrixConfig(name="solo:m/a", kind="solo", runner=solo),
+            MatrixConfig(name="council", kind="council", runner=council),
+        ]
+        rows = await run_matrix(
+            configs, dataset_dir=d, runs_dir=tmp_path / "runs", max_usd=2.0
+        )
+        by_name = {r["config"]: r for r in rows}
+        assert by_name["solo:m/a"]["pass_rate"] == 1.0  # floor skipped for solo
+        assert by_name["council"]["pass_rate"] == 1.0
+        assert by_name["solo:m/a"]["quality_per_dollar"] > by_name["council"]["quality_per_dollar"]
+        table = format_matrix_table(rows)
+        assert "quality/$" in table and "council" in table
+
+    @pytest.mark.asyncio
+    async def test_config_error_reported_not_fatal(self, tmp_path):
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+
+        async def broken(prompt):
+            raise RuntimeError("boom")
+
+        async def council(prompt):
+            return _result("hello", cost=0.10)
+
+        rows = await run_matrix(
+            [
+                MatrixConfig(name="bad", kind="solo", runner=broken),
+                MatrixConfig(name="council", kind="council", runner=council),
+            ],
+            dataset_dir=d,
+            runs_dir=tmp_path / "runs",
+            max_usd=2.0,
+        )
+        by_name = {r["config"]: r for r in rows}
+        assert by_name["bad"]["pass_rate"] == 0.0
+        assert by_name["council"]["pass_rate"] == 1.0

--- a/tests/test_bench_matrix.py
+++ b/tests/test_bench_matrix.py
@@ -100,3 +100,34 @@ class TestMatrix:
         by_name = {r["config"]: r for r in rows}
         assert by_name["bad"]["pass_rate"] == 0.0
         assert by_name["council"]["pass_rate"] == 1.0
+
+
+class TestCouncilRound1:
+    @pytest.mark.asyncio
+    async def test_graduated_flag_never_leaks_to_next_config(self, monkeypatch, tmp_path):
+        # #440 r1: the graduated runner set LLM_COUNCIL_GRADUATED_DEPTH and
+        # never reverted — a 'council' config running AFTER 'graduated' would
+        # silently run graduated too, invalidating the comparison.
+        import os
+
+        from llm_council.bench.matrix import _default_runner
+
+        monkeypatch.delenv("LLM_COUNCIL_GRADUATED_DEPTH", raising=False)
+        observed = {}
+
+        async def fake_council(prompt, **kwargs):
+            observed["flag_during_call"] = os.environ.get("LLM_COUNCIL_GRADUATED_DEPTH")
+            return {"synthesis": "x", "metadata": {}}
+
+        import llm_council.council as council_mod
+
+        monkeypatch.setattr(council_mod, "run_council_with_fallback", fake_council)
+
+        graduated = _default_runner(MatrixConfig(name="graduated", kind="graduated"))
+        await graduated("q")
+        assert observed["flag_during_call"] == "true"  # on DURING the call
+        assert "LLM_COUNCIL_GRADUATED_DEPTH" not in os.environ  # restored after
+
+        plain = _default_runner(MatrixConfig(name="council", kind="council"))
+        await plain("q")
+        assert observed["flag_during_call"] is None  # plain config unaffected

--- a/tests/test_bench_matrix.py
+++ b/tests/test_bench_matrix.py
@@ -131,3 +131,11 @@ class TestCouncilRound1:
         plain = _default_runner(MatrixConfig(name="council", kind="council"))
         await plain("q")
         assert observed["flag_during_call"] is None  # plain config unaffected
+
+    def test_unknown_kind_raises_never_spends(self):
+        # #440 r2: an unknown kind fell through to the FULL COUNCIL runner —
+        # a typo could silently spend real money.
+        from llm_council.bench.matrix import _default_runner
+
+        with pytest.raises(ValueError, match="unknown matrix kind"):
+            _default_runner(MatrixConfig(name="oops", kind="banana"))


### PR DESCRIPTION
Closes #419

## Summary
The empirical answer to 'when does deliberation pay?' (ADR-048 §P2): `llm-council bench matrix` runs the golden dataset across configurations — each member solo, the full council, ADR-044 graduated depth — and renders a quality-per-dollar table from **ADR-011 actuals**.

- `quality/$` = pass_rate / known-cost; unknown or zero cost ⇒ `n/a`, never a fabricated/infinite ratio
- solo configs skip consensus `min_score` floors by explicit design (no council signal exists); key-content assertions apply to every config equally
- each config gets its own capped bench run; a broken config scores 0 without aborting the rest
- `bench/METHODOLOGY.md`: measurement definitions and the caveats that must accompany any published numbers (ADR-047 judge-bias inheritance, small-N, fixed-config comparability)

## Tests
5 new, all mocked (zero spend): qpd math incl. unknown/zero-cost honesty, per-config runs + solo floor skip + table rendering, config-error containment. Suite 3149 green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)