### PR TITLE
Release v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-07-03
+
+**Council Quality Benchmark (ADR-048)** — epic [#421](https://github.com/amiable-dev/llm-council/issues/421). The core product claim becomes measurable: a governed golden dataset with drift regression, a quality-per-dollar configuration matrix from ADR-011 actuals ("when does deliberation pay?"), harness-regenerated results publication, and DeepEval/RAGAS bridges. Spend is capped per-run and per-month with honest unknown-cost accounting; CI never spends (mocked-council tests only; nightly workflow only).
+
 ### Added
 
 - **Publication + eval bridges (ADR-048 P3, #420)** — `llm-council bench report --publish docs/bench-results.md` regenerates the results page FROM the harness output (reproducibility fields mandatory: dataset version, date, spend, methodology pointer — never hand-edited). Thin dependency-free adapters let external eval suites drive the council as a target: `make_council_eval_callable` (DeepEval-style prompt→answer) and `council_to_ragas_row` (synthesis as answer, stage-1 drafts as contexts), each with a round-trip example under `examples/eval_bridges/`.

--- a/docs/adr/ADR-048-quality-benchmark.md
+++ b/docs/adr/ADR-048-quality-benchmark.md
@@ -1,6 +1,6 @@
 # ADR-048: Council Quality Benchmark & Golden-Dataset Regression
 
-**Status:** Draft 2026-07-03
+**Status:** Implemented 2026-07-03 (epic #421, v0.32.0)
 **Date:** 2026-07-03
 **Decision Makers:** Chris Joseph, LLM Council
 **Council Review:** 2026-07-03 (4 models, balanced) — feedback incorporated: spend caps, CLI spec, dataset governance, per-phase DoD

--- a/server-card.json
+++ b/server-card.json
@@ -3,7 +3,7 @@
   "name": "io.github.amiable-dev/llm-council",
   "title": "LLM Council",
   "description": "Multi-model deliberation council with anonymized peer review, exposed as MCP tools.",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "websiteUrl": "https://github.com/amiable-dev/llm-council",
   "repository": {
     "source": "github",


### PR DESCRIPTION
## v0.32.0 — Council Quality Benchmark (ADR-048, epic #421)

- **P1** (#418, PR #439): golden dataset v1 (20 items, governance doc) + drift harness; per-run + monthly spend caps with conservative unknown-cost accounting; `llm-council bench run|baseline|report`; nightly workflow (never per-PR)
- **P2** (#419, PR #440): quality-per-dollar config matrix (solo members / council / graduated depth) from ADR-011 actuals; methodology doc with mandatory caveats
- **P3** (#420, PR #441): harness-regenerated results page (`--publish`); dependency-free DeepEval/RAGAS bridges + round-trip examples

ADR-048 status → Implemented; static card stamped 0.32.0.

**Tag v0.32.0 will be pushed after merge (version confirmation pending).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)