### PR TITLE
feat(api): consult_council facade — docs-as-spec (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`consult_council` Python facade (#444)** — the API the published quickstart always documented now exists: `from llm_council import consult_council` returns a `CouncilResult` (`.synthesis`, `.metadata`, `.model_responses`, `.raw`) with MCP-tool-parity tier semantics (confidence → tier contract → tier-sovereign timeouts; unknown confidence falls back to `high`; unknown `verdict_type` raises — it changes the output contract, so it is never silently coerced). Docs-as-spec fix from the 2026-07-03 documentation review.
+
 ## [0.32.0] - 2026-07-03
 
 **Council Quality Benchmark (ADR-048)** — epic [#421](https://github.com/amiable-dev/llm-council/issues/421). The core product claim becomes measurable: a governed golden dataset with drift regression, a quality-per-dollar configuration matrix from ADR-011 actuals ("when does deliberation pay?"), harness-regenerated results publication, and DeepEval/RAGAS bridges. Spend is capped per-run and per-month with honest unknown-cost accounting; CI never spends (mocked-council tests only; nightly workflow only).

--- a/src/llm_council/__init__.py
+++ b/src/llm_council/__init__.py
@@ -1,12 +1,17 @@
 """LLM Council - Multi-LLM council system with peer review and synthesis.
 
 Usage:
+    from llm_council import consult_council
+
+    result = await consult_council(
+        "What's the best approach for error handling?", confidence="balanced"
+    )
+    print(result.synthesis)
+
+Lower-level (stage tuples):
     from llm_council import run_full_council
 
-    # Run the full 3-stage council process
-    stage1, stage2, stage3, metadata = await run_full_council(
-        "What's the best approach for error handling?"
-    )
+    stage1, stage2, stage3, metadata = await run_full_council("...")
     print(stage3["response"])
 
 For MCP server usage:
@@ -14,6 +19,7 @@ For MCP server usage:
     llm-council
 """
 
+from llm_council.facade import CouncilResult, consult_council
 from llm_council.council import (
     run_full_council,
     stage1_collect_responses,

--- a/src/llm_council/facade.py
+++ b/src/llm_council/facade.py
@@ -70,13 +70,18 @@ async def consult_council(
             a bad verdict type changes the OUTPUT CONTRACT, so it must not
             be silently coerced).
     """
-    try:
-        verdict = VerdictType(verdict_type.lower())
-    except ValueError:
-        valid = ", ".join(v.value for v in VerdictType)
-        raise ValueError(
-            f"unknown verdict_type {verdict_type!r}; expected one of: {valid}"
-        ) from None
+    # Accept the enum directly or its string value (#450 review) — any other
+    # type is a ValueError, never an AttributeError.
+    if isinstance(verdict_type, VerdictType):
+        verdict = verdict_type
+    else:
+        try:
+            verdict = VerdictType(str(verdict_type).lower())
+        except ValueError:
+            valid = ", ".join(v.value for v in VerdictType)
+            raise ValueError(
+                f"unknown verdict_type {verdict_type!r}; expected one of: {valid}"
+            ) from None
 
     tier = confidence if confidence in TIER_MODEL_POOLS else "high"
     tier_contract = create_tier_contract(tier)

--- a/src/llm_council/facade.py
+++ b/src/llm_council/facade.py
@@ -1,0 +1,99 @@
+"""High-level Python facade: ``consult_council`` (#444, docs-as-spec).
+
+The published quickstart documented ``from llm_council import consult_council``
+returning an object with ``.synthesis`` before any such API existed. The
+documented shape is better library UX than tuple-unpacking
+``run_full_council``, so this ships it: one awaitable call, tier semantics
+identical to the MCP ``consult_council`` tool (confidence → tier contract →
+tier-sovereign timeouts, unknown values falling back to ``high``).
+
+Usage::
+
+    from llm_council import consult_council
+
+    result = await consult_council(
+        "What are the best practices for error handling in Python?",
+        confidence="balanced",
+    )
+    print(result.synthesis)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from llm_council.council import run_council_with_fallback
+from llm_council.tier_contract import TIER_MODEL_POOLS, create_tier_contract
+from llm_council.verdict import VerdictType
+
+__all__ = ["CouncilResult", "consult_council"]
+
+
+@dataclass
+class CouncilResult:
+    """The documented result shape.
+
+    ``raw`` carries the full ADR-012 structured dict for anything not lifted
+    to an attribute (usage/cost per ADR-011 lives in ``metadata['usage']``).
+    """
+
+    synthesis: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    model_responses: Dict[str, Any] = field(default_factory=dict)
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+
+async def consult_council(
+    query: str,
+    confidence: str = "high",
+    *,
+    verdict_type: str = "synthesis",
+    include_dissent: bool = False,
+    models: Optional[List[str]] = None,
+    bypass_cache: bool = False,
+) -> CouncilResult:
+    """Run the 3-stage council and return the synthesized result.
+
+    Args:
+        query: The question to deliberate.
+        confidence: quick | balanced | high | reasoning — selects the tier
+            (models + timeouts). Unknown values fall back to ``high``, the
+            same forgiving semantics as the MCP tool.
+        verdict_type: synthesis | binary | tie_breaker (ADR-025b Jury Mode).
+        include_dissent: Extract minority opinions from the peer review.
+        models: Optional explicit council override (else tier pool).
+        bypass_cache: Skip the response cache.
+
+    Raises:
+        ValueError: on an unknown ``verdict_type`` (unlike ``confidence``,
+            a bad verdict type changes the OUTPUT CONTRACT, so it must not
+            be silently coerced).
+    """
+    try:
+        verdict = VerdictType(verdict_type.lower())
+    except ValueError:
+        valid = ", ".join(v.value for v in VerdictType)
+        raise ValueError(
+            f"unknown verdict_type {verdict_type!r}; expected one of: {valid}"
+        ) from None
+
+    tier = confidence if confidence in TIER_MODEL_POOLS else "high"
+    tier_contract = create_tier_contract(tier)
+
+    raw = await run_council_with_fallback(
+        query,
+        models=models,
+        bypass_cache=bypass_cache,
+        tier_contract=tier_contract,
+        synthesis_deadline=tier_contract.deadline_ms / 1000,
+        per_model_timeout=tier_contract.per_model_timeout_ms / 1000,
+        verdict_type=verdict,
+        include_dissent=include_dissent,
+    )
+    return CouncilResult(
+        synthesis=raw.get("synthesis", ""),
+        metadata=raw.get("metadata", {}),
+        model_responses=raw.get("model_responses", {}),
+        raw=raw,
+    )

--- a/src/llm_council/facade.py
+++ b/src/llm_council/facade.py
@@ -81,15 +81,23 @@ async def consult_council(
     tier = confidence if confidence in TIER_MODEL_POOLS else "high"
     tier_contract = create_tier_contract(tier)
 
+    # Public-API hardening (#450 review): a misconfigured tier could carry
+    # None timeouts; omit the kwargs and let the orchestrator's defaults
+    # apply rather than crashing on arithmetic.
+    timeout_kwargs = {}
+    if tier_contract.deadline_ms:
+        timeout_kwargs["synthesis_deadline"] = tier_contract.deadline_ms / 1000
+    if tier_contract.per_model_timeout_ms:
+        timeout_kwargs["per_model_timeout"] = tier_contract.per_model_timeout_ms / 1000
+
     raw = await run_council_with_fallback(
         query,
         models=models,
         bypass_cache=bypass_cache,
         tier_contract=tier_contract,
-        synthesis_deadline=tier_contract.deadline_ms / 1000,
-        per_model_timeout=tier_contract.per_model_timeout_ms / 1000,
         verdict_type=verdict,
         include_dissent=include_dissent,
+        **timeout_kwargs,
     )
     return CouncilResult(
         synthesis=raw.get("synthesis", ""),

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -117,3 +117,24 @@ class TestDocumentedQuickstartShape:
         assert result.synthesis == "ok"
         assert "synthesis_deadline" not in run.call_args.kwargs
         assert "per_model_timeout" not in run.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_verdict_type_enum_instance_accepted(self):
+        # #450 r2: a public API should take the enum directly, not only str.
+        from llm_council import consult_council
+        from llm_council.verdict import VerdictType
+
+        with patch(
+            "llm_council.facade.run_council_with_fallback",
+            new_callable=AsyncMock,
+            return_value={"synthesis": "", "metadata": {}, "model_responses": {}},
+        ) as run:
+            await consult_council("q", verdict_type=VerdictType.BINARY)
+        assert run.call_args.kwargs["verdict_type"] == VerdictType.BINARY
+
+    @pytest.mark.asyncio
+    async def test_non_string_verdict_type_raises_valueerror_not_attributeerror(self):
+        from llm_council import consult_council
+
+        with pytest.raises(ValueError, match="verdict_type"):
+            await consult_council("q", verdict_type=42)

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -1,0 +1,97 @@
+"""#444: consult_council facade — ship the API the docs promised (docs-as-spec).
+
+The published quickstart documents `from llm_council import consult_council`
+returning an object with `.synthesis`; that API never existed. These tests
+pin the exact documented shape.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class TestDocumentedQuickstartShape:
+    @pytest.mark.asyncio
+    async def test_exact_quickstart_snippet_runs(self):
+        # Verbatim shape from docs/getting-started/quickstart.md
+        from llm_council import consult_council
+
+        fake = {
+            "synthesis": "the answer",
+            "metadata": {"status": "complete"},
+            "model_responses": {"m/a": {"status": "ok"}},
+        }
+        with patch(
+            "llm_council.facade.run_council_with_fallback",
+            new_callable=AsyncMock,
+            return_value=fake,
+        ):
+            result = await consult_council(
+                "What are the best practices for error handling in Python?",
+                confidence="balanced",
+            )
+        assert result.synthesis == "the answer"
+        assert result.metadata["status"] == "complete"
+        assert result.model_responses["m/a"]["status"] == "ok"
+        assert result.raw is fake
+
+    @pytest.mark.asyncio
+    async def test_confidence_maps_to_tier_contract(self):
+        from llm_council import consult_council
+
+        with patch(
+            "llm_council.facade.run_council_with_fallback",
+            new_callable=AsyncMock,
+            return_value={"synthesis": "", "metadata": {}, "model_responses": {}},
+        ) as run:
+            await consult_council("q", confidence="quick")
+        kwargs = run.call_args.kwargs
+        assert kwargs["tier_contract"].tier == "quick"
+        # Timeouts derived from the tier contract (MCP-server parity).
+        assert kwargs["synthesis_deadline"] == pytest.approx(
+            kwargs["tier_contract"].deadline_ms / 1000
+        )
+        assert kwargs["per_model_timeout"] == pytest.approx(
+            kwargs["tier_contract"].per_model_timeout_ms / 1000
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_confidence_falls_back_to_high(self):
+        # Same forgiving semantics as the MCP consult_council tool.
+        from llm_council import consult_council
+
+        with patch(
+            "llm_council.facade.run_council_with_fallback",
+            new_callable=AsyncMock,
+            return_value={"synthesis": "", "metadata": {}, "model_responses": {}},
+        ) as run:
+            await consult_council("q", confidence="banana")
+        assert run.call_args.kwargs["tier_contract"].tier == "high"
+
+    @pytest.mark.asyncio
+    async def test_verdict_type_and_dissent_pass_through(self):
+        from llm_council import consult_council
+        from llm_council.verdict import VerdictType
+
+        with patch(
+            "llm_council.facade.run_council_with_fallback",
+            new_callable=AsyncMock,
+            return_value={"synthesis": "", "metadata": {}, "model_responses": {}},
+        ) as run:
+            await consult_council(
+                "q", verdict_type="binary", include_dissent=True, models=["m/a"]
+            )
+        kwargs = run.call_args.kwargs
+        assert kwargs["verdict_type"] == VerdictType.BINARY
+        assert kwargs["include_dissent"] is True
+        assert kwargs["models"] == ["m/a"]
+
+    def test_invalid_verdict_type_raises_clearly(self):
+        import asyncio
+
+        from llm_council import consult_council
+
+        with pytest.raises(ValueError, match="verdict_type"):
+            asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
+                consult_council("q", verdict_type="banana")
+            )

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -86,12 +86,34 @@ class TestDocumentedQuickstartShape:
         assert kwargs["include_dissent"] is True
         assert kwargs["models"] == ["m/a"]
 
-    def test_invalid_verdict_type_raises_clearly(self):
-        import asyncio
-
+    @pytest.mark.asyncio
+    async def test_invalid_verdict_type_raises_clearly(self):
         from llm_council import consult_council
 
         with pytest.raises(ValueError, match="verdict_type"):
-            asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
-                consult_council("q", verdict_type="banana")
-            )
+            await consult_council("q", verdict_type="banana")
+
+    @pytest.mark.asyncio
+    async def test_none_tier_timeouts_omitted_not_crashed(self, monkeypatch):
+        # #450 review: a misconfigured tier contract with None timeouts must
+        # fall through to orchestrator defaults, never crash on arithmetic.
+        from types import SimpleNamespace
+
+        from llm_council import facade
+
+        monkeypatch.setattr(
+            facade,
+            "create_tier_contract",
+            lambda tier: SimpleNamespace(
+                tier=tier, deadline_ms=None, per_model_timeout_ms=None
+            ),
+        )
+        with patch(
+            "llm_council.facade.run_council_with_fallback",
+            new_callable=AsyncMock,
+            return_value={"synthesis": "ok", "metadata": {}, "model_responses": {}},
+        ) as run:
+            result = await facade.consult_council("q", confidence="high")
+        assert result.synthesis == "ok"
+        assert "synthesis_deadline" not in run.call_args.kwargs
+        assert "per_model_timeout" not in run.call_args.kwargs


### PR DESCRIPTION
Closes #444 (epic #443, 1/6)

## Summary
Ships the Python API the published quickstart has documented all along (docs-as-spec, per the 2026-07-03 documentation review): `from llm_council import consult_council` → `CouncilResult` with `.synthesis` / `.metadata` / `.model_responses` / `.raw`.

- Tier semantics have **MCP-tool parity**: confidence → `create_tier_contract` → tier-sovereign timeouts; unknown confidence falls back to `high` (same forgiving behavior as the tool).
- Unknown `verdict_type` **raises** — unlike confidence, it changes the output contract, so silent coercion would be wrong.
- Test suite pins the **verbatim quickstart snippet**, so child 3 (docs fixes) can reference running code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)