### PR TITLE
feat(cli): gate --tier + bundled-skill accuracy (#445)

### DIFF
--- a/.github/skills/council-gate/SKILL.md
+++ b/.github/skills/council-gate/SKILL.md
@@ -6,11 +6,11 @@ description: |
   Keywords: gate, CI, CD, pipeline, automated approval, quality gate, GitHub Actions
 
 license: Apache-2.0
-compatibility: "llm-council >= 2.0, mcp >= 1.0, github-actions >= 2.0"
+compatibility: "llm-council-core >= 0.33, mcp >= 1.0, github-actions >= 2.0"
 metadata:
   category: ci-cd
   domain: devops
-  council-version: "2.0"
+  council-version: "0.33"
   author: amiable-dev
   repository: https://github.com/amiable-dev/llm-council
 
@@ -113,19 +113,19 @@ jobs:
 
 ### Timeout Handling (ADR-040)
 
-If `timeout_fired: true`, the gate timed out before completing all stages. This returns exit code `2` (UNCLEAR), pausing the pipeline for human review. Check `completed_stages` to see how far it got. Consider using `--tier quick` for faster gate checks.
+If `timeout_fired: true`, the gate timed out before completing all stages. This returns exit code `2` (UNCLEAR), pausing the pipeline for human review. Check `completed_stages` to see how far it got. Consider using `--tier quick` for faster gate checks (the tier sets the timeout budget; there is no separate --timeout flag).
 
 ## Example Usage
 
 ```bash
 # Basic gate check
-council-gate --snapshot $(git rev-parse HEAD)
+llm-council gate --snapshot $(git rev-parse HEAD)
 
 # Security-focused gate
-council-gate --rubric-focus Security --confidence-threshold 0.9
+llm-council gate --snapshot $(git rev-parse HEAD) --rubric-focus Security --confidence-threshold 0.9
 
 # Quick tier for faster feedback
-council-gate --tier quick --timeout 60
+llm-council gate --snapshot $(git rev-parse HEAD) --tier quick
 ```
 
 ## Progressive Disclosure

--- a/.github/skills/council-review/SKILL.md
+++ b/.github/skills/council-review/SKILL.md
@@ -6,11 +6,11 @@ description: |
   Keywords: code review, PR, pull request, quality check, peer review, feedback
 
 license: Apache-2.0
-compatibility: "llm-council >= 2.0, mcp >= 1.0"
+compatibility: "llm-council-core >= 0.33, mcp >= 1.0"
 metadata:
   category: code-review
   domain: software-engineering
-  council-version: "2.0"
+  council-version: "0.33"
   author: amiable-dev
   repository: https://github.com/amiable-dev/llm-council
 
@@ -106,16 +106,16 @@ If `timeout_fired: true`, the review timed out. Check `completed_stages` to see 
 
 ```bash
 # Review specific files
-council-review --file-paths "src/main.py,src/utils.py" --snapshot abc123
+llm-council gate --snapshot abc123 --file-paths src/main.py src/utils.py
 
 # Review git diff
-council-review --git-diff "$(git diff HEAD~1)" --snapshot $(git rev-parse HEAD)
+llm-council gate --snapshot $(git rev-parse HEAD)  # reviews the snapshot; pass --file-paths to scope
 
 # Review with custom focus
-council-review --rubric-focus Security --file-paths "src/auth.py"
+llm-council gate --snapshot $(git rev-parse HEAD) --rubric-focus Security --file-paths src/auth.py
 
 # Deep reasoning review for complex changes
-council-review --snapshot $(git rev-parse HEAD) --tier reasoning --rubric-focus Security
+llm-council gate --snapshot $(git rev-parse HEAD) --tier reasoning --rubric-focus Security
 ```
 
 ## Progressive Disclosure

--- a/.github/skills/council-verify/SKILL.md
+++ b/.github/skills/council-verify/SKILL.md
@@ -6,11 +6,11 @@ description: |
   Keywords: verify, check, validate, review, approve, pass/fail, consensus, multi-model
 
 license: Apache-2.0
-compatibility: "llm-council >= 2.1, mcp >= 1.0"
+compatibility: "llm-council-core >= 0.33, mcp >= 1.0"
 metadata:
   category: verification
   domain: ai-governance
-  council-version: "2.0"
+  council-version: "0.33"
   author: amiable-dev
   repository: https://github.com/amiable-dev/llm-council
 
@@ -30,10 +30,10 @@ Use LLM Council's multi-model deliberation to verify work with structured, machi
 
 ## Workflow
 
-1. **Capture Snapshot**: Capture current git diff or file state (snapshot pinning for reproducibility)
-2. **Invoke Verification**: Call `mcp:llm-council/verify` with isolated context
-3. **Receive Verdict**: Get structured JSON with verdict, confidence, and blocking issues
-4. **Audit Trail**: Persist transcript via `mcp:llm-council/audit`
+1. **Snapshot**: pin the git commit SHA (reproducibility)
+2. **Verify**: call `mcp:llm-council/verify` (isolated context)
+3. **Act on the verdict** (structured JSON below)
+4. **Audit**: transcript via `mcp:llm-council/audit`
 
 ## Parameters
 
@@ -65,6 +65,8 @@ Pass pre-computed analysis from upstream tools (linters, slop detectors) via `ev
 {
   "verdict": "pass|fail|unclear",
   "confidence": 0.85,
+  "confidence_calibrated": 0.62,
+  "unclear_reason": null,
   "rubric_scores": { "accuracy": 8.5, "completeness": 7.0, "...": "..." },
   "blocking_issues": [...],
   "rationale": "Chairman synthesis...",
@@ -81,6 +83,8 @@ Pass pre-computed analysis from upstream tools (linters, slop detectors) via `ev
 
 If `timeout_fired: true`, the tier deadline was exceeded. Check `completed_stages` for progress. `timing.budget_utilization` shows time used vs deadline (1.0 on timeout). See ADR-040 for full timeout semantics.
 
+On UNCLEAR, route on `unclear_reason`: infra_failure → check gateway + RETRY; low_confidence → accept-and-audit if no blocking issues; timeout → re-tier. Details: `references/unclear-routing.md`.
+
 ## Rules
 
 1. **One call at a time.** Never fire multiple verify calls concurrently or in rapid succession. Wait for each to complete before deciding next steps.
@@ -93,5 +97,4 @@ If `timeout_fired: true`, the tier deadline was exceeded. Check `completed_stage
 
 ## Related Skills
 
-- `council-review`: Code review with structured feedback
-- `council-gate`: CI/CD quality gate
+`council-review` (code review), `council-gate` (CI/CD gate)

--- a/.github/skills/council-verify/references/unclear-routing.md
+++ b/.github/skills/council-verify/references/unclear-routing.md
@@ -1,7 +1,9 @@
 # UNCLEAR Routing (ADR-047)
 
-On an `unclear` verdict (exit code 2), `unclear_reason` says why. Route on it
-instead of treating every UNCLEAR alike:
+On an `unclear` verdict, `unclear_reason` says why. The exit code stays `2`
+for all three causes — that is the ADR-047 compatibility contract; the REASON
+field, not the exit code, is the routing signal ("accept-and-audit" etc. are
+caller policies applied on top of exit 2, never different exit codes):
 
 | unclear_reason | Meaning | Action |
 |---|---|---|

--- a/.github/skills/council-verify/references/unclear-routing.md
+++ b/.github/skills/council-verify/references/unclear-routing.md
@@ -1,0 +1,26 @@
+# UNCLEAR Routing (ADR-047)
+
+On an `unclear` verdict (exit code 2), `unclear_reason` says why. Route on it
+instead of treating every UNCLEAR alike:
+
+| unclear_reason | Meaning | Action |
+|---|---|---|
+| `infra_failure` | the chairman call itself errored (billing 402, auth, rate-limit, transport) | check gateway/billing, RETRY — never treat as a review outcome |
+| `low_confidence` | deliberation completed, confidence below threshold | accept-and-audit per policy when `blocking_issues` is empty |
+| `timeout` | the tier deadline fired (`timeout_fired: true`) | re-tier (e.g. balanced) or reduce input scope |
+
+`unclear_reason` is `null` for pass/fail and on non-deliberated cap results
+(where the `error` marker governs, e.g. `input_too_large`).
+
+## Calibrated confidence (ADR-047 P2)
+
+`confidence_calibrated` is the raw confidence passed through the persisted
+monotonic calibration mapping (`.council/calibration/mapping.json`). It equals
+the raw value until a mapping is fitted from human dispositions:
+
+```bash
+llm-council calibration-report --fit
+```
+
+The PASS threshold consumes the calibrated value only behind
+`LLM_COUNCIL_CALIBRATED_CONFIDENCE=true` (default off).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`gate --tier` + accurate bundled skills (#445)** — `llm-council gate` gains `--tier {quick,balanced,high,reasoning}` (tier-sovereign models/timeouts/input caps, matching the verify tool); `unclear_reason` and `confidence_calibrated` flow through both gate output formats via the shared formatter. All three bundled SKILL.md files now execute against the shipped CLI (invocations corrected to `llm-council gate`, phantom `--timeout` flag removed, version claims fixed) and council-verify documents the ADR-047 UNCLEAR routing table.
 - **`consult_council` Python facade (#444)** — the API the published quickstart always documented now exists: `from llm_council import consult_council` returns a `CouncilResult` (`.synthesis`, `.metadata`, `.model_responses`, `.raw`) with MCP-tool-parity tier semantics (confidence → tier contract → tier-sovereign timeouts; unknown confidence falls back to `high`; unknown `verdict_type` raises — it changes the output contract, so it is never silently coerced). Docs-as-spec fix from the 2026-07-03 documentation review.
 
 ## [0.32.0] - 2026-07-03

--- a/src/llm_council/cli.py
+++ b/src/llm_council/cli.py
@@ -404,6 +404,12 @@ def main():
         help="Minimum confidence to pass (0.0-1.0, default: 0.7)",
     )
     gate_parser.add_argument(
+        "--tier",
+        choices=["quick", "balanced", "high", "reasoning"],
+        default="balanced",
+        help="Verification tier: models + timeouts + input cap (default: balanced)",
+    )
+    gate_parser.add_argument(
         "--rubric-focus",
         type=str,
         dest="rubric_focus",
@@ -477,6 +483,7 @@ def main():
             confidence_threshold=args.confidence_threshold,
             rubric_focus=args.rubric_focus,
             output_format=args.output_format,
+            tier=args.tier,
         )
         sys.exit(exit_code)
     else:
@@ -736,6 +743,7 @@ def run_gate(
     confidence_threshold: float = 0.7,
     rubric_focus: str = None,
     output_format: str = "text",
+    tier: str = "balanced",
 ) -> int:
     """Run quality gate verification for CI/CD.
 
@@ -775,6 +783,7 @@ def run_gate(
             target_paths=file_paths,
             rubric_focus=rubric_focus,
             confidence_threshold=confidence_threshold,
+            tier=tier,
         )
         store = create_transcript_store()
         return await run_verification(request, store)

--- a/src/llm_council/skills/bundled/council-gate/SKILL.md
+++ b/src/llm_council/skills/bundled/council-gate/SKILL.md
@@ -6,11 +6,11 @@ description: |
   Keywords: gate, CI, CD, pipeline, automated approval, quality gate, GitHub Actions
 
 license: Apache-2.0
-compatibility: "llm-council >= 2.0, mcp >= 1.0, github-actions >= 2.0"
+compatibility: "llm-council-core >= 0.33, mcp >= 1.0, github-actions >= 2.0"
 metadata:
   category: ci-cd
   domain: devops
-  council-version: "2.0"
+  council-version: "0.33"
   author: amiable-dev
   repository: https://github.com/amiable-dev/llm-council
 
@@ -113,19 +113,19 @@ jobs:
 
 ### Timeout Handling (ADR-040)
 
-If `timeout_fired: true`, the gate timed out before completing all stages. This returns exit code `2` (UNCLEAR), pausing the pipeline for human review. Check `completed_stages` to see how far it got. Consider using `--tier quick` for faster gate checks.
+If `timeout_fired: true`, the gate timed out before completing all stages. This returns exit code `2` (UNCLEAR), pausing the pipeline for human review. Check `completed_stages` to see how far it got. Consider using `--tier quick` for faster gate checks (the tier sets the timeout budget; there is no separate --timeout flag).
 
 ## Example Usage
 
 ```bash
 # Basic gate check
-council-gate --snapshot $(git rev-parse HEAD)
+llm-council gate --snapshot $(git rev-parse HEAD)
 
 # Security-focused gate
-council-gate --rubric-focus Security --confidence-threshold 0.9
+llm-council gate --snapshot $(git rev-parse HEAD) --rubric-focus Security --confidence-threshold 0.9
 
 # Quick tier for faster feedback
-council-gate --tier quick --timeout 60
+llm-council gate --snapshot $(git rev-parse HEAD) --tier quick
 ```
 
 ## Progressive Disclosure

--- a/src/llm_council/skills/bundled/council-review/SKILL.md
+++ b/src/llm_council/skills/bundled/council-review/SKILL.md
@@ -6,11 +6,11 @@ description: |
   Keywords: code review, PR, pull request, quality check, peer review, feedback
 
 license: Apache-2.0
-compatibility: "llm-council >= 2.0, mcp >= 1.0"
+compatibility: "llm-council-core >= 0.33, mcp >= 1.0"
 metadata:
   category: code-review
   domain: software-engineering
-  council-version: "2.0"
+  council-version: "0.33"
   author: amiable-dev
   repository: https://github.com/amiable-dev/llm-council
 
@@ -106,16 +106,16 @@ If `timeout_fired: true`, the review timed out. Check `completed_stages` to see 
 
 ```bash
 # Review specific files
-council-review --file-paths "src/main.py,src/utils.py" --snapshot abc123
+llm-council gate --snapshot abc123 --file-paths src/main.py src/utils.py
 
 # Review git diff
-council-review --git-diff "$(git diff HEAD~1)" --snapshot $(git rev-parse HEAD)
+llm-council gate --snapshot $(git rev-parse HEAD)  # reviews the snapshot; pass --file-paths to scope
 
 # Review with custom focus
-council-review --rubric-focus Security --file-paths "src/auth.py"
+llm-council gate --snapshot $(git rev-parse HEAD) --rubric-focus Security --file-paths src/auth.py
 
 # Deep reasoning review for complex changes
-council-review --snapshot $(git rev-parse HEAD) --tier reasoning --rubric-focus Security
+llm-council gate --snapshot $(git rev-parse HEAD) --tier reasoning --rubric-focus Security
 ```
 
 ## Progressive Disclosure

--- a/src/llm_council/skills/bundled/council-verify/SKILL.md
+++ b/src/llm_council/skills/bundled/council-verify/SKILL.md
@@ -6,11 +6,11 @@ description: |
   Keywords: verify, check, validate, review, approve, pass/fail, consensus, multi-model
 
 license: Apache-2.0
-compatibility: "llm-council >= 2.1, mcp >= 1.0"
+compatibility: "llm-council-core >= 0.33, mcp >= 1.0"
 metadata:
   category: verification
   domain: ai-governance
-  council-version: "2.0"
+  council-version: "0.33"
   author: amiable-dev
   repository: https://github.com/amiable-dev/llm-council
 
@@ -30,10 +30,10 @@ Use LLM Council's multi-model deliberation to verify work with structured, machi
 
 ## Workflow
 
-1. **Capture Snapshot**: Capture current git diff or file state (snapshot pinning for reproducibility)
-2. **Invoke Verification**: Call `mcp:llm-council/verify` with isolated context
-3. **Receive Verdict**: Get structured JSON with verdict, confidence, and blocking issues
-4. **Audit Trail**: Persist transcript via `mcp:llm-council/audit`
+1. **Snapshot**: pin the git commit SHA (reproducibility)
+2. **Verify**: call `mcp:llm-council/verify` (isolated context)
+3. **Act on the verdict** (structured JSON below)
+4. **Audit**: transcript via `mcp:llm-council/audit`
 
 ## Parameters
 
@@ -65,6 +65,8 @@ Pass pre-computed analysis from upstream tools (linters, slop detectors) via `ev
 {
   "verdict": "pass|fail|unclear",
   "confidence": 0.85,
+  "confidence_calibrated": 0.62,
+  "unclear_reason": null,
   "rubric_scores": { "accuracy": 8.5, "completeness": 7.0, "...": "..." },
   "blocking_issues": [...],
   "rationale": "Chairman synthesis...",
@@ -81,6 +83,8 @@ Pass pre-computed analysis from upstream tools (linters, slop detectors) via `ev
 
 If `timeout_fired: true`, the tier deadline was exceeded. Check `completed_stages` for progress. `timing.budget_utilization` shows time used vs deadline (1.0 on timeout). See ADR-040 for full timeout semantics.
 
+On UNCLEAR, route on `unclear_reason`: infra_failure → check gateway + RETRY; low_confidence → accept-and-audit if no blocking issues; timeout → re-tier. Details: `references/unclear-routing.md`.
+
 ## Rules
 
 1. **One call at a time.** Never fire multiple verify calls concurrently or in rapid succession. Wait for each to complete before deciding next steps.
@@ -93,5 +97,4 @@ If `timeout_fired: true`, the tier deadline was exceeded. Check `completed_stage
 
 ## Related Skills
 
-- `council-review`: Code review with structured feedback
-- `council-gate`: CI/CD quality gate
+`council-review` (code review), `council-gate` (CI/CD gate)

--- a/src/llm_council/skills/bundled/council-verify/references/unclear-routing.md
+++ b/src/llm_council/skills/bundled/council-verify/references/unclear-routing.md
@@ -1,7 +1,9 @@
 # UNCLEAR Routing (ADR-047)
 
-On an `unclear` verdict (exit code 2), `unclear_reason` says why. Route on it
-instead of treating every UNCLEAR alike:
+On an `unclear` verdict, `unclear_reason` says why. The exit code stays `2`
+for all three causes — that is the ADR-047 compatibility contract; the REASON
+field, not the exit code, is the routing signal ("accept-and-audit" etc. are
+caller policies applied on top of exit 2, never different exit codes):
 
 | unclear_reason | Meaning | Action |
 |---|---|---|

--- a/src/llm_council/skills/bundled/council-verify/references/unclear-routing.md
+++ b/src/llm_council/skills/bundled/council-verify/references/unclear-routing.md
@@ -1,0 +1,26 @@
+# UNCLEAR Routing (ADR-047)
+
+On an `unclear` verdict (exit code 2), `unclear_reason` says why. Route on it
+instead of treating every UNCLEAR alike:
+
+| unclear_reason | Meaning | Action |
+|---|---|---|
+| `infra_failure` | the chairman call itself errored (billing 402, auth, rate-limit, transport) | check gateway/billing, RETRY — never treat as a review outcome |
+| `low_confidence` | deliberation completed, confidence below threshold | accept-and-audit per policy when `blocking_issues` is empty |
+| `timeout` | the tier deadline fired (`timeout_fired: true`) | re-tier (e.g. balanced) or reduce input scope |
+
+`unclear_reason` is `null` for pass/fail and on non-deliberated cap results
+(where the `error` marker governs, e.g. `input_too_large`).
+
+## Calibrated confidence (ADR-047 P2)
+
+`confidence_calibrated` is the raw confidence passed through the persisted
+monotonic calibration mapping (`.council/calibration/mapping.json`). It equals
+the raw value until a mapping is fitted from human dispositions:
+
+```bash
+llm-council calibration-report --fit
+```
+
+The PASS threshold consumes the calibrated value only behind
+`LLM_COUNCIL_CALIBRATED_CONFIDENCE=true` (default off).

--- a/tests/test_gate_tier.py
+++ b/tests/test_gate_tier.py
@@ -1,0 +1,57 @@
+"""#445: gate --tier passthrough (epic #443)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from llm_council.cli import run_gate
+
+
+class TestGateTier:
+    def test_tier_reaches_verify_request(self):
+        captured = {}
+
+        async def fake_run_verification(request, store):
+            captured["tier"] = request.tier
+            return {"verdict": "pass", "confidence": 0.9, "exit_code": 0,
+                    "rubric_scores": {}, "blocking_issues": [], "rationale": "r",
+                    "transcript_location": "/tmp/t"}
+
+        with (
+            patch("llm_council.verification.api.run_verification", fake_run_verification),
+            patch("llm_council.verification.transcript.create_transcript_store", MagicMock()),
+        ):
+            code = run_gate(snapshot="abc1234", tier="quick")
+        assert captured["tier"] == "quick"
+        assert code == 0
+
+    def test_default_tier_balanced(self):
+        captured = {}
+
+        async def fake_run_verification(request, store):
+            captured["tier"] = request.tier
+            return {"verdict": "unclear", "confidence": 0.4, "exit_code": 2,
+                    "unclear_reason": "low_confidence",
+                    "rubric_scores": {}, "blocking_issues": [], "rationale": "r",
+                    "transcript_location": "/tmp/t"}
+
+        with (
+            patch("llm_council.verification.api.run_verification", fake_run_verification),
+            patch("llm_council.verification.transcript.create_transcript_store", MagicMock()),
+        ):
+            code = run_gate(snapshot="abc1234")
+        assert captured["tier"] == "balanced"
+        assert code == 2
+
+    def test_text_output_surfaces_unclear_reason(self, capsys):
+        async def fake_run_verification(request, store):
+            return {"verdict": "unclear", "confidence": 0.4, "exit_code": 2,
+                    "unclear_reason": "infra_failure",
+                    "rubric_scores": {}, "blocking_issues": [], "rationale": "r",
+                    "transcript_location": "/tmp/t"}
+
+        with (
+            patch("llm_council.verification.api.run_verification", fake_run_verification),
+            patch("llm_council.verification.transcript.create_transcript_store", MagicMock()),
+        ):
+            run_gate(snapshot="abc1234")
+        out = capsys.readouterr().out
+        assert "infra_failure" in out


### PR DESCRIPTION
Closes #445 (epic #443, 2/6)

## Summary
Docs-as-spec second half: the bundled `council-gate` skill always documented `--tier` — now the CLI has it.

- `llm-council gate --tier {quick,balanced,high,reasoning}` → `VerifyRequest.tier`
- `unclear_reason` + `confidence_calibrated` surface in both gate output formats (shared formatter; test-pinned)
- Bundled skills (and `.github/skills` dev copies — sync-tested) now execute against the shipped CLI: `llm-council gate` invocations, phantom `--timeout` removed, frontmatter versions fixed
- ADR-047 UNCLEAR routing shipped as `references/unclear-routing.md` with a one-line pointer in the SKILL body — the level-2 **1000-token progressive-disclosure budget is test-enforced**, so the detail lives at level 3 where it belongs

## Tests
3 new (tier passthrough, default, unclear_reason in text output); skill token-budget + bundled↔dev sync suites green. Suite 3170; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)