### PR TITLE
Release v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.34.0] - 2026-07-04
+
+**Prompt Caching Across Gateways (ADR-049)** — epic [#458](https://github.com/amiable-dev/llm-council/issues/458). Verification rounds re-send a nearly identical prompt every round; this release makes the stable prefix actually cacheable and the cache observable. Stable-prefix-first prompt assembly (D1), Anthropic `cache_control` breakpoints + OpenRouter session affinity on the verify path (D2, default ON — price-class-only, empirically verified −92% read cost on the production route), cache price classes in registry estimates (D3), cache-write/route/session telemetry with log-only hit-rate reconstruction (D4), and a per-path TTL knob with an opt-in live probe (D5). Every decision traces to the ADR's research matrix — vendor docs adversarially verified plus two-call probes on our own key; refuted routes (OpenAI/Gemini/DeepSeek via OpenRouter) are documented with a quarterly re-probe note.
 
 ### Added
 

--- a/docs/adr/ADR-049-prompt-caching-across-gateways.md
+++ b/docs/adr/ADR-049-prompt-caching-across-gateways.md
@@ -1,6 +1,6 @@
 # ADR-049: Prompt Caching Across Gateways
 
-**Status:** Proposed 2026-07-04 (rev 2: research matrix verified — vendor docs via adversarial deep-research + empirical two-call probes on our own OpenRouter key; codebase claims audited against source)
+**Status:** Implemented 2026-07-04 (v0.34.0, epic #458: D1 #459/PR #464, D2 #460/PR #466, D3 #461/PR #467, D4 #462/PR #468, D5 #463/PR #469; live two-call probe green against the production route. Rev 2 research matrix: vendor docs via adversarial deep-research + empirical probes on our own OpenRouter key)
 **Date:** 2026-07-04
 **Decision Makers:** llm-council maintainers (review requested)
 **Proposed by:** epic-loop project (consumer hand-over — Chris / Claude; companion evidence in `epic-loop/docs/assessments/research-2026-07-04-headroom-context-compression.md` and `council-verify-stats.md`)


### PR DESCRIPTION
**Prompt Caching Across Gateways (ADR-049)** — epic #458 complete.

- D1 #459 (PR #464): stable-prefix-first verification prompt assembly (SHA moved to the volatile tail; segment map exposed)
- D2 #460 (PR #466): Anthropic `cache_control` breakpoints + OpenRouter `session_id` affinity, default ON, kill-switch `LLM_COUNCIL_PROMPT_CACHING`
- D3 #461 (PR #467): `cache_read`/`cache_write_5m`/`cache_write_1h` price classes in registry estimates
- D4 #462 (PR #468): cache-write + route/session telemetry; hit-rate reconstructable from `.council/logs` alone
- D5 #463 (PR #469): `LLM_COUNCIL_PROMPT_CACHE_TTL` knob (verify→1h) + opt-in live two-call probe — **validated green against the production route** (call 2: cache reads > 0, discounted `usage.cost`)

This PR: CHANGELOG 0.34.0 header + ADR-049 Status → Implemented. Tag `v0.34.0` after merge (publish.yml → PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E43uRciABobxwpUCHPQAwh