### PR TITLE
feat(gateway): ADR-050 — PostHog emitter config + soft-fail foundation (1/4)

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -168,6 +168,15 @@
 | `LLM_COUNCIL_TELEMETRY` | Telemetry client | code |
 | `LLM_COUNCIL_TELEMETRY_ENDPOINT` | Telemetry endpoint | code |
 
+## PostHog LLM Analytics (ADR-050)
+
+Opt-in emission of `$ai_generation` events to PostHog. Off by default — with no `POSTHOG_API_KEY` the emitter is disabled and behavior is byte-identical (the optional `posthog` SDK is never imported). Install with `pip install "llm-council-core[posthog]"`.
+
+| Variable | Description | Default |
+|---|---|---|
+| `POSTHOG_API_KEY` | PostHog project API key (publishable `phc_` key). Presence enables emission | — (disabled) |
+| `POSTHOG_HOST` | PostHog ingestion host. Use `https://us.i.posthog.com` for US Cloud | `https://eu.i.posthog.com` |
+
 ## Webhooks
 
 | Variable | Description | Default |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ mcp = [
 secure = ["keyring>=23.0.0"]
 # Ollama local LLM support via LiteLLM - install with: pip install "llm-council-core[ollama]"
 ollama = ["litellm>=1.50.0"]
+# PostHog LLM Analytics emission (ADR-050) - install with: pip install "llm-council-core[posthog]"
+posthog = ["posthog>=3.0.0"]
 # All server dependencies
 all = ["llm-council-core[http,mcp]"]
 # Development dependencies

--- a/src/llm_council/observability/posthog_emitter.py
+++ b/src/llm_council/observability/posthog_emitter.py
@@ -1,0 +1,119 @@
+"""Opt-in PostHog LLM Analytics emitter foundation (ADR-050 Part 5 + transport).
+
+Off by default: with no ``POSTHOG_API_KEY`` the emitter is disabled and every
+entry point is a no-op — byte-identical to pre-ADR-050 behavior, and the
+optional ``posthog`` SDK is never imported. Emission is **soft-fail**: any
+failure (missing SDK, bad key, network down) is logged at debug and never
+raises into or delays a verification (ADR-011/024 convention).
+
+This module is only the foundation (config + transport). The actual
+``$ai_generation`` property mapping lands in ADR-050 D2 (#474).
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import threading
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# EU ingestion endpoint (ADR-050 Part 5). Note the `.i.` host — `eu.posthog.com`
+# is the app/private host and is wrong for capture. The SDK maps app hosts to
+# ingestion hosts, but we default explicitly.
+DEFAULT_HOST = "https://eu.i.posthog.com"
+
+# Bounded flush: dropped events are acceptable (soft-fail), a hung process is
+# not. shutdown() joins the flush thread for at most this many seconds.
+_FLUSH_TIMEOUT_S = 3.0
+
+_lock = threading.Lock()
+_client: Optional[Any] = None
+_init_attempted = False
+_atexit_registered = False
+
+
+def posthog_emission_enabled() -> bool:
+    """True iff a PostHog project key is configured (opt-in, off by default)."""
+    return bool(os.getenv("POSTHOG_API_KEY"))
+
+
+def _get_client() -> Optional[Any]:
+    """Lazily build the PostHog client; ``None`` if disabled or unavailable.
+
+    Import-guarded: the optional ``posthog`` SDK is imported only when a key is
+    configured, so an unconfigured install pays nothing and never needs the
+    dependency. Initialization is attempted at most once; a failure caches
+    ``None`` (soft-fail) rather than retrying on every emit.
+    """
+    global _client, _init_attempted, _atexit_registered
+    if not posthog_emission_enabled():
+        return None
+    with _lock:
+        if _init_attempted:
+            return _client
+        _init_attempted = True
+        try:
+            from posthog import Posthog  # optional dependency — [posthog] extra
+
+            _client = Posthog(
+                project_api_key=os.environ["POSTHOG_API_KEY"],
+                host=os.getenv("POSTHOG_HOST", DEFAULT_HOST),
+            )
+            if not _atexit_registered:
+                atexit.register(shutdown)
+                _atexit_registered = True
+        except Exception as exc:  # missing SDK, bad config — soft-fail
+            logger.debug("posthog emitter init failed (disabled): %s", exc)
+            _client = None
+        return _client
+
+
+def emit(event: str, properties: Dict[str, Any], distinct_id: str) -> None:
+    """Emit one event via the SDK's non-blocking batched ``capture()``.
+
+    Soft-fail: never raises and never blocks the caller on network I/O (the
+    SDK buffers to a background consumer). A no-op when emission is disabled.
+    """
+    try:
+        client = _get_client()
+        if client is None:
+            return
+        client.capture(distinct_id=distinct_id, event=event, properties=properties)
+    except Exception as exc:  # emission must never break a run
+        logger.debug("posthog emit failed for %s (ignored): %s", event, exc)
+
+
+def shutdown(timeout: float = _FLUSH_TIMEOUT_S) -> None:
+    """Flush the buffer on exit, bounded so a stuck flush never hangs the process.
+
+    The flush runs on a daemon thread joined for ``timeout`` seconds; if it
+    hasn't returned, we drop the remaining buffer and move on (the daemon dies
+    with the process). Registered via ``atexit`` on client init; also safe to
+    call explicitly from a CLI/gate teardown.
+    """
+    client = _client
+    if client is None:
+        return
+
+    def _flush() -> None:
+        try:
+            fn = getattr(client, "shutdown", None) or getattr(client, "flush", None)
+            if fn is not None:
+                fn()
+        except Exception as exc:  # flush failure is non-fatal
+            logger.debug("posthog shutdown failed (ignored): %s", exc)
+
+    t = threading.Thread(target=_flush, name="posthog-flush", daemon=True)
+    t.start()
+    t.join(timeout)
+
+
+def reset_for_testing() -> None:
+    """Test hook: clear the module singleton so env changes take effect."""
+    global _client, _init_attempted
+    with _lock:
+        _client = None
+        _init_attempted = False

--- a/src/llm_council/observability/posthog_emitter.py
+++ b/src/llm_council/observability/posthog_emitter.py
@@ -55,11 +55,18 @@ def _get_client() -> Optional[Any]:
         if _init_attempted:
             return _client
         _init_attempted = True
+        # Re-read the key under the lock via getenv (consistent with
+        # posthog_emission_enabled) — never os.environ[...], which would
+        # KeyError if the env was cleared between the enabled-check and here.
+        key = os.getenv("POSTHOG_API_KEY")
+        if not key:
+            _client = None
+            return None
         try:
             from posthog import Posthog  # optional dependency — [posthog] extra
 
             _client = Posthog(
-                project_api_key=os.environ["POSTHOG_API_KEY"],
+                project_api_key=key,
                 host=os.getenv("POSTHOG_HOST", DEFAULT_HOST),
             )
             if not _atexit_registered:
@@ -94,7 +101,8 @@ def shutdown(timeout: float = _FLUSH_TIMEOUT_S) -> None:
     with the process). Registered via ``atexit`` on client init; also safe to
     call explicitly from a CLI/gate teardown.
     """
-    client = _client
+    with _lock:  # snapshot under the lock — a concurrent reset must not race
+        client = _client
     if client is None:
         return
 
@@ -112,7 +120,12 @@ def shutdown(timeout: float = _FLUSH_TIMEOUT_S) -> None:
 
 
 def reset_for_testing() -> None:
-    """Test hook: clear the module singleton so env changes take effect."""
+    """Test hook: clear the client singleton so env changes take effect.
+
+    Deliberately does NOT clear ``_atexit_registered``: the atexit handler is
+    process-global and idempotent (None-guarded), so it must be registered at
+    most once for the process, never re-registered per test.
+    """
     global _client, _init_attempted
     with _lock:
         _client = None

--- a/tests/test_posthog_emitter.py
+++ b/tests/test_posthog_emitter.py
@@ -1,0 +1,146 @@
+"""ADR-050 D1 (#473): opt-in, soft-fail PostHog emitter foundation.
+
+Off by default: no POSTHOG_API_KEY ⇒ disabled ⇒ byte-identical to pre-ADR
+(no posthog import, no capture). Emission is soft-fail (never raises into a
+verification). Flush is bounded (a stuck flush never hangs the process).
+"""
+
+import sys
+import time
+import types
+
+import pytest
+
+from llm_council.observability import posthog_emitter as pe
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    monkeypatch.delenv("POSTHOG_API_KEY", raising=False)
+    monkeypatch.delenv("POSTHOG_HOST", raising=False)
+    pe.reset_for_testing()
+    yield
+    pe.reset_for_testing()
+
+
+def _fake_posthog(monkeypatch, capture_sink=None, init_sink=None, raise_on_init=None):
+    class FakePosthog:
+        def __init__(self, project_api_key=None, host=None, **kw):
+            if raise_on_init:
+                raise raise_on_init
+            if init_sink is not None:
+                init_sink["key"] = project_api_key
+                init_sink["host"] = host
+
+        def capture(self, **kw):
+            if capture_sink is not None:
+                capture_sink.append(kw)
+
+    monkeypatch.setitem(sys.modules, "posthog", types.SimpleNamespace(Posthog=FakePosthog))
+
+
+class TestDisabledByDefault:
+    def test_disabled_without_key(self):
+        assert pe.posthog_emission_enabled() is False
+
+    def test_emit_is_noop_and_imports_nothing(self, monkeypatch):
+        # A poisoned posthog module proves emit() never imports it when disabled.
+        monkeypatch.setitem(sys.modules, "posthog", None)
+        pe.emit("$ai_generation", {"a": 1}, "did")  # no raise
+        assert pe._get_client() is None
+
+    def test_enabled_with_key(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
+        assert pe.posthog_emission_enabled() is True
+
+
+class TestClientBuild:
+    def test_builds_with_key_and_default_eu_host(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_abc")
+        init = {}
+        _fake_posthog(monkeypatch, init_sink=init)
+        assert pe._get_client() is not None
+        assert init["key"] == "phc_abc"
+        assert init["host"] == "https://eu.i.posthog.com"
+
+    def test_host_override(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_abc")
+        monkeypatch.setenv("POSTHOG_HOST", "https://us.i.posthog.com")
+        init = {}
+        _fake_posthog(monkeypatch, init_sink=init)
+        pe._get_client()
+        assert init["host"] == "https://us.i.posthog.com"
+
+    def test_client_is_cached(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_abc")
+        _fake_posthog(monkeypatch)
+        assert pe._get_client() is pe._get_client()
+
+    def test_emit_calls_capture(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_abc")
+        sink = []
+        _fake_posthog(monkeypatch, capture_sink=sink)
+        pe.emit("$ai_generation", {"$ai_model": "m"}, "trace-1")
+        assert sink and sink[0]["event"] == "$ai_generation"
+        assert sink[0]["distinct_id"] == "trace-1"
+        assert sink[0]["properties"] == {"$ai_model": "m"}
+
+
+class TestSoftFail:
+    def test_emit_soft_fails_on_capture_error(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
+
+        class BadClient:
+            def capture(self, **kw):
+                raise RuntimeError("network down")
+
+        monkeypatch.setattr(pe, "_get_client", lambda: BadClient())
+        pe.emit("$ai_generation", {"a": 1}, "did")  # must not raise
+
+    def test_init_soft_fails_when_sdk_missing(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
+        monkeypatch.setitem(sys.modules, "posthog", None)  # import → error
+        assert pe._get_client() is None
+        pe.emit("$ai_generation", {"a": 1}, "did")  # no-op, no raise
+
+    def test_init_soft_fails_on_bad_config(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
+        _fake_posthog(monkeypatch, raise_on_init=ValueError("bad key"))
+        assert pe._get_client() is None  # swallowed
+
+
+class TestShutdown:
+    def test_shutdown_flushes(self, monkeypatch):
+        flushed = {}
+
+        class C:
+            def shutdown(self):
+                flushed["s"] = True
+
+        pe._client = C()
+        pe._init_attempted = True
+        pe.shutdown(timeout=1.0)
+        assert flushed.get("s") is True
+
+    def test_shutdown_bounded_on_hang(self):
+        class C:
+            def shutdown(self):
+                time.sleep(5)  # simulate a stuck flush
+
+        pe._client = C()
+        pe._init_attempted = True
+        t0 = time.monotonic()
+        pe.shutdown(timeout=0.2)
+        assert time.monotonic() - t0 < 2.0  # returned promptly, never waited 5s
+
+    def test_shutdown_noop_without_client(self):
+        pe.shutdown()  # no client → no-op, no raise
+
+    def test_shutdown_soft_fails(self):
+        class C:
+            def shutdown(self):
+                raise RuntimeError("boom")
+
+        pe._client = C()
+        pe._init_attempted = True
+        pe.shutdown(timeout=1.0)  # must not raise


### PR DESCRIPTION
Closes #473 (epic #472, ADR-050 D1).

## What
Opt-in, off-by-default PostHog emission foundation (ADR-050 Part 5 + transport). Every other child builds on this.

- `observability/posthog_emitter.py`: `posthog_emission_enabled()` (key presence), a lazy **import-guarded** client (`POSTHOG_API_KEY` + `POSTHOG_HOST`, default EU ingestion host `eu.i.posthog.com`), `emit()` wrapping the SDK's non-blocking batched `capture()` in **soft-fail** (never raises into a verification — ADR-011/024), and a **bounded** `shutdown()` (daemon-thread flush joined with a timeout so a stuck flush can't hang the process; `atexit`-registered).
- `pyproject` `[posthog]` extra.
- Env reference documents `POSTHOG_API_KEY`/`POSTHOG_HOST`.

## Contract
With no `POSTHOG_API_KEY`: **byte-identical to today** — early return before the import, no capture, no SDK dependency needed.

## Tests (14)
disabled-by-default no-op (a poisoned `posthog` module proves nothing is imported); client build + host default/override + caching; emit→capture; soft-fail on capture/init/missing-SDK/bad-config; shutdown flush + bounded-on-hang + noop + soft-fail.

## Gates
`make lint` clean · `make test-fast` 3244 passed. Council gate to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E43uRciABobxwpUCHPQAwh