### PR TITLE
feat(gateway): ADR-050 — $ai_generation emission per member call (2/4)

### DIFF
--- a/src/llm_council/observability/ai_generation.py
+++ b/src/llm_council/observability/ai_generation.py
@@ -1,0 +1,117 @@
+"""Map the ADR-011 usage summary to PostHog ``$ai_generation`` events (ADR-050 Part 1).
+
+Emits one ``$ai_generation`` per council-member model from ``usage.by_model``.
+Off by default (gated on ``posthog_emission_enabled``) and soft-fail — never
+raises into or delays a verification.
+
+The load-bearing mapping rule is the cache subtraction: PostHog's cost engine
+and the cache-hit-rate tile (``cache_read / (cache_read + input)``) assume
+**exclusive** token counting, so ``$ai_input_tokens`` MUST be the non-cached
+input count. We clamp with ``max(0, prompt - cache_read)`` so an
+already-exclusive route or a ``cached > prompt`` reporting anomaly never
+produces a negative count.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from .posthog_emitter import emit, posthog_emission_enabled
+
+logger = logging.getLogger(__name__)
+
+# Consumers post evaluations against this actor when none is supplied.
+DEFAULT_DISTINCT_ID = "llm-council"
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def build_generation_properties(
+    model: str,
+    model_usage: Dict[str, Any],
+    *,
+    verification_id: str,
+    tier: Optional[str] = None,
+    route: Optional[str] = None,
+    round: Optional[int] = None,
+    subject_sha: Optional[str] = None,
+    consumer: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build the ``$ai_generation`` properties for one ``by_model`` entry.
+
+    ``$ai_total_cost_usd`` is our ADR-011 ground-truth cost (overrides PostHog's
+    auto-calc) — emitted only when ``cost_known`` so an estimate is never
+    presented as a bill. ``$ai_cache_creation_input_tokens`` is Anthropic-
+    specific and omitted when zero.
+    """
+    prompt = _int(model_usage.get("prompt_tokens"))
+    completion = _int(model_usage.get("completion_tokens"))
+    cache_read = _int(model_usage.get("cached_tokens"))
+    cache_write = _int(model_usage.get("cache_write_tokens"))
+
+    props: Dict[str, Any] = {
+        "$ai_trace_id": verification_id,
+        "$ai_model": model,
+        "$ai_provider": model.split("/", 1)[0] if "/" in model else "unknown",
+        # Cache-subtraction clamp (ADR-050 Part 1): non-cached input only.
+        "$ai_input_tokens": max(0, prompt - cache_read),
+        "$ai_output_tokens": completion,
+        "$ai_cache_read_input_tokens": cache_read,
+    }
+    if cache_write:
+        props["$ai_cache_creation_input_tokens"] = cache_write
+    if model_usage.get("cost_known"):
+        props["$ai_total_cost_usd"] = float(model_usage.get("cost_usd", 0.0) or 0.0)
+    for key, value in (
+        ("tier", tier),
+        ("route", route),
+        ("round", round),
+        ("subject_sha", subject_sha),
+        ("consumer", consumer),
+    ):
+        if value is not None:
+            props[key] = value
+    return props
+
+
+def emit_generation_events(
+    usage: Optional[Dict[str, Any]],
+    *,
+    verification_id: str,
+    tier: Optional[str] = None,
+    route: Optional[str] = None,
+    round: Optional[int] = None,
+    subject_sha: Optional[str] = None,
+    consumer: Optional[str] = None,
+) -> None:
+    """Emit one ``$ai_generation`` per council-member model. Soft-fail, opt-in.
+
+    ``$ai_trace_id`` is the ``verification_id`` (the cross-repo contract);
+    ``distinct_id`` is the opaque ``consumer`` (or ``llm-council``).
+    """
+    if not posthog_emission_enabled() or not usage or not verification_id:
+        return
+    try:
+        distinct_id = consumer or DEFAULT_DISTINCT_ID
+        for model, model_usage in (usage.get("by_model") or {}).items():
+            if not isinstance(model_usage, dict):
+                continue
+            props = build_generation_properties(
+                str(model),
+                model_usage,
+                verification_id=verification_id,
+                tier=tier,
+                route=route,
+                round=round,
+                subject_sha=subject_sha,
+                consumer=consumer,
+            )
+            emit("$ai_generation", props, distinct_id=distinct_id)
+    except Exception as exc:  # emission must never break a run
+        logger.debug("emit_generation_events failed (ignored): %s", exc)

--- a/src/llm_council/observability/ai_generation.py
+++ b/src/llm_council/observability/ai_generation.py
@@ -32,6 +32,18 @@ def _int(value: Any) -> int:
         return 0
 
 
+def _float(value: Any) -> float:
+    """Coerce a cost to a finite float, else 0.0 — a junk value must never drop
+    the whole event via an unguarded ``float()`` raise."""
+    try:
+        import math
+
+        f = float(value or 0.0)
+        return f if math.isfinite(f) else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def build_generation_properties(
     model: str,
     model_usage: Dict[str, Any],
@@ -39,7 +51,7 @@ def build_generation_properties(
     verification_id: str,
     tier: Optional[str] = None,
     route: Optional[str] = None,
-    round: Optional[int] = None,
+    round_index: Optional[int] = None,
     subject_sha: Optional[str] = None,
     consumer: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -67,11 +79,11 @@ def build_generation_properties(
     if cache_write:
         props["$ai_cache_creation_input_tokens"] = cache_write
     if model_usage.get("cost_known"):
-        props["$ai_total_cost_usd"] = float(model_usage.get("cost_usd", 0.0) or 0.0)
+        props["$ai_total_cost_usd"] = _float(model_usage.get("cost_usd"))
     for key, value in (
         ("tier", tier),
         ("route", route),
-        ("round", round),
+        ("round", round_index),
         ("subject_sha", subject_sha),
         ("consumer", consumer),
     ):
@@ -86,7 +98,7 @@ def emit_generation_events(
     verification_id: str,
     tier: Optional[str] = None,
     route: Optional[str] = None,
-    round: Optional[int] = None,
+    round_index: Optional[int] = None,
     subject_sha: Optional[str] = None,
     consumer: Optional[str] = None,
 ) -> None:
@@ -108,7 +120,7 @@ def emit_generation_events(
                 verification_id=verification_id,
                 tier=tier,
                 route=route,
-                round=round,
+                round_index=round_index,
                 subject_sha=subject_sha,
                 consumer=consumer,
             )

--- a/src/llm_council/verification/api.py
+++ b/src/llm_council/verification/api.py
@@ -150,6 +150,36 @@ def _persist_result_safe(store: Any, verification_id: str, result: Dict[str, Any
         logger.debug("Failed to persist partial/timeout result.json", exc_info=True)
 
 
+def _emit_posthog_generations(
+    usage: Optional[Dict[str, Any]],
+    *,
+    verification_id: str,
+    tier: str,
+    subject_sha: Optional[str] = None,
+) -> None:
+    """ADR-050 D2: opt-in PostHog ``$ai_generation`` emission (soft-fail).
+
+    Gated on ``posthog_emission_enabled`` BEFORE importing the mapper, so a
+    verify with no ``POSTHOG_API_KEY`` pays only one env check and is
+    byte-identical. Telemetry never breaks a verify.
+    """
+    try:
+        from llm_council.observability.posthog_emitter import posthog_emission_enabled
+
+        if not posthog_emission_enabled():
+            return
+        from llm_council.observability.ai_generation import emit_generation_events
+
+        emit_generation_events(
+            usage,
+            verification_id=verification_id,
+            tier=tier,
+            subject_sha=subject_sha,
+        )
+    except Exception:  # telemetry must never break a verify
+        logger.debug("posthog $ai_generation emission failed (ignored)", exc_info=True)
+
+
 # Maximum characters per file to include in prompt.
 
 async def _build_verification_prompt(
@@ -709,6 +739,16 @@ async def _run_verification_pipeline(
 
     # Persist result
     store.write_stage(verification_id, "result", result)
+
+    # ADR-050 D2 (#474): opt-in PostHog $ai_generation emission — one event per
+    # council-member model, keyed to this verification_id. No-op + soft-fail
+    # when POSTHOG_API_KEY is unset (byte-identical); never delays a verify.
+    _emit_posthog_generations(
+        partial_state.get("usage"),
+        verification_id=verification_id,
+        tier=request.tier,
+        subject_sha=request.snapshot_id,
+    )
 
     return result
 

--- a/tests/test_ai_generation.py
+++ b/tests/test_ai_generation.py
@@ -70,7 +70,7 @@ class TestBuildProperties:
               "cost_usd": 0.0}
         p = ag.build_generation_properties(
             "m/x", mu, verification_id="v", tier="high", route="openrouter",
-            round=2, subject_sha="abc123", consumer="opaque-1")
+            round_index=2, subject_sha="abc123", consumer="opaque-1")
         assert p["route"] == "openrouter"
         assert p["round"] == 2
         assert p["subject_sha"] == "abc123"

--- a/tests/test_ai_generation.py
+++ b/tests/test_ai_generation.py
@@ -1,0 +1,140 @@
+"""ADR-050 D2 (#474): $ai_generation property mapping + per-member emission.
+
+One $ai_generation per council-member model, mapped from the ADR-011
+usage.by_model summary. The load-bearing rule: $ai_input_tokens is the
+NON-cached input count (max(0, prompt - cache_read)) so PostHog's hit-rate
+tile cache_read/(cache_read+input) isn't double-counted.
+"""
+
+import pytest
+
+from llm_council.observability import ai_generation as ag
+from llm_council.observability import posthog_emitter as pe
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    monkeypatch.delenv("POSTHOG_API_KEY", raising=False)
+    pe.reset_for_testing()
+    yield
+    pe.reset_for_testing()
+
+
+class TestBuildProperties:
+    def test_core_mapping(self):
+        mu = {"prompt_tokens": 1000, "completion_tokens": 200, "total_tokens": 1200,
+              "cost_usd": 0.05, "cached_tokens": 0, "cache_write_tokens": 0,
+              "cost_known": True}
+        p = ag.build_generation_properties("anthropic/claude-opus-4.8", mu,
+                                           verification_id="v1", tier="balanced")
+        assert p["$ai_trace_id"] == "v1"
+        assert p["$ai_model"] == "anthropic/claude-opus-4.8"
+        assert p["$ai_provider"] == "anthropic"
+        assert p["$ai_input_tokens"] == 1000
+        assert p["$ai_output_tokens"] == 200
+        assert p["$ai_cache_read_input_tokens"] == 0
+        assert p["$ai_total_cost_usd"] == 0.05
+        assert p["tier"] == "balanced"
+
+    def test_cache_subtraction(self):
+        # prompt includes cache reads (inclusive route) → input excludes them
+        mu = {"prompt_tokens": 5000, "completion_tokens": 100, "cached_tokens": 4000,
+              "cache_write_tokens": 800, "cost_known": True, "cost_usd": 0.01}
+        p = ag.build_generation_properties("anthropic/claude-haiku-4.5", mu,
+                                           verification_id="v")
+        assert p["$ai_input_tokens"] == 1000  # 5000 - 4000
+        assert p["$ai_cache_read_input_tokens"] == 4000
+        assert p["$ai_cache_creation_input_tokens"] == 800
+
+    def test_clamp_never_negative(self):
+        # cached > prompt (anomaly / already-exclusive route) must clamp to 0
+        mu = {"prompt_tokens": 100, "completion_tokens": 0, "cached_tokens": 500,
+              "cost_known": False}
+        p = ag.build_generation_properties("m/x", mu, verification_id="v")
+        assert p["$ai_input_tokens"] == 0
+
+    def test_cost_omitted_when_unknown(self):
+        mu = {"prompt_tokens": 10, "completion_tokens": 5, "cost_known": False,
+              "cost_usd": 0.0}
+        p = ag.build_generation_properties("m/x", mu, verification_id="v")
+        assert "$ai_total_cost_usd" not in p  # never present a fabricated cost
+
+    def test_cache_creation_omitted_when_zero(self):
+        mu = {"prompt_tokens": 10, "completion_tokens": 5, "cached_tokens": 0,
+              "cache_write_tokens": 0, "cost_known": True, "cost_usd": 0.001}
+        p = ag.build_generation_properties("m/x", mu, verification_id="v")
+        assert "$ai_cache_creation_input_tokens" not in p
+
+    def test_custom_props_only_when_set(self):
+        mu = {"prompt_tokens": 1, "completion_tokens": 1, "cost_known": True,
+              "cost_usd": 0.0}
+        p = ag.build_generation_properties(
+            "m/x", mu, verification_id="v", tier="high", route="openrouter",
+            round=2, subject_sha="abc123", consumer="opaque-1")
+        assert p["route"] == "openrouter"
+        assert p["round"] == 2
+        assert p["subject_sha"] == "abc123"
+        assert p["consumer"] == "opaque-1"
+        # unset custom keys absent
+        p2 = ag.build_generation_properties("m/x", mu, verification_id="v")
+        assert "route" not in p2 and "subject_sha" not in p2
+
+    def test_provider_from_model_prefix(self):
+        mu = {"prompt_tokens": 1, "completion_tokens": 1, "cost_known": False}
+        assert ag.build_generation_properties("openai/gpt-5.4", mu,
+                                              verification_id="v")["$ai_provider"] == "openai"
+        assert ag.build_generation_properties("localmodel", mu,
+                                              verification_id="v")["$ai_provider"] == "unknown"
+
+
+class TestEmitGenerationEvents:
+    def _usage(self):
+        return {"by_model": {
+            "anthropic/claude-opus-4.8": {"prompt_tokens": 100, "completion_tokens": 10,
+                                          "cached_tokens": 0, "cache_write_tokens": 0,
+                                          "cost_usd": 0.02, "cost_known": True},
+            "openai/gpt-5.4": {"prompt_tokens": 200, "completion_tokens": 20,
+                               "cached_tokens": 50, "cache_write_tokens": 0,
+                               "cost_usd": 0.03, "cost_known": True},
+        }}
+
+    def test_one_event_per_member(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_x")
+        sink = []
+        monkeypatch.setattr(ag, "emit",
+                            lambda event, properties, distinct_id: sink.append((event, properties, distinct_id)))
+        ag.emit_generation_events(self._usage(), verification_id="v1",
+                                  tier="balanced", consumer="opaque")
+        assert len(sink) == 2
+        assert all(e == "$ai_generation" for e, _, _ in sink)
+        models = {p["$ai_model"] for _, p, _ in sink}
+        assert models == {"anthropic/claude-opus-4.8", "openai/gpt-5.4"}
+        # trace_id keyed to verification_id; distinct_id = consumer
+        assert all(p["$ai_trace_id"] == "v1" for _, p, _ in sink)
+        assert all(did == "opaque" for _, _, did in sink)
+
+    def test_distinct_id_defaults_to_llm_council(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_x")
+        sink = []
+        monkeypatch.setattr(ag, "emit",
+                            lambda event, properties, distinct_id: sink.append(distinct_id))
+        ag.emit_generation_events(self._usage(), verification_id="v1")
+        assert all(did == "llm-council" for did in sink)
+
+    def test_disabled_is_noop(self, monkeypatch):
+        # No POSTHOG_API_KEY → emit_generation_events does nothing, no raise.
+        called = []
+        monkeypatch.setattr(ag, "emit", lambda *a, **k: called.append(1))
+        ag.emit_generation_events(self._usage(), verification_id="v1")
+        assert called == []  # gated by posthog_emission_enabled()
+
+    def test_soft_fail_on_bad_usage(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_x")
+        # by_model with a non-dict value must not raise
+        ag.emit_generation_events({"by_model": {"m": None}}, verification_id="v1")
+
+    def test_empty_usage_noop(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_x")
+        ag.emit_generation_events(None, verification_id="v1")
+        ag.emit_generation_events({}, verification_id="v1")
+        ag.emit_generation_events(self._usage(), verification_id="")  # no trace id


### PR DESCRIPTION
Closes #474 (epic #472, ADR-050 D2). Blocked-by #473 (merged).

## What
Maps the ADR-011 `usage.by_model` summary → one PostHog `$ai_generation` event **per council-member model**, wired into the verify result path, keyed to `$ai_trace_id = verification_id`.

- `observability/ai_generation.py`: `build_generation_properties` (pure, golden-tested) + `emit_generation_events` (opt-in, soft-fail).
- **Cache-subtraction clamp:** `$ai_input_tokens = max(0, prompt − cache_read)` so PostHog's hit-rate tile `cache_read/(cache_read+input)` isn't double-counted; reads → `$ai_cache_read_input_tokens`, writes → `$ai_cache_creation_input_tokens` (Anthropic-specific, omitted when 0).
- `$ai_total_cost_usd` = ADR-011 ground truth, emitted **only when `cost_known`** (never an estimate-as-bill); overrides PostHog auto-calc.
- `verification/api.py`: gated on `posthog_emission_enabled` **before** importing the mapper ⇒ byte-identical when `POSTHOG_API_KEY` unset; soft-fail, never delays a verify.

## Tests (12)
core mapping, cache subtraction, clamp-never-negative (`cached>prompt`), cost-omit-when-unknown, cache-creation-omit-when-zero, provider-from-prefix, per-member fan-out, distinct_id default, disabled no-op, soft-fail on bad usage.

## Gates
`make lint` clean · `make test-fast` 3256 passed. Council to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E43uRciABobxwpUCHPQAwh