### PR TITLE
feat(observability): ADR-050 — adjudication $ai_metric contract keyed to verification_id (4/4)

### DIFF
--- a/src/llm_council/observability/adjudication.py
+++ b/src/llm_council/observability/adjudication.py
@@ -1,0 +1,74 @@
+"""Post a human adjudication onto a verify trace (ADR-050 Part 3, revised).
+
+The cross-repo hook: epic-loop's retro records a per-verification human
+disposition (``real`` / ``marginal`` / ``refuted`` / ``pass-clean``) by
+emitting a follow-up PostHog ``$ai_metric`` event keyed to the SAME
+``$ai_trace_id = verification_id``. A numeric ``metric_value`` drives TPR/FPR
+trends; a text ``adjudication_label`` carries the raw category.
+
+This is NOT PostHog's automated Evaluations product (which runs LLM-as-a-judge
+at sample time). The follow-up-event-by-trace_id join is the documented path.
+
+**Verify-before-implementation** (ADR-050 §Decision Part 3): PostHog's public
+docs don't pin ``$ai_metric``'s value type or whether a metric keyed to a
+trace renders trace-scoped vs generation-scoped — confirm empirically against
+the live project before relying on this in production. The fallback, if
+``$ai_metric`` doesn't behave, is a plain custom event carrying the same
+``$ai_trace_id``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from .ai_generation import DEFAULT_DISTINCT_ID
+from .posthog_emitter import emit, posthog_emission_enabled, scrub_exception
+
+logger = logging.getLogger(__name__)
+
+# ADR-050 Part 3 vocabulary → numeric scalar (Council rev-2: numeric for trends
+# AND a text label). real/pass-clean are "good" (1.0); refuted is "bad" (0.0);
+# marginal sits between.
+ADJUDICATION_VALUES = {
+    "real": 1.0,
+    "marginal": 0.5,
+    "refuted": 0.0,
+    "pass-clean": 1.0,
+}
+
+
+def emit_adjudication(
+    verification_id: str,
+    disposition: str,
+    *,
+    notes: Optional[str] = None,
+    consumer: Optional[str] = None,
+) -> None:
+    """Emit an ``$ai_metric`` adjudication keyed to ``verification_id``.
+
+    Input validation is UNCONDITIONAL: an invalid ``disposition`` raises
+    ``ValueError`` even when emission is disabled, so a caller's typo surfaces
+    immediately (the no-op-when-disabled contract governs the emission
+    side-effect, not argument validation). Emission itself is soft-fail and
+    opt-in.
+    """
+    if disposition not in ADJUDICATION_VALUES:
+        raise ValueError(
+            f"disposition must be one of {sorted(ADJUDICATION_VALUES)}, "
+            f"got {disposition!r}"
+        )
+    if not posthog_emission_enabled() or not verification_id:
+        return
+    try:
+        props = {
+            "$ai_trace_id": verification_id,
+            "metric_name": "adjudication",
+            "metric_value": ADJUDICATION_VALUES[disposition],
+            "adjudication_label": disposition,
+        }
+        if notes:
+            props["adjudication_notes"] = notes
+        emit("$ai_metric", props, distinct_id=consumer or DEFAULT_DISTINCT_ID)
+    except Exception as exc:  # telemetry must never break the caller
+        logger.debug("emit_adjudication failed (ignored): %s", scrub_exception(exc))

--- a/src/llm_council/observability/adjudication.py
+++ b/src/llm_council/observability/adjudication.py
@@ -53,12 +53,17 @@ def emit_adjudication(
     side-effect, not argument validation). Emission itself is soft-fail and
     opt-in.
     """
+    # Required-input validation is unconditional and consistent: both a bad
+    # disposition AND a missing verification_id are caller errors that must
+    # surface even when emission is disabled.
     if disposition not in ADJUDICATION_VALUES:
         raise ValueError(
             f"disposition must be one of {sorted(ADJUDICATION_VALUES)}, "
             f"got {disposition!r}"
         )
-    if not posthog_emission_enabled() or not verification_id:
+    if not verification_id:
+        raise ValueError("verification_id is required (the $ai_trace_id to key the metric)")
+    if not posthog_emission_enabled():
         return
     try:
         props = {

--- a/src/llm_council/observability/adjudication.py
+++ b/src/llm_council/observability/adjudication.py
@@ -61,8 +61,10 @@ def emit_adjudication(
             f"disposition must be one of {sorted(ADJUDICATION_VALUES)}, "
             f"got {disposition!r}"
         )
-    if not verification_id:
-        raise ValueError("verification_id is required (the $ai_trace_id to key the metric)")
+    if not verification_id or not verification_id.strip():
+        raise ValueError(
+            "verification_id is required and non-blank (the $ai_trace_id to key the metric)"
+        )
     if not posthog_emission_enabled():
         return
     try:
@@ -72,8 +74,10 @@ def emit_adjudication(
             "metric_value": ADJUDICATION_VALUES[disposition],
             "adjudication_label": disposition,
         }
-        if notes:
+        if notes and notes.strip():  # omit empty/whitespace-only notes
             props["adjudication_notes"] = notes
-        emit("$ai_metric", props, distinct_id=consumer or DEFAULT_DISTINCT_ID)
+        # Empty/whitespace consumer falls back to the default actor.
+        distinct_id = (consumer or "").strip() or DEFAULT_DISTINCT_ID
+        emit("$ai_metric", props, distinct_id=distinct_id)
     except Exception as exc:  # telemetry must never break the caller
         logger.debug("emit_adjudication failed (ignored): %s", scrub_exception(exc))

--- a/tests/test_adjudication_metric.py
+++ b/tests/test_adjudication_metric.py
@@ -74,11 +74,11 @@ class TestEmitAdjudication:
         adj.emit_adjudication("v1", "real")  # no key → no emit
         assert sink == []
 
-    def test_empty_verification_id_noop(self, monkeypatch):
-        monkeypatch.setenv("POSTHOG_API_KEY", "phc_x")
-        sink = self._capture(monkeypatch)
-        adj.emit_adjudication("", "real")
-        assert sink == []
+    def test_empty_verification_id_raises(self):
+        # Required input: an empty trace id is a caller error (consistent with
+        # the disposition validation), raised even when emission is disabled.
+        with pytest.raises(ValueError):
+            adj.emit_adjudication("", "real")
 
     def test_soft_fail_on_emit_error(self, monkeypatch):
         monkeypatch.setenv("POSTHOG_API_KEY", "phc_x")

--- a/tests/test_adjudication_metric.py
+++ b/tests/test_adjudication_metric.py
@@ -91,3 +91,26 @@ class TestEmitAdjudication:
 
     def test_vocabulary_is_the_adr_set(self):
         assert set(adj.ADJUDICATION_VALUES) == {"real", "marginal", "refuted", "pass-clean"}
+
+
+class TestEdgeCases:
+    def test_whitespace_verification_id_raises(self):
+        import pytest as _pytest
+        with _pytest.raises(ValueError):
+            adj.emit_adjudication("   ", "real")
+
+    def test_blank_consumer_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_x")
+        sink = []
+        monkeypatch.setattr(adj, "emit",
+                            lambda event, properties, distinct_id: sink.append(distinct_id))
+        adj.emit_adjudication("v1", "real", consumer="   ")
+        assert sink == ["llm-council"]
+
+    def test_whitespace_notes_omitted(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_x")
+        sink = []
+        monkeypatch.setattr(adj, "emit",
+                            lambda event, properties, distinct_id: sink.append(properties))
+        adj.emit_adjudication("v1", "real", notes="   ")
+        assert "adjudication_notes" not in sink[0]

--- a/tests/test_adjudication_metric.py
+++ b/tests/test_adjudication_metric.py
@@ -1,0 +1,93 @@
+"""ADR-050 D4 (#476): adjudication $ai_metric contract keyed to verification_id.
+
+epic-loop's retro posts a human disposition onto a verify trace by emitting a
+follow-up $ai_metric event keyed to $ai_trace_id = verification_id, with a
+numeric metric_value (for TPR/FPR trends) plus a text adjudication_label.
+Verify-before-implementation: the exact $ai_metric value-type / trace-vs-
+generation scope is confirmed empirically against the live project before
+production use (public docs don't pin it); the follow-up-event-by-trace_id
+join itself IS documented.
+"""
+
+import pytest
+
+from llm_council.observability import adjudication as adj
+from llm_council.observability import posthog_emitter as pe
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    monkeypatch.delenv("POSTHOG_API_KEY", raising=False)
+    pe.reset_for_testing()
+    yield
+    pe.reset_for_testing()
+
+
+class TestEmitAdjudication:
+    def _capture(self, monkeypatch):
+        sink = []
+        monkeypatch.setattr(adj, "emit",
+                            lambda event, properties, distinct_id: sink.append((event, properties, distinct_id)))
+        return sink
+
+    @pytest.mark.parametrize("disposition,value", [
+        ("real", 1.0), ("marginal", 0.5), ("refuted", 0.0), ("pass-clean", 1.0),
+    ])
+    def test_numeric_value_and_label(self, monkeypatch, disposition, value):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_x")
+        sink = self._capture(monkeypatch)
+        adj.emit_adjudication("verif-123", disposition)
+        assert len(sink) == 1
+        event, props, did = sink[0]
+        assert event == "$ai_metric"
+        assert props["$ai_trace_id"] == "verif-123"
+        assert props["metric_name"] == "adjudication"
+        assert props["metric_value"] == value
+        assert props["adjudication_label"] == disposition
+        assert did == "llm-council"
+
+    def test_notes_and_consumer(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_x")
+        sink = self._capture(monkeypatch)
+        adj.emit_adjudication("v1", "marginal", notes="borderline on edge case",
+                              consumer="opaque-7")
+        _, props, did = sink[0]
+        assert props["adjudication_notes"] == "borderline on edge case"
+        assert did == "opaque-7"
+
+    def test_notes_absent_by_default(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_x")
+        sink = self._capture(monkeypatch)
+        adj.emit_adjudication("v1", "real")
+        assert "adjudication_notes" not in sink[0][1]
+
+    def test_invalid_disposition_raises_even_when_disabled(self):
+        # Input validation is unconditional (a caller typo must surface); the
+        # no-op-when-disabled contract governs EMISSION, not validation.
+        with pytest.raises(ValueError):
+            adj.emit_adjudication("v1", "REAL")  # wrong case / not in vocab
+        with pytest.raises(ValueError):
+            adj.emit_adjudication("v1", "bogus")
+
+    def test_disabled_is_noop(self, monkeypatch):
+        sink = self._capture(monkeypatch)
+        adj.emit_adjudication("v1", "real")  # no key → no emit
+        assert sink == []
+
+    def test_empty_verification_id_noop(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_x")
+        sink = self._capture(monkeypatch)
+        adj.emit_adjudication("", "real")
+        assert sink == []
+
+    def test_soft_fail_on_emit_error(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_x")
+
+        def boom(*a, **k):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr(adj, "emit", boom)
+        adj.emit_adjudication("v1", "real")  # must not raise
+
+    def test_vocabulary_is_the_adr_set(self):
+        assert set(adj.ADJUDICATION_VALUES) == {"real", "marginal", "refuted", "pass-clean"}


### PR DESCRIPTION
Closes #476 (epic #472, ADR-050 D4 — final child). Blocked-by #474 (merged).

## What
The cross-repo hook (ADR-050 Part 3, revised): epic-loop's retro records a per-verification human disposition by emitting a follow-up `$ai_metric` event keyed to the same `$ai_trace_id = verification_id`.

- `observability/adjudication.py` `emit_adjudication(verification_id, disposition, notes=, consumer=)`: emits `$ai_metric` with `metric_name='adjudication'`, a **numeric** `metric_value` (real/pass-clean=1.0, marginal=0.5, refuted=0.0 — for TPR/FPR trends) **and** a text `adjudication_label` (Council rev-2 encoding). Optional `notes` → `adjudication_notes`.
- **NOT** PostHog's automated Evaluations product (rev-2 refutation).
- Input validation unconditional (invalid disposition raises even when disabled — a caller typo must surface); emission soft-fail + opt-in.
- `$ai_metric` value-type / trace-vs-generation scope flagged **verify-before-impl** in the docstring (public docs don't pin it; fallback is a plain custom event carrying `$ai_trace_id`).

## Tests (11)
numeric value + label per disposition (parametrized), notes/consumer, invalid→ValueError (even disabled), disabled no-op, empty-id no-op, soft-fail, vocabulary == ADR set.

## Gates
`make lint` clean · `make test-fast` 3274 passed. Council to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E43uRciABobxwpUCHPQAwh