### PR TITLE
docs(adr): ADR-051 verify findings channel + verdict–evidence consistency (Draft)

### DIFF
--- a/docs/adr/ADR-051-implementation-spec.md
+++ b/docs/adr/ADR-051-implementation-spec.md
@@ -1,0 +1,187 @@
+# ADR-051 Implementation Spec — Verify Findings Channel
+
+**Companion to:** [ADR-051](ADR-051-verify-findings-channel.md) (Proposed) · **Tracking:** [#482](https://github.com/amiable-dev/llm-council/issues/482)
+**Status:** Draft spec 2026-07-05 · resolves the ADR's open implementation forks before `/adr-epic`.
+
+This spec pins the *how* (the ADR pins the *what/why*): the enforcement
+mechanism, the concrete response schema, the flagged migration, the exhaustive
+documentation surface + a new drift guard, and the child breakdown. It is
+written to be deep-read by `/adr-epic`.
+
+---
+
+## 1. Enforcement mechanism — two-phase generation (decided)
+
+**Context.** ADR-051 Part 1 requires the chairman to enumerate `findings[]`
+*before* committing its verdict ("Proof-Before-Preference"), because a rationale
+emitted *alongside* the verdict does not fix verdict–evidence decoupling. Today
+there is **no structured-output plumbing**: `verdict.py:parse_binary_verdict`
+regex-parses the chairman's prose. So every option below is net-new.
+
+**Decision: two-phase generation for v1.**
+
+- **Phase 1 (findings):** the chairman is called with the code + evidence and a
+  prompt that asks *only* for `findings[]` (severity, description, cited
+  location) — **no verdict requested, none in context.**
+- **Phase 2 (verdict):** a second, compact chairman call receives *its own
+  Phase-1 findings* (not the code again) and renders `approved|rejected` +
+  confidence **as a function of those findings.**
+
+**The one decisive reason:** only two-phase makes the verdict *causally* depend
+on the findings. Phase 1 cannot backfill findings to a verdict it has not made;
+Phase 2 has the findings as its input. The alternatives give **cosmetic**
+ordering at best.
+
+| Option | Causal findings-first? | Portability | Failure mode left open |
+|---|---|---|---|
+| **A. Two-phase (chosen)** | **Yes** — Phase 1 has no verdict | High (reuses the chairman call twice; provider-agnostic) | Phase-1/Phase-2 drift (mitigated: Phase 2 sees the findings verbatim; a mismatch trips the Part-2 guard) |
+| B. Constrained decoding | No — JSON field order ≠ reasoning order; model may decide verdict-first and emit findings to match | Low — needs per-provider structured-output adapters (OpenAI json_schema / Gemini responseSchema / Anthropic tool-use) built + maintained | Rationalization survives; the exact pathology we're fixing |
+| C. Single free-form + parse | No | High | Weakest; ~= today's prose fragility |
+
+**Cost.** One extra chairman hop inside stage-3's waterfall budget (ADR-040:
+stage 3 gets the remaining time). Phase 2's input is compact (findings only, not
+the code), so it is short and cheap. Acceptable for a quality gate where
+correctness dominates a ~1–2 s latency add.
+
+**Graceful degradation (soft-fail, ADR-011/024).** If Phase 2 fails or times
+out, fall back to a verdict derived from Phase-1 findings (critical present ⇒
+lean fail) and mark `findings_source: structured`, `verdict_source: degraded`.
+If Phase 1 itself fails or the flag is off, fall back to the **legacy single
+synthesis + `parse_binary_verdict` + prose-regex** path and mark
+`findings_source: fallback`, `fallback_reason: <cause>`. Verify never crashes on
+a bad model output.
+
+**Constrained decoding is explicitly deferred** to a future per-chairman-model
+optimization — considered only if a provider's structured output empirically
+adds value over two-phase, and never as the sole enforcement (it is cosmetic on
+the causal property).
+
+> Note: a Council validation of this fork was attempted 2026-07-05 but the
+> council could not run (OpenRouter `402 Payment Required` — account credits).
+> Re-validate once billing is restored; the decision does not block on it.
+
+## 2. Response schema (concrete)
+
+New Pydantic in `verification/schemas.py` (and mirrored in `types.py`):
+
+```python
+class Finding(BaseModel):
+    severity: Literal["critical", "major", "minor", "info"]
+    description: str
+    location: Optional[str] = None          # "file.py:42" or "global"/None for holistic
+    dimension: Optional[str] = None          # which rubric axis, when derivable
+
+class VerifyDiagnostics(BaseModel):          # telemetry-only; NOT control flow
+    inner_verdict: Optional[str] = None       # "approved"/"rejected" pre-softening
+    inner_confidence: Optional[float] = None
+    inner_confidence_calibrated: Optional[float] = None
+    verdict_evidence_mismatch: Optional[str] = None   # "fail_without_findings" | "pass_with_critical"
+    findings_source: Literal["structured", "fallback"] = "fallback"
+    fallback_reason: Optional[str] = None
+    verdict_source: Literal["two_phase", "degraded", "legacy"] = "legacy"
+```
+
+`VerifyResponse` gains:
+- `findings: List[Finding]` — the full structured list (all severities).
+- `diagnostics: VerifyDiagnostics` — nested, telemetry-only.
+
+`blocking_issues` is **derived**, unchanged in type
+(`List[BlockingIssueResponse]` — already `{severity, description, location}`, so
+**no type break**): `blocking_issues = [b for f in findings if f.severity ==
+"critical"]` plus any ADR-042 blocking-evidence dispositions. Non-critical
+findings live only in `findings[]`.
+
+**Invariant tests:** a FAIL with a critical finding never yields
+`blocking_issues == []`; `findings[]` ⊇ `blocking_issues` (by severity filter).
+
+## 3. Migration & versioning — flagged, non-breaking epic; deliberate flip
+
+The blast radius is a **breaking contract change** (`blocking_issues`:
+always-`[]` → populated on FAIL; Hyrum's Law — epic-loop keys its green-chase
+cap on the count). De-risked as a two-step:
+
+1. **Epic ships behind `LLM_COUNCIL_STRUCTURED_FINDINGS`, default OFF.** Flag off
+   ⇒ byte-identical to today (legacy path, `findings: []`, `blocking_issues` via
+   regex). This whole epic is therefore a **non-breaking, opt-in minor** —
+   consumers (epic-loop) flip it on, migrate their gate logic off "always-empty",
+   and validate.
+2. **A separate, deliberate flip to default-ON is the breaking release** —
+   MAJOR bump (or a clearly-`### BREAKING` minor for a 0.x line) with a
+   migration note. Not bundled into the build epic.
+
+New env var (documented in `docs/reference/environment-variables.md`, enforced
+by the drift guard): `LLM_COUNCIL_STRUCTURED_FINDINGS` (default `false` in the
+epic; the flip changes the default, not the code).
+
+## 4. Documentation surface (the checklist — DoD, not afterthought)
+
+Every child that changes the contract updates its slice; the consolidated docs
+child (C6) closes the list. **All of these reference the verify contract and
+MUST be reconciled:**
+
+- `docs/guides/verify.md` — findings/diagnostics fields, `findings_source`, the
+  consistency-guard marker, the flag, exit-code semantics unchanged.
+- `docs/api.md` — `POST /v1/council/verify` response schema (new fields).
+- `docs/guides/mcp.md` — the `verify` MCP tool output fields.
+- `docs/guides/skills.md`, `docs/blog/12-cicd-quality-gates.md` — gate examples.
+- Bundled skills (must stay in sync with the shipped tool, sync-tested):
+  `council-verify/SKILL.md` + `references/{rubrics.md, unclear-routing.md}`;
+  `council-gate/SKILL.md` + `references/ci-cd-rubric.md`;
+  `council-review/SKILL.md` + `references/code-review-rubric.md`.
+- `CHANGELOG.md` (with a `### BREAKING` entry on the flip), `CLAUDE.md`
+  (verification module note), `docs/reference/environment-variables.md` (flag).
+- A consumer **migration guide** (`docs/guides/verify.md#migrating` or a note):
+  "stop keying on `blocking_issues == []`; key on `findings`/severity."
+
+**New drift guard (highest-leverage completeness guarantee).** Extend
+`tests/test_docs_drift.py`: assert every field on `VerifyResponse` (and each
+`Finding`/`VerifyDiagnostics` field) appears by name in `docs/guides/verify.md`
+or `docs/api.md`. Turns "did we document the new response fields?" into a red
+build — the gap the current guards (env / ADR-nav / snippet) don't cover.
+
+## 5. Child breakdown for `/adr-epic` (sequenced)
+
+Per-decision granularity; foundation-first; the breaking flip is *out* of the
+epic. Non-critical/`info` findings are retained in `findings[]`.
+
+1. **C1 — flag + additive schema (foundation, non-breaking).** Add
+   `LLM_COUNCIL_STRUCTURED_FINDINGS` (default off), the `Finding` /
+   `VerifyDiagnostics` models, and the additive `VerifyResponse` fields
+   (empty by default). Flag-off ⇒ byte-identical (test-pinned). Env-reference +
+   drift-guard field assertion.
+2. **C2 — two-phase chairman emission (behind flag).** Phase-1 findings-first
+   prompt, Phase-2 verdict-from-findings; populate `findings[]`; soft-fail
+   ladder (degraded → legacy) with `findings_source`/`verdict_source`.
+3. **C3 — derive `blocking_issues` from `findings[critical]`.** Prose regex
+   demoted to the flagged fallback; `findings_source`/`fallback_reason` set;
+   #355 regression pinned (approval prose must not fabricate criticals).
+4. **C4 — bidirectional verdict–evidence consistency guard.** `fail`+no findings
+   and `pass`+critical both emit `diagnostics.verdict_evidence_mismatch`;
+   zero-finding FAIL survives; any re-run is non-coercive (localize only).
+5. **C5 — `diagnostics.inner_verdict`/`inner_confidence` on softened UNCLEAR.**
+6. **C6 — docs sweep + drift guard + migration guide.** The §4 checklist,
+   bundled-skill sync, CHANGELOG (flag), CLAUDE.md. Flag still default-off.
+
+**Out of this epic (per ADR-051 + Council rev-2):**
+- **P4 completeness reweight** — a separate follow-up PR; re-measure *after*
+  C1–C6 land (it lives in the stage-2 rubric path, `verdict_extractor.py:135`,
+  not the findings channel).
+- **P5 LLM-as-a-Fuser spike** — a separate research task *after* the epic (needs
+  structured findings to exist); pre-registered accept thresholds; produces a
+  go/no-go report, spawning its own ADR only if it clears them.
+- **Default-ON flip** — a deliberate breaking release after consumers migrate.
+
+## 6. Test plan (across the epic)
+
+- Flag-off byte-identical (C1).
+- Two-phase: Phase-1 prompt contains no verdict; Phase-2 input is the findings;
+  Phase-2 failure degrades, never crashes (C2).
+- `blocking_issues` invariants: FAIL+critical ⇒ non-empty; `findings ⊇
+  blocking_issues`; #355 approval-prose regression (C3).
+- Bidirectional guard fires on both mismatches; zero-finding FAIL passes through
+  untouched (C4).
+- Softened UNCLEAR carries `diagnostics.inner_verdict` (C5).
+- Drift guard: an undocumented `VerifyResponse` field fails CI (C1/C6).
+- **Corpus replay:** re-run the epic-loop 25-call log (verification_ids in
+  `council-verify-stats.md`) with the flag on; assert FAILs now carry non-empty
+  `findings`. (Requires OpenRouter credits — currently blocked by the 402.)

--- a/docs/adr/ADR-051-implementation-spec.md
+++ b/docs/adr/ADR-051-implementation-spec.md
@@ -18,47 +18,56 @@ emitted *alongside* the verdict does not fix verdict–evidence decoupling. Toda
 there is **no structured-output plumbing**: `verdict.py:parse_binary_verdict`
 regex-parses the chairman's prose. So every option below is net-new.
 
-**Decision: two-phase generation for v1.**
+**Decision: mechanical gate — LLM findings, deterministic verdict.** (Revised
+after the Council fork review, 2026-07-05, high tier — it challenged plain
+two-phase and 3/4 models converged on this hybrid.)
 
-- **Phase 1 (findings):** the chairman is called with the code + evidence and a
-  prompt that asks *only* for `findings[]` (severity, description, cited
-  location) — **no verdict requested, none in context.**
-- **Phase 2 (verdict):** a second, compact chairman call receives *its own
-  Phase-1 findings* (not the code again) and renders `approved|rejected` +
-  confidence **as a function of those findings.**
+- **Phase 1 (LLM):** ONE chairman call emits severity-tagged `findings[]`
+  (severity, description, cited location) *and* the human-readable synthesis
+  prose. No verdict is requested.
+- **Phase 2 (deterministic host code):** the verdict is **computed from the
+  findings**, not generated — v1 policy: any `severity == "critical"` finding
+  (or an ADR-042 blocking-evidence disposition) ⇒ `fail`; otherwise `pass`.
+  The policy is explicit, auditable code (tunable later, e.g. "N majors ⇒
+  fail"). Confidence continues to come from the existing deliberation/agreement
+  signal (`calculate_confidence_from_agreement`), independent of the verdict.
 
-**The one decisive reason:** only two-phase makes the verdict *causally* depend
-on the findings. Phase 1 cannot backfill findings to a verdict it has not made;
-Phase 2 has the findings as its input. The alternatives give **cosmetic**
-ordering at best.
+**The one decisive reason:** the verdict is a **provable function of the
+findings** — it is literally `verdict = policy(findings)` in code, the strongest
+possible form of "findings-first." A generated Phase-2 verdict is only
+*hopefully* causal; the Council showed a second LLM call that sees the code
+re-judges freshly and can emit `ACCEPT` over its own `CRITICAL` finding (the
+"Yes-Man contradiction").
 
-| Option | Causal findings-first? | Portability | Failure mode left open |
+| Option | Verdict genuinely = f(findings)? | LLM hops | Failure mode left open |
 |---|---|---|---|
-| **A. Two-phase (chosen)** | **Yes** — Phase 1 has no verdict | High (reuses the chairman call twice; provider-agnostic) | Phase-1/Phase-2 drift (mitigated: Phase 2 sees the findings verbatim; a mismatch trips the Part-2 guard) |
-| B. Constrained decoding | No — JSON field order ≠ reasoning order; model may decide verdict-first and emit findings to match | Low — needs per-provider structured-output adapters (OpenAI json_schema / Gemini responseSchema / Anthropic tool-use) built + maintained | Rationalization survives; the exact pathology we're fixing |
-| C. Single free-form + parse | No | High | Weakest; ~= today's prose fragility |
+| **Mechanical gate (chosen)** | **Yes — computed in code** | **1** (same as today) | Severity **mis-labelling** by the model (a real "critical" tagged "major" won't fail) — localized, auditable, tunable via the rubric + policy |
+| Two-phase (both LLM) | No — Phase 2 can re-judge / Yes-Man contradict | 2 (extra hop, waterfall-budget risk) | Contradiction + latency; needs info-starvation + a code guard anyway → collapses toward the mechanical gate |
+| Constrained decoding | No — JSON field order ≠ reasoning order | 1 | Rationalization survives; net-new per-provider adapters |
+| Single free-form + parse | No | 1 | Weakest; ≈ today's prose fragility |
 
-**Cost.** One extra chairman hop inside stage-3's waterfall budget (ADR-040:
-stage 3 gets the remaining time). Phase 2's input is compact (findings only, not
-the code), so it is short and cheap. Acceptable for a quality gate where
-correctness dominates a ~1–2 s latency add.
+**Why this beats plain two-phase (Council):** it is single-hop (no waterfall-
+budget penalty — Gemini's objection), makes the Yes-Man contradiction
+*structurally impossible* (so the Part-2 guard becomes a defensive invariant,
+§below), and makes soft-fail safe (a deterministic verdict from stranded
+findings, never an untrusted LLM inference). It also lands the ADR's root fix
+maximally: the verdict is no longer *decoupled* from the evidence — it is
+*derived* from it.
 
-**Graceful degradation (soft-fail, ADR-011/024).** If Phase 2 fails or times
-out, fall back to a verdict derived from Phase-1 findings (critical present ⇒
-lean fail) and mark `findings_source: structured`, `verdict_source: degraded`.
-If Phase 1 itself fails or the flag is off, fall back to the **legacy single
-synthesis + `parse_binary_verdict` + prose-regex** path and mark
-`findings_source: fallback`, `fallback_reason: <cause>`. Verify never crashes on
-a bad model output.
+**Graceful degradation (soft-fail, ADR-011/024).** If the Phase-1 findings
+emission fails or won't parse (or the flag is off), fall back to the **legacy
+single synthesis + `parse_binary_verdict` + prose-regex** path and mark
+`findings_source: fallback`, `fallback_reason: <cause>`. The verdict computation
+(Phase 2) is pure code and never fails. Verify never crashes on a bad model
+output.
 
 **Constrained decoding is explicitly deferred** to a future per-chairman-model
-optimization — considered only if a provider's structured output empirically
-adds value over two-phase, and never as the sole enforcement (it is cosmetic on
-the causal property).
+optimization for how Phase 1 *emits* findings (e.g. json_schema / responseSchema
+/ tool-use) — a robustness upgrade to parsing, never the verdict mechanism.
 
-> Note: a Council validation of this fork was attempted 2026-07-05 but the
-> council could not run (OpenRouter `402 Payment Required` — account credits).
-> Re-validate once billing is restored; the decision does not block on it.
+> The Council validation ran 2026-07-05, high tier (OpenRouter billing
+> restored). It did not rubber-stamp two-phase — the mechanical-gate pivot is
+> its convergent recommendation, folded in here.
 
 ## 2. Response schema (concrete)
 
@@ -75,24 +84,34 @@ class VerifyDiagnostics(BaseModel):          # telemetry-only; NOT control flow
     inner_verdict: Optional[str] = None       # "approved"/"rejected" pre-softening
     inner_confidence: Optional[float] = None
     inner_confidence_calibrated: Optional[float] = None
-    verdict_evidence_mismatch: Optional[str] = None   # "fail_without_findings" | "pass_with_critical"
+    verdict_evidence_mismatch: Optional[str] = None   # invariant assertion — should never fire
     findings_source: Literal["structured", "fallback"] = "fallback"
     fallback_reason: Optional[str] = None
-    verdict_source: Literal["two_phase", "degraded", "legacy"] = "legacy"
+    verdict_source: Literal["mechanical", "legacy"] = "legacy"   # mechanical = policy(findings)
 ```
 
 `VerifyResponse` gains:
 - `findings: List[Finding]` — the full structured list (all severities).
 - `diagnostics: VerifyDiagnostics` — nested, telemetry-only.
 
+**Verdict is derived, not parsed.** On the structured path the verdict is
+`verdict_source: mechanical` = `policy(findings)` (v1: any `critical` ⇒ `fail`,
+else `pass`); confidence stays from the deliberation/agreement signal. On the
+fallback path it is `legacy` (`parse_binary_verdict` + prose regex).
+
 `blocking_issues` is **derived**, unchanged in type
 (`List[BlockingIssueResponse]` — already `{severity, description, location}`, so
-**no type break**): `blocking_issues = [b for f in findings if f.severity ==
+**no type break**): `blocking_issues = [f for f in findings if f.severity ==
 "critical"]` plus any ADR-042 blocking-evidence dispositions. Non-critical
 findings live only in `findings[]`.
 
-**Invariant tests:** a FAIL with a critical finding never yields
-`blocking_issues == []`; `findings[]` ⊇ `blocking_issues` (by severity filter).
+**Invariants (now structural, not hoped-for).** Because the verdict is
+`policy(findings)`, `fail`-with-no-critical and `pass`-with-critical are
+**impossible by construction** on the mechanical path — the Part-2
+`verdict_evidence_mismatch` marker is a defensive assertion that should never
+fire (if it does, it's a code bug in the gate policy, and it's logged). Tests:
+`fail` ⇒ `blocking_issues` non-empty; `findings[] ⊇ blocking_issues`; the policy
+is a pure function (property test over synthetic findings).
 
 ## 3. Migration & versioning — flagged, non-breaking epic; deliberate flip
 
@@ -149,15 +168,19 @@ epic. Non-critical/`info` findings are retained in `findings[]`.
    `VerifyDiagnostics` models, and the additive `VerifyResponse` fields
    (empty by default). Flag-off ⇒ byte-identical (test-pinned). Env-reference +
    drift-guard field assertion.
-2. **C2 — two-phase chairman emission (behind flag).** Phase-1 findings-first
-   prompt, Phase-2 verdict-from-findings; populate `findings[]`; soft-fail
-   ladder (degraded → legacy) with `findings_source`/`verdict_source`.
-3. **C3 — derive `blocking_issues` from `findings[critical]`.** Prose regex
-   demoted to the flagged fallback; `findings_source`/`fallback_reason` set;
-   #355 regression pinned (approval prose must not fabricate criticals).
-4. **C4 — bidirectional verdict–evidence consistency guard.** `fail`+no findings
-   and `pass`+critical both emit `diagnostics.verdict_evidence_mismatch`;
-   zero-finding FAIL survives; any re-run is non-coercive (localize only).
+2. **C2 — structured findings emission (behind flag).** One chairman call emits
+   severity-tagged `findings[]` (+ synthesis prose); populate `findings[]`;
+   soft-fail to the legacy path (`findings_source`/`fallback_reason`).
+3. **C3 — mechanical verdict + derive `blocking_issues`.** `verdict =
+   policy(findings)` (any `critical` ⇒ `fail`) as a pure host function
+   (`verdict_source: mechanical`); `blocking_issues = findings[critical]`; prose
+   regex demoted to the flagged fallback; #355 regression pinned (approval prose
+   must not fabricate criticals).
+4. **C4 — consistency invariant + severity-calibration telemetry.** Assert the
+   structural invariant (`fail`⇔critical present) and log
+   `verdict_evidence_mismatch` if it ever fires (a gate-policy bug); emit
+   findings-count / severity-distribution telemetry so severity **mis-labelling**
+   (the named residual failure mode) is observable over time.
 5. **C5 — `diagnostics.inner_verdict`/`inner_confidence` on softened UNCLEAR.**
 6. **C6 — docs sweep + drift guard + migration guide.** The §4 checklist,
    bundled-skill sync, CHANGELOG (flag), CLAUDE.md. Flag still default-off.
@@ -174,14 +197,18 @@ epic. Non-critical/`info` findings are retained in `findings[]`.
 ## 6. Test plan (across the epic)
 
 - Flag-off byte-identical (C1).
-- Two-phase: Phase-1 prompt contains no verdict; Phase-2 input is the findings;
-  Phase-2 failure degrades, never crashes (C2).
-- `blocking_issues` invariants: FAIL+critical ⇒ non-empty; `findings ⊇
-  blocking_issues`; #355 approval-prose regression (C3).
-- Bidirectional guard fires on both mismatches; zero-finding FAIL passes through
-  untouched (C4).
+- Findings emission: a Phase-1 failure / unparseable output degrades to the
+  legacy path, never crashes (C2).
+- **Mechanical verdict is a pure function** — property test over synthetic
+  `findings[]`: `policy(findings)` is deterministic; any `critical` ⇒ `fail`;
+  no `critical` ⇒ `pass`; verdict never depends on prose (C3).
+- `blocking_issues` invariants: FAIL ⇒ non-empty; `findings ⊇ blocking_issues`;
+  #355 approval-prose regression (C3).
+- Structural invariant: `pass`-with-critical / `fail`-without-critical cannot be
+  produced; the `verdict_evidence_mismatch` assertion never fires in normal
+  operation (C4).
 - Softened UNCLEAR carries `diagnostics.inner_verdict` (C5).
 - Drift guard: an undocumented `VerifyResponse` field fails CI (C1/C6).
 - **Corpus replay:** re-run the epic-loop 25-call log (verification_ids in
   `council-verify-stats.md`) with the flag on; assert FAILs now carry non-empty
-  `findings`. (Requires OpenRouter credits — currently blocked by the 402.)
+  `findings`. (OpenRouter credits restored 2026-07-05.)

--- a/docs/adr/ADR-051-verify-findings-channel.md
+++ b/docs/adr/ADR-051-verify-findings-channel.md
@@ -6,6 +6,7 @@
 **Proposed by:** maintainer triage of a downstream field report (amiable-dev/epic-loop)
 **Relates to:** ADR-025b (Jury Mode / binary verdict), ADR-034 (verification), ADR-042 (evidence injection), ADR-047 (verifier calibration & unclear taxonomy), ADR-016 (rubric scoring)
 **Tracking:** [#482](https://github.com/amiable-dev/llm-council/issues/482)
+**Implementation spec:** [ADR-051-implementation-spec.md](ADR-051-implementation-spec.md) (enforcement mechanism, response schema, flagged migration, doc checklist, child breakdown)
 
 ---
 

--- a/docs/adr/ADR-051-verify-findings-channel.md
+++ b/docs/adr/ADR-051-verify-findings-channel.md
@@ -94,10 +94,12 @@ independently confirmed by the maintainer against the arXiv HTML.
 
 The Council endorsed the core diagnosis and the structured-findings fix, and
 raised amendments, all folded in above:
-1. **Proof-Before-Preference needs enforcement, not a prompt** → Part 1
-   commits to two-phase / constrained decoding.
-2. **Bidirectional consistency guard** → Part 2 now also guards `pass` +
-   critical findings; zero-finding FAILs survive; any re-run is non-coercive.
+1. **Proof-Before-Preference needs enforcement, not a prompt** → Part 1 → the
+   fork review (spec §1) landed on a **mechanical gate**: LLM emits findings,
+   host code computes the verdict.
+2. **Consistency guard** → the mechanical gate makes `pass`+critical /
+   `fail`-without-critical structurally impossible, so Part 2 downgrades to a
+   defensive invariant assertion + severity-calibration telemetry.
 3. **`inner_verdict` is a footgun as a top-level field** → Part 3 nests it
    under `diagnostics`, telemetry-only.
 4. **P4 (completeness) is orthogonal** → deferred to its own follow-up.
@@ -137,24 +139,27 @@ only as a fallback for models that don't return structured findings, and set
 `findings_source: structured|fallback` + `fallback_reason` on the response so
 consumers see when the channel degraded.
 
-**Findings precede the verdict — and it must be *enforced*, not just
-prompted (Council rev-2).** Research verification refuted the weaker version:
-a structured rationale emitted *alongside* the verdict does not fix decoupling.
-But JSON has no ordering guarantee and generation order alone is brittle, so
-"findings first" must be enforced by one of: **constrained decoding / structured
-outputs** (schema topological order), **two-phase generation** (emit findings,
-then a second call renders the verdict from them), or at minimum a **parse-time
-co-emission + ordering check**. The ADR commits to two-phase or constrained
-decoding — not a bare prompt instruction ("Proof-Before-Preference").
+**Findings precede the verdict — enforced by a *mechanical gate*, not a
+prompt (Council rev-2 + fork review).** Research verification refuted the
+weaker version: a structured rationale emitted *alongside* the verdict does not
+fix decoupling. The fork review (implementation spec §1) then rejected a second
+LLM verdict call too — it re-judges and can approve over its own critical
+finding. The chosen mechanism: **the chairman (LLM) emits severity-tagged
+`findings[]`; the verdict is computed by deterministic host code**
+(`verdict = policy(findings)`, v1: any `critical` ⇒ `fail`). The verdict is a
+*provable function* of the findings, single-hop, and impossible to decouple —
+see [ADR-051-implementation-spec.md](ADR-051-implementation-spec.md) §1.
 
 ### 2. Verdict–evidence consistency guard
 
-Guard **both directions** (Council rev-2): `fail`/`unclear` with empty
-`findings` (rejection with no justification), AND `pass` with any
-`severity == critical` finding (approval over a stated blocker). Either
-inconsistency emits a structured `verdict_evidence_mismatch` marker and is
-logged. This makes the pathology **observable** instead of silently producing
-`blocking_issues: []`.
+Under the mechanical gate (Part 1) the verdict is `policy(findings)`, so the
+two inconsistencies this guard targeted — `fail` with empty `findings`, and
+`pass` with a `critical` finding — are **structurally impossible**. The guard
+therefore downgrades to a **defensive invariant assertion**: if it ever fires,
+that is a bug in the gate policy, not model behavior, and it is logged as
+`verdict_evidence_mismatch`. The residual risk moves to **severity
+mis-labelling** (a real critical tagged `major`), surfaced by
+findings-count/severity telemetry rather than a verdict-vs-findings check.
 
 **A zero-finding FAIL is legitimate and must survive** (Council rev-2): a
 holistic rejection ("fundamentally wrong approach") may have no line-level
@@ -224,8 +229,9 @@ consumers built gating logic against always-`[]`, and populating it on FAIL
 wakes that dormant logic. It warrants a **MAJOR version bump** (or a transition
 feature flag defaulting to the new behavior with an opt-out) — not just a
 CHANGELOG line. Parts 1–3 touch the verdict-extraction hot path and need golden
-tests against both the structured and fallback paths; the two-phase/constrained
-enforcement adds one generation hop on the chairman path.
+tests against both the structured and fallback paths; the mechanical gate keeps
+this to a **single** chairman hop (no extra generation call — the verdict is
+host code).
 
 **Neutral.** `input_too_large` / `unclear_reason` structured outcomes are
 unchanged (keep). No new external dependency.
@@ -237,7 +243,10 @@ unchanged (keep). No new external dependency.
   `blocking_issues: []`.
 - Unit: prose-only chairman (no structured findings) ⇒ fallback regex path,
   response flags `findings_source: fallback`.
-- Unit: `verdict=fail` + empty findings ⇒ `verdict_evidence_mismatch` marker
+- Unit: the verdict policy is a pure function of `findings` — any `critical` ⇒
+  `fail`, none ⇒ `pass`; `pass`-with-critical / `fail`-without-critical are
+  unreachable (the `verdict_evidence_mismatch` assertion never fires in normal
+  operation)
   present.
 - Unit: softened UNCLEAR carries `inner_verdict`/`inner_confidence`.
 - Regression: the #355 corpus (approval prose like "critical issues resolved")

--- a/docs/adr/ADR-051-verify-findings-channel.md
+++ b/docs/adr/ADR-051-verify-findings-channel.md
@@ -89,10 +89,27 @@ independently confirmed by the maintainer against the arXiv HTML.
 | LLM judges are overconfident / miscalibrated; reasoning models are better-calibrated judges | **VERIFIED** | Overconfidence documented (2508.06225 + others); reasoning/extended-CoT models strictly better calibrated in 33/36 model×dataset settings — corroborates the observed "high tier converges, balanced tier churns". |
 | Critique/evidence **fusion is *necessary*** to beat independent tallying | **MIXED — do not overclaim** | Some fusion aggregators beat tallying, but PoLL ("Replacing Judges with Juries", arXiv [2404.18796](https://arxiv.org/abs/2404.18796)) shows a **diverse panel with simple independent voting already beats a single strong judge, ~7× cheaper**. llm-council already does diverse-panel tallying. ⇒ Part 5 is "does the Fuser beat our *existing panel*", not "adopt fusion". |
 
+### Council review (rev 2, high tier)
+
+The Council endorsed the core diagnosis and the structured-findings fix, and
+raised amendments, all folded in above:
+1. **Proof-Before-Preference needs enforcement, not a prompt** → Part 1
+   commits to two-phase / constrained decoding.
+2. **Bidirectional consistency guard** → Part 2 now also guards `pass` +
+   critical findings; zero-finding FAILs survive; any re-run is non-coercive.
+3. **`inner_verdict` is a footgun as a top-level field** → Part 3 nests it
+   under `diagnostics`, telemetry-only.
+4. **P4 (completeness) is orthogonal** → deferred to its own follow-up.
+5. **P5 must be bounded** → pre-registered accept thresholds.
+6. **Breaking change** → MAJOR bump / feature flag, not a CHANGELOG line.
+One council claim was **rejected on the code**: `blocking_issues` is not
+`List[str]` (no type-crash risk) — it is already `List[BlockingIssueResponse]`,
+the exact object shape `findings[]` produces.
+
 ## Decision (proposed)
 
-Five parts, ordered by leverage. Parts 1–3 are the core; 4 is a rider; 5 is a
-spike.
+Five parts, ordered by leverage. Parts 1–3 are the core structural fix; 4 is
+deferred to a follow-up; 5 is a bounded spike.
 
 ### 1. Structured findings channel (P0)
 
@@ -109,41 +126,64 @@ findings: [ { severity: critical|major|minor,
 
 Populate `blocking_issues` from `findings` filtered to
 `severity == critical` (and any ADR-042 blocking-evidence dispositions),
-**not** from the prose regex. Keep `extract_blocking_issues` only as a
-fallback for models that don't return structured findings, and mark that
-fallback in the response so consumers know the channel degraded.
+**not** from the prose regex. Non-critical findings (`major`/`minor`/`info`)
+stay in `findings[]` (not dropped) but do not gate. **No type break** (Council
+rev-2): `blocking_issues` is already `List[BlockingIssueResponse]`
+(`{severity, description, location: Optional[str]}`, `schemas.py`), the exact
+shape `findings[]` produces — this is object→object, and `location` already
+permits `null` (a holistic finding with no line). Keep `extract_blocking_issues`
+only as a fallback for models that don't return structured findings, and set
+`findings_source: structured|fallback` + `fallback_reason` on the response so
+consumers see when the channel degraded.
 
-**Findings precede the verdict (evidence-locking).** Research verification
-refuted the weaker version of this decision: a structured rationale *emitted
-alongside* the verdict does not fix decoupling — the judge still rationalizes
-post-hoc. The chairman must be prompted to enumerate `findings` (with cited
-locations) *before* committing the go/no-go, so the verdict is a function of
-the findings rather than the findings a justification of the verdict
-("Proof-Before-Preference"). This is a prompt-ordering constraint, not just a
-schema change.
+**Findings precede the verdict — and it must be *enforced*, not just
+prompted (Council rev-2).** Research verification refuted the weaker version:
+a structured rationale emitted *alongside* the verdict does not fix decoupling.
+But JSON has no ordering guarantee and generation order alone is brittle, so
+"findings first" must be enforced by one of: **constrained decoding / structured
+outputs** (schema topological order), **two-phase generation** (emit findings,
+then a second call renders the verdict from them), or at minimum a **parse-time
+co-emission + ordering check**. The ADR commits to two-phase or constrained
+decoding — not a bare prompt instruction ("Proof-Before-Preference").
 
 ### 2. Verdict–evidence consistency guard
 
-When `verdict == fail` (or `unclear`) but `findings` is empty, the result is
-internally inconsistent (rejection with no justification). Emit a structured
-`verdict_evidence_mismatch` marker on the response and log it; optionally,
-behind a flag, trigger a single bounded re-run. This makes the pathology
-**observable** instead of silently producing `blocking_issues: []`.
+Guard **both directions** (Council rev-2): `fail`/`unclear` with empty
+`findings` (rejection with no justification), AND `pass` with any
+`severity == critical` finding (approval over a stated blocker). Either
+inconsistency emits a structured `verdict_evidence_mismatch` marker and is
+logged. This makes the pathology **observable** instead of silently producing
+`blocking_issues: []`.
+
+**A zero-finding FAIL is legitimate and must survive** (Council rev-2): a
+holistic rejection ("fundamentally wrong approach") may have no line-level
+finding. The marker is observability, never a forced flip. If a bounded re-run
+is enabled behind a flag it must be **non-coercive** — it may ask the model to
+*localize its existing failure* (fill `findings`), never to *reconsider the
+verdict*. Coercing localization risks fabricated findings or a false `pass`
+just to satisfy the parser.
 
 ### 3. Surface the inner verdict on UNCLEAR
 
 When a structured "approved @ c" is softened to `unclear` because
 `c < threshold`, carry `inner_verdict` and `inner_confidence` (and the
-calibrated value) as structured fields on the response. Automation can then
-distinguish "the council approved but under threshold" from "the council was
-genuinely undecided" without parsing prose.
+calibrated value) so automation can distinguish "approved but under threshold"
+from "genuinely undecided" without parsing prose. **Nest these under a
+`diagnostics: {}` object** (Council rev-2) and document them as telemetry-only,
+so consumers don't parse `inner_verdict` to bypass the low-confidence safety
+gate — the softening to `unclear` is the contract; the inner state is for
+threshold tuning and observability, not control flow.
 
-### 4. Recalibrate `completeness` for code-review verification
+### 4. Recalibrate `completeness` — DEFERRED to a follow-up (Council rev-2)
 
-`completeness` (0.20 weight) does not discriminate for code review. Either
-drop its weight in the code-review rubric profile, or redefine it as a
-code-relevant axis (e.g. "tests/edge-cases covered"). A non-signal dimension
-must not carry a fifth of the weighted score.
+`completeness` (0.20 weight) does not discriminate for code review — drop its
+weight in the code-review rubric profile or redefine it as a code-relevant axis
+("tests/edge-cases covered"). But this is a **scoring-heuristic tweak,
+orthogonal to the evidence-plumbing defect** (it lives in the stage-2 rubric
+path, `verdict_extractor.py:135`, not the `blocking_issues` regex), so it is
+**deferred out of this ADR** to keep the P0/P1 structural fix unblocked.
+Re-measure `completeness` *after* P0/P1 lands to confirm the flatness isn't
+entangled with the findings channel, then reweight in its own change.
 
 ### 5. (Spike) evaluate a fuser aggregator against our existing panel
 
@@ -159,7 +199,11 @@ beats a single strong judge ~7× cheaper — and that is essentially what
 llm-council already does. So the question is not "single judge → fusion" (a
 straw man; we don't use a single judge) but "existing panel-tallying → fusion:
 does it add enough calibration/accuracy to justify the extra synthesis cost?"
-A research spike with a cost/quality gate, not a committed change. Note the
+A research spike, not a committed change — and **pre-registered** to keep it
+bounded (Council rev-2): before running it, fix the thresholds that would
+justify adopting a Fuser — a minimum accuracy/calibration delta over the
+existing panel, a maximum added latency, and a maximum cost multiple. If the
+spike doesn't clear all three, the incumbent panel-tallying stays. Note the
 2508.06225 baseline is *Self-Confidence* (a per-judge confidence method), not
 self-consistency.
 
@@ -173,11 +217,14 @@ keys on blocking count (the reported downstream pain).
 
 **Negative / cost.** The chairman prompt gains a structured-output
 requirement (a compatibility surface across models; needs the same
-JSON-won't-parse fallback the rubric already has). `blocking_issues`
-semantics change — a **behavior change for consumers** that must be versioned
-and documented (today they receive `[]`; after, they receive real findings on
-FAIL). Parts 1–3 touch the verdict-extraction hot path and need golden tests
-against both the structured and fallback paths.
+JSON-won't-parse fallback the rubric already has). **`blocking_issues`
+semantics change is a breaking change under Hyrum's Law** (Council rev-2):
+consumers built gating logic against always-`[]`, and populating it on FAIL
+wakes that dormant logic. It warrants a **MAJOR version bump** (or a transition
+feature flag defaulting to the new behavior with an opt-out) — not just a
+CHANGELOG line. Parts 1–3 touch the verdict-extraction hot path and need golden
+tests against both the structured and fallback paths; the two-phase/constrained
+enforcement adds one generation hop on the chairman path.
 
 **Neutral.** `input_too_large` / `unclear_reason` structured outcomes are
 unchanged (keep). No new external dependency.

--- a/docs/adr/ADR-051-verify-findings-channel.md
+++ b/docs/adr/ADR-051-verify-findings-channel.md
@@ -1,0 +1,163 @@
+# ADR-051: Verify Findings Channel & Verdict–Evidence Consistency
+
+**Status:** Draft 2026-07-04
+**Date:** 2026-07-04
+**Decision Makers:** llm-council maintainers (review requested)
+**Proposed by:** maintainer triage of a downstream field report (amiable-dev/epic-loop)
+**Relates to:** ADR-025b (Jury Mode / binary verdict), ADR-034 (verification), ADR-042 (evidence injection), ADR-047 (verifier calibration & unclear taxonomy), ADR-016 (rubric scoring)
+**Tracking:** [#482](https://github.com/amiable-dev/llm-council/issues/482)
+
+---
+
+## Context
+
+`verify()`'s primary machine-readable contract is its verdict plus a
+`blocking_issues` list — automation (CI gates, epic-loop's green-chase cap)
+routes on the blocking count. Field data from a downstream consumer
+(amiable-dev/epic-loop: 27 calls / 25 completed across two tiers, every
+`verification_id` logged in `docs/assessments/council-verify-stats.md`) plus
+an independent second corpus (this repo's ADR-049/050 delivery epics, same
+council config) show a correctness defect:
+
+> **`blocking_issues` is `[]` on effectively every call** — pass, fail, and
+> unclear alike — including FAILs whose own rationale names findings the
+> council calls "critical".
+
+### Root cause — verdict and findings are decoupled by construction
+
+The two fields come from **different, unlinked sources**:
+
+- **Verdict** — the structured ADR-025b BINARY `VerdictResult`
+  (`verification/verdict_extractor.py::_verdict_from_structured`),
+  authoritative since #355. A clean go/no-go + confidence.
+- **`blocking_issues`** — a regex scrape of the chairman's **prose**
+  (`extract_blocking_issues`), matching only severity tokens anchored at
+  line start: `^\s*[-*]?\s*\**(CRITICAL|MAJOR|MINOR)\**:\s+…`.
+
+Modern chairmen (gemini-3.1-pro, opus-4.8) write findings as prose, which the
+strict regex never matches, so `blocking_issues == []` even when the verdict
+is `fail`. There is **no structured `findings[]`** anywhere in the pipeline,
+and blocking-strength *evidence* (ADR-042) does not feed `blocking_issues`
+(it drives screening/budget only). This is the classic LLM-judge
+**verdict–evidence decoupling** pathology: a rejection with no machine-readable
+justification.
+
+**#355 backstory (why it swung to never-fires):** the regex was originally
+loose (`(CRITICAL|MAJOR|MINOR)[:\s]+` anywhere), which fabricated blocking
+issues from *approval* prose ("the critical issues have been resolved"). #355
+tightened it to strict line-anchored markers — trading false positives for
+**universal false negatives**. A third regex is not the fix; a structured
+channel is.
+
+### Secondary observations from the same corpus
+
+- **UNCLEAR discards the inner verdict.** `verdict_extractor.py` softens
+  `pass→unclear` when the calibrated confidence is below threshold, but drops
+  the fact that the structured verdict was e.g. "approved @ 0.85". The
+  `unclear_reason` taxonomy (ADR-047 P1) exists; the inner verdict/confidence
+  do not surface.
+- **`completeness` does not discriminate.** Scores sit in a narrow 5.3–6.6
+  band across trivial and complex changes (or fall to the synthetic
+  `mean_score * 0.9` estimate), yet carry **0.20 rubric weight** — a
+  Q&A-oriented axis acting as a constant drag on code-review verdicts.
+- **Balanced tier churns; high tier converges.** Balanced-tier FAILs surfaced
+  fresh marginal findings each round instead of confirming fixes (7/9 failed,
+  one arithmetically false, one re-litigated). High tier (+ a factual
+  informational evidence item) produced substantively real findings every
+  time and twice gave explicit fix-acknowledgement. Consistent with the
+  overconfidence / aggregation literature (arXiv 2508.06225v2, 2508.06225).
+- **ADR-042 evidence firewall: flag-then-penalize.** The council correctly
+  firewalled imperative language inside an *informational* evidence item, then
+  cited that flagged "steering" sentence *in the rejection rationale* —
+  counting it against the submission rather than flag-and-ignore.
+- **Structured non-verdicts work.** `input_too_large` and
+  `unclear_reason=low_confidence` were clean, routable outcomes — keep them.
+
+## Decision (proposed)
+
+Five parts, ordered by leverage. Parts 1–3 are the core; 4 is a rider; 5 is a
+spike.
+
+### 1. Structured findings channel (P0)
+
+Have the chairman emit findings as **structured data**, not prose to be
+scraped. Extend the ADR-025b verdict output (or add a sibling structured
+field the chairman is prompted to fill) with:
+
+```
+findings: [ { severity: critical|major|minor,
+              description: str,
+              location: str | null,        # file:line where derivable
+              dimension: str | null } ]     # which rubric axis it maps to
+```
+
+Populate `blocking_issues` from `findings` filtered to
+`severity == critical` (and any ADR-042 blocking-evidence dispositions),
+**not** from the prose regex. Keep `extract_blocking_issues` only as a
+fallback for models that don't return structured findings, and mark that
+fallback in the response so consumers know the channel degraded.
+
+### 2. Verdict–evidence consistency guard
+
+When `verdict == fail` (or `unclear`) but `findings` is empty, the result is
+internally inconsistent (rejection with no justification). Emit a structured
+`verdict_evidence_mismatch` marker on the response and log it; optionally,
+behind a flag, trigger a single bounded re-run. This makes the pathology
+**observable** instead of silently producing `blocking_issues: []`.
+
+### 3. Surface the inner verdict on UNCLEAR
+
+When a structured "approved @ c" is softened to `unclear` because
+`c < threshold`, carry `inner_verdict` and `inner_confidence` (and the
+calibrated value) as structured fields on the response. Automation can then
+distinguish "the council approved but under threshold" from "the council was
+genuinely undecided" without parsing prose.
+
+### 4. Recalibrate `completeness` for code-review verification
+
+`completeness` (0.20 weight) does not discriminate for code review. Either
+drop its weight in the code-review rubric profile, or redefine it as a
+code-relevant axis (e.g. "tests/edge-cases covered"). A non-signal dimension
+must not carry a fifth of the weighted score.
+
+### 5. (Spike) critique-fusion aggregation
+
+Evaluate replacing independent-verdict tallying with a critique-fusion
+aggregator (one strong fuser synthesizing member critiques). The literature
+(arXiv 2508.06225v2: 86.3% acc / 6.4% ECE vs 77.4% best-single) and the
+corpus (high-tier synthesis quality drove verdict quality) both point this
+way. Scoped as a research spike, not part of the core change.
+
+## Consequences
+
+**Positive.** Gates key on structured findings instead of prose regex, so
+`blocking_issues` reflects reality; the verdict–evidence mismatch becomes
+observable; UNCLEAR carries the inner verdict for cleaner routing; the rubric
+stops dragging on a non-signal. Directly unblocks consumers whose automation
+keys on blocking count (the reported downstream pain).
+
+**Negative / cost.** The chairman prompt gains a structured-output
+requirement (a compatibility surface across models; needs the same
+JSON-won't-parse fallback the rubric already has). `blocking_issues`
+semantics change — a **behavior change for consumers** that must be versioned
+and documented (today they receive `[]`; after, they receive real findings on
+FAIL). Parts 1–3 touch the verdict-extraction hot path and need golden tests
+against both the structured and fallback paths.
+
+**Neutral.** `input_too_large` / `unclear_reason` structured outcomes are
+unchanged (keep). No new external dependency.
+
+## Compliance / Validation
+
+- Unit: chairman returns structured `findings` ⇒ `blocking_issues` =
+  critical-severity findings; a FAIL with findings never yields
+  `blocking_issues: []`.
+- Unit: prose-only chairman (no structured findings) ⇒ fallback regex path,
+  response flags `findings_source: fallback`.
+- Unit: `verdict=fail` + empty findings ⇒ `verdict_evidence_mismatch` marker
+  present.
+- Unit: softened UNCLEAR carries `inner_verdict`/`inner_confidence`.
+- Regression: the #355 corpus (approval prose like "critical issues resolved")
+  must NOT fabricate blocking issues under the structured or fallback path.
+- Corpus replay: re-run the epic-loop 25-call log (verification_ids in
+  `council-verify-stats.md`) and assert FAILs now carry non-empty findings.

--- a/docs/adr/ADR-051-verify-findings-channel.md
+++ b/docs/adr/ADR-051-verify-findings-channel.md
@@ -1,6 +1,6 @@
 # ADR-051: Verify Findings Channel & Verdict–Evidence Consistency
 
-**Status:** Draft 2026-07-04
+**Status:** Proposed 2026-07-04 (rev 2: literature claims verified via adversarial deep-research, 105 agents, 3-vote, checked 2026-07-04, with the anchor paper's numbers independently confirmed against the primary arXiv source. See "Research verification".)
 **Date:** 2026-07-04
 **Decision Makers:** llm-council maintainers (review requested)
 **Proposed by:** maintainer triage of a downstream field report (amiable-dev/epic-loop)
@@ -65,13 +65,29 @@ channel is.
   one arithmetically false, one re-litigated). High tier (+ a factual
   informational evidence item) produced substantively real findings every
   time and twice gave explicit fix-acknowledgement. Consistent with the
-  overconfidence / aggregation literature (arXiv 2508.06225v2, 2508.06225).
+  overconfidence / calibration literature (arXiv 2508.06225; see Research
+  verification).
 - **ADR-042 evidence firewall: flag-then-penalize.** The council correctly
   firewalled imperative language inside an *informational* evidence item, then
   cited that flagged "steering" sentence *in the rejection rationale* —
   counting it against the submission rather than flag-and-ignore.
 - **Structured non-verdicts work.** `input_too_large` and
   `unclear_reason=low_confidence` were clean, routable outcomes — keep them.
+
+## Research verification (rev 2)
+
+The literature scaffolding was checked by adversarial deep-research (105
+agents, 3-vote) against primary sources; the load-bearing statistic was then
+independently confirmed by the maintainer against the arXiv HTML.
+
+| Claim | Status | Evidence |
+|---|---|---|
+| The cited "86.3% acc / 6.4% ECE vs 77.4%" figures are real | **VERIFIED** | arXiv [2508.06225](https://arxiv.org/abs/2508.06225) (Tian et al., *Overconfidence in LLM-as-a-Judge*): **LLM-as-a-Fuser** = 86.29% / 6.42% ECE vs single-judge Self-Confidence baseline 77.43% / 11.78% on JudgeBench (Tables 1 & 4, confirmed against the [v3 HTML](https://arxiv.org/html/2508.06225v3)). Majority-vote / confidence-weighted-vote = 80.00%. |
+| Method name "critique-fusion" | **CORRECTED** | The method is **LLM-as-a-Fuser** (fuses decisions *and* rationales; ships a `TH-Score` calibration metric). The ADR's "critique-fusion" label was a misremember; the decoy papers 2508.16889 (ObjexMT) and 2601.05420 (single-judge debiasing) report neither the method nor these numbers. |
+| Verdict–evidence decoupling / post-hoc rationalization is an established LLM-judge pathology | **VERIFIED** | Multi-paper finding: superficial cues drive verdicts the rationale never mentions; judges trust asserted reasoning over observable evidence. Directly supports Parts 1–3. |
+| Structured rationale *alone* fixes it | **REFUTED (important nuance)** | Free-text/JSON rationale does **not** close the gap; a protocol that **locks cited evidence BEFORE scoring** ("Proof-Before-Preference") substantially reduces rationalization. ⇒ Part 1 must emit findings *before* the verdict, not alongside it. |
+| LLM judges are overconfident / miscalibrated; reasoning models are better-calibrated judges | **VERIFIED** | Overconfidence documented (2508.06225 + others); reasoning/extended-CoT models strictly better calibrated in 33/36 model×dataset settings — corroborates the observed "high tier converges, balanced tier churns". |
+| Critique/evidence **fusion is *necessary*** to beat independent tallying | **MIXED — do not overclaim** | Some fusion aggregators beat tallying, but PoLL ("Replacing Judges with Juries", arXiv [2404.18796](https://arxiv.org/abs/2404.18796)) shows a **diverse panel with simple independent voting already beats a single strong judge, ~7× cheaper**. llm-council already does diverse-panel tallying. ⇒ Part 5 is "does the Fuser beat our *existing panel*", not "adopt fusion". |
 
 ## Decision (proposed)
 
@@ -97,6 +113,15 @@ Populate `blocking_issues` from `findings` filtered to
 fallback for models that don't return structured findings, and mark that
 fallback in the response so consumers know the channel degraded.
 
+**Findings precede the verdict (evidence-locking).** Research verification
+refuted the weaker version of this decision: a structured rationale *emitted
+alongside* the verdict does not fix decoupling — the judge still rationalizes
+post-hoc. The chairman must be prompted to enumerate `findings` (with cited
+locations) *before* committing the go/no-go, so the verdict is a function of
+the findings rather than the findings a justification of the verdict
+("Proof-Before-Preference"). This is a prompt-ordering constraint, not just a
+schema change.
+
 ### 2. Verdict–evidence consistency guard
 
 When `verdict == fail` (or `unclear`) but `findings` is empty, the result is
@@ -120,13 +145,23 @@ drop its weight in the code-review rubric profile, or redefine it as a
 code-relevant axis (e.g. "tests/edge-cases covered"). A non-signal dimension
 must not carry a fifth of the weighted score.
 
-### 5. (Spike) critique-fusion aggregation
+### 5. (Spike) evaluate a fuser aggregator against our existing panel
 
-Evaluate replacing independent-verdict tallying with a critique-fusion
-aggregator (one strong fuser synthesizing member critiques). The literature
-(arXiv 2508.06225v2: 86.3% acc / 6.4% ECE vs 77.4% best-single) and the
-corpus (high-tier synthesis quality drove verdict quality) both point this
-way. Scoped as a research spike, not part of the core change.
+Evaluate whether an **LLM-as-a-Fuser** aggregator (one strong model fusing the
+panel's decisions *and* rationales — Tian et al., arXiv 2508.06225: 86.29% acc
+/ 6.42% ECE vs 77.43% for the best single judge on JudgeBench) beats
+llm-council's **current** diverse-panel independent tallying.
+
+Framed carefully, because the research verification found the "fusion is
+necessary" premise is **mixed**: PoLL ("Replacing Judges with Juries", arXiv
+2404.18796) shows a diverse panel with *simple independent voting* already
+beats a single strong judge ~7× cheaper — and that is essentially what
+llm-council already does. So the question is not "single judge → fusion" (a
+straw man; we don't use a single judge) but "existing panel-tallying → fusion:
+does it add enough calibration/accuracy to justify the extra synthesis cost?"
+A research spike with a cost/quality gate, not a committed change. Note the
+2508.06225 baseline is *Self-Confidence* (a per-judge confidence method), not
+self-consistency.
 
 ## Consequences
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,7 @@ nav:
       - ADR-049 Prompt Caching: adr/ADR-049-prompt-caching-across-gateways.md
       - ADR-050 PostHog LLM Analytics: adr/ADR-050-posthog-llm-analytics-emission.md
       - ADR-051 Verify Findings Channel: adr/ADR-051-verify-findings-channel.md
+      - ADR-051 Implementation Spec: adr/ADR-051-implementation-spec.md
     - Roadmap 2026-H2: roadmap-2026-h2.md
     - Stateless Audit (ADR-045 P3): adr-045-p3-state-inventory.md
   - Reference:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,6 +138,7 @@ nav:
       - ADR-048 Quality Benchmark: adr/ADR-048-quality-benchmark.md
       - ADR-049 Prompt Caching: adr/ADR-049-prompt-caching-across-gateways.md
       - ADR-050 PostHog LLM Analytics: adr/ADR-050-posthog-llm-analytics-emission.md
+      - ADR-051 Verify Findings Channel: adr/ADR-051-verify-findings-channel.md
     - Roadmap 2026-H2: roadmap-2026-h2.md
     - Stateless Audit (ADR-045 P3): adr-045-p3-state-inventory.md
   - Reference:


### PR DESCRIPTION
Captures the maintainer triage of the epic-loop field report as a Draft ADR. Tracks #482.

## Why
`verify()`'s `blocking_issues` is `[]` on effectively every call (pass/fail/unclear) — confirmed on two independent corpora (epic-loop's 25-call log + this repo's ADR-049/050 delivery). Root cause: the **verdict** comes from the structured ADR-025b BINARY `VerdictResult`, while **`blocking_issues`** is regex-scraped from chairman *prose* that modern models (gemini-3.1-pro, opus-4.8) don't format with `SEVERITY:` markers. Two decoupled sources ⇒ rejection with no machine-readable justification (the classic LLM-judge verdict–evidence decoupling).

## Proposes
1. **P0 — structured `findings[]` channel** from the chairman; populate `blocking_issues` from that, not prose regex (regex kept as a flagged fallback).
2. Verdict–evidence consistency guard (`fail` + empty findings ⇒ mismatch marker).
3. Surface `inner_verdict`/`inner_confidence` on softened UNCLEAR.
4. Recalibrate `completeness` (0.20 weight, non-discriminating for code review).
5. (Spike) critique-fusion aggregation.

**Behavior change to version:** `blocking_issues` semantics change (today `[]`, after: real findings on FAIL).

Status: **Draft** — ready for the ADR-049/050-style review/research cycle (deep-research + council) before `/adr-epic`. Code references verified against master; see #482 for the full triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E43uRciABobxwpUCHPQAwh