### PR TITLE
feat(verify): ADR-051 C1 — flag + additive findings/diagnostics schema (1/6)

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -128,6 +128,7 @@
 | `LLM_COUNCIL_SCREENING` | Screening judge: off / shadow / active (ADR-047 P3) | off |
 | `LLM_COUNCIL_SCREEN_MAX_CHARS` | Screening eligibility: max content chars | 5000 |
 | `LLM_COUNCIL_SCREEN_MIN_SCORE` | Screening unanimity minimum per dimension | 9 |
+| `LLM_COUNCIL_STRUCTURED_FINDINGS` | ADR-051 structured findings channel: the chairman emits severity-tagged findings and the verdict is derived from them (`blocking_issues` = critical subset). Off by default — additive/opt-in until a later breaking default-ON flip | false |
 | `LLM_COUNCIL_TIMEOUT_MULTIPLIER` | Verification global-deadline multiplier (ADR-040) | 2.0 |
 | `LLM_COUNCIL_TRANSCRIPT_PATH` | Verification transcript root | .council/logs |
 

--- a/src/llm_council/verification/findings.py
+++ b/src/llm_council/verification/findings.py
@@ -1,0 +1,23 @@
+"""Structured findings channel (ADR-051) — flag + (later) parser/policy.
+
+C1 (#485) adds only the opt-in flag; C2 adds the chairman findings parser and
+C3 the deterministic verdict policy (`policy(findings)`). The whole epic is
+gated on ``LLM_COUNCIL_STRUCTURED_FINDINGS`` (default OFF) so it is additive and
+non-breaking until a later deliberate default-ON flip (a breaking release).
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = ["structured_findings_enabled"]
+
+
+def structured_findings_enabled() -> bool:
+    """Opt-in flag for the ADR-051 structured findings channel (default OFF)."""
+    return os.getenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "false").strip().lower() not in (
+        "false",
+        "0",
+        "no",
+        "",
+    )

--- a/src/llm_council/verification/schemas.py
+++ b/src/llm_council/verification/schemas.py
@@ -284,6 +284,51 @@ class BlockingIssueResponse(BaseModel):
     location: Optional[str] = Field(default=None, description="File/line location")
 
 
+class Finding(BaseModel):
+    """A structured finding from the chairman (ADR-051).
+
+    The full severity range; ``blocking_issues`` is derived from the
+    ``critical`` subset (C3). Same shape as ``BlockingIssueResponse`` plus a
+    ``dimension`` link, so object→object with no type break.
+    """
+
+    severity: Literal["critical", "major", "minor", "info"] = Field(
+        ..., description="critical | major | minor | info"
+    )
+    description: str = Field(..., description="Finding description")
+    location: Optional[str] = Field(
+        default=None, description="File/line ('file.py:42') or 'global'/None for holistic"
+    )
+    dimension: Optional[str] = Field(
+        default=None, description="Rubric axis this finding maps to, when derivable"
+    )
+
+
+class VerifyDiagnostics(BaseModel):
+    """Telemetry-only diagnostics (ADR-051) — NOT control flow.
+
+    Nested so consumers don't parse ``inner_verdict`` to bypass the
+    low-confidence gate. ``verdict_evidence_mismatch`` is a defensive invariant
+    assertion (should never fire under the mechanical gate).
+    """
+
+    inner_verdict: Optional[str] = Field(
+        default=None, description="Structured verdict before UNCLEAR softening"
+    )
+    inner_confidence: Optional[float] = Field(default=None, ge=0, le=1)
+    inner_confidence_calibrated: Optional[float] = Field(default=None, ge=0, le=1)
+    verdict_evidence_mismatch: Optional[str] = Field(
+        default=None, description="Invariant assertion marker; None in normal operation"
+    )
+    findings_source: Literal["structured", "fallback"] = Field(
+        default="fallback", description="Where findings came from"
+    )
+    fallback_reason: Optional[str] = Field(default=None)
+    verdict_source: Literal["mechanical", "legacy"] = Field(
+        default="legacy", description="mechanical = policy(findings); legacy = prose parse"
+    )
+
+
 class VerifyResponse(BaseModel):
     """Response body for POST /v1/council/verify."""
 
@@ -297,7 +342,17 @@ class VerifyResponse(BaseModel):
     )
     blocking_issues: List[BlockingIssueResponse] = Field(
         default_factory=list,
-        description="Issues that caused FAIL verdict",
+        description="Issues that caused FAIL verdict (the critical subset of findings)",
+    )
+    # ADR-051 (#485): additive structured findings channel. Empty until the
+    # LLM_COUNCIL_STRUCTURED_FINDINGS flag emits them (C2); non-breaking.
+    findings: List[Finding] = Field(
+        default_factory=list,
+        description="Full structured findings (all severities); blocking_issues = critical subset",
+    )
+    diagnostics: VerifyDiagnostics = Field(
+        default_factory=VerifyDiagnostics,
+        description="Telemetry-only diagnostics (inner verdict, findings_source, ...) — not control flow",
     )
     rationale: str = Field(..., description="Chairman synthesis explanation")
     transcript_location: str = Field(..., description="Path to verification transcript")

--- a/tests/test_verify_findings_schema.py
+++ b/tests/test_verify_findings_schema.py
@@ -1,0 +1,90 @@
+"""ADR-051 C1 (#485): flag + additive findings/diagnostics schema (foundation).
+
+The whole ADR-051 epic ships behind LLM_COUNCIL_STRUCTURED_FINDINGS (default
+off). C1 adds only the schema + flag — no emission yet (C2) — so it is purely
+additive and non-breaking: the new response fields default empty and no
+existing field changes.
+"""
+
+import pytest
+
+from llm_council.verification.findings import structured_findings_enabled
+from llm_council.verification.schemas import (
+    Finding,
+    VerifyDiagnostics,
+    VerifyResponse,
+)
+
+
+class TestFlag:
+    def test_default_off(self, monkeypatch):
+        monkeypatch.delenv("LLM_COUNCIL_STRUCTURED_FINDINGS", raising=False)
+        assert structured_findings_enabled() is False
+
+    def test_on(self, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "true")
+        assert structured_findings_enabled() is True
+
+    def test_falsey_values_off(self, monkeypatch):
+        for v in ("false", "0", "no", ""):
+            monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", v)
+            assert structured_findings_enabled() is False
+
+
+class TestFindingModel:
+    def test_minimal(self):
+        f = Finding(severity="critical", description="null deref at line 42")
+        assert f.severity == "critical"
+        assert f.location is None and f.dimension is None
+
+    def test_full(self):
+        f = Finding(severity="major", description="d", location="x.py:10",
+                    dimension="correctness")
+        assert f.location == "x.py:10"
+
+    def test_severity_is_constrained(self):
+        with pytest.raises(Exception):
+            Finding(severity="blocker", description="d")  # not in the enum
+
+    def test_all_severities_valid(self):
+        for s in ("critical", "major", "minor", "info"):
+            assert Finding(severity=s, description="d").severity == s
+
+
+class TestDiagnosticsModel:
+    def test_defaults(self):
+        d = VerifyDiagnostics()
+        assert d.inner_verdict is None
+        assert d.findings_source == "fallback"
+        assert d.verdict_source == "legacy"
+        assert d.verdict_evidence_mismatch is None
+
+
+class TestVerifyResponseAdditive:
+    def _base(self, **kw):
+        base = dict(
+            verification_id="v1", verdict="pass", confidence=0.9, exit_code=0,
+            rationale="ok", transcript_location="/tmp/t",
+        )
+        base.update(kw)
+        return VerifyResponse(**base)
+
+    def test_new_fields_default_empty(self):
+        # Additive + non-breaking: absent findings/diagnostics ⇒ empty defaults,
+        # existing fields untouched.
+        r = self._base()
+        assert r.findings == []
+        assert isinstance(r.diagnostics, VerifyDiagnostics)
+        assert r.blocking_issues == []  # unchanged
+        assert r.verdict == "pass"
+
+    def test_accepts_populated_findings(self):
+        r = self._base(findings=[Finding(severity="critical", description="d")])
+        assert r.findings[0].severity == "critical"
+
+    def test_existing_contract_unchanged(self):
+        # A pre-C1 payload (no findings/diagnostics keys) still validates.
+        r = self._base(verdict="fail", exit_code=1,
+                       blocking_issues=[{"severity": "critical", "description": "x"}])
+        assert r.verdict == "fail"
+        assert r.blocking_issues[0].severity == "critical"


### PR DESCRIPTION
Closes #485 (epic #484, ADR-051 C1 — foundation).

## What
Additive, non-breaking foundation for the mechanical-gate findings channel — gated on `LLM_COUNCIL_STRUCTURED_FINDINGS` (**default OFF**), no emission yet (C2), so existing fields are unchanged and the new response fields default empty.

- `verification/findings.py`: `structured_findings_enabled()` (the module C2/C3 extend with the parser + verdict policy).
- `schemas.py`: `Finding {severity(critical|major|minor|info), description, location?, dimension?}`, `VerifyDiagnostics` (telemetry-only), and additive `VerifyResponse.findings` / `.diagnostics` (empty defaults). `blocking_issues` type **unchanged** (`List[BlockingIssueResponse]`) — object→object, no break.
- Env reference documents the flag.

## Tests (11)
flag default-off/on/falsey; `Finding` validation + severity enum; `VerifyDiagnostics` defaults; `VerifyResponse` additive-empty + still accepts a pre-C1 payload.

## Gates
`make lint` clean · `make test-fast` 3288 passed. Council to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E43uRciABobxwpUCHPQAwh