### PR TITLE
feat(verify): ADR-051 C2 — structured findings emission behind flag (2/6)

### DIFF
--- a/src/llm_council/verdict.py
+++ b/src/llm_council/verdict.py
@@ -449,6 +449,34 @@ def _get_binary_chairman_prompt(
 ) -> str:
     """Generate chairman prompt for binary verdict mode."""
     dispositions_block = dispositions_instruction or ""
+
+    # ADR-051 C2: behind the flag, ask the chairman to enumerate structured
+    # findings FIRST, then the verdict — so the verdict is grounded in the
+    # findings ("Proof-Before-Preference"). Lazy import avoids a module cycle.
+    from llm_council.verification.findings import structured_findings_enabled
+
+    if structured_findings_enabled():
+        findings_instruction = (
+            "First enumerate every concrete finding, THEN render the verdict as a"
+            " function of those findings. Use severity `critical` for anything"
+            " that should block approval.\n\n"
+        )
+        json_schema = """{
+  "findings": [
+    {"severity": "critical|major|minor|info", "description": "...", "location": "file.py:line or null"}
+  ],
+  "verdict": "approved" or "rejected",
+  "confidence": 0.0 to 1.0,
+  "rationale": "Brief explanation grounded in the findings above"
+}"""
+    else:
+        findings_instruction = ""
+        json_schema = """{
+  "verdict": "approved" or "rejected",
+  "confidence": 0.0 to 1.0,
+  "rationale": "Brief explanation of the decision basis"
+}"""
+
     return f"""You are the Chairman synthesizing the council's deliberation.
 
 The council has reviewed and ranked responses to the following query:
@@ -467,12 +495,8 @@ Consider:
 RANKINGS SUMMARY:
 {rankings}
 {dispositions_block}
-Output ONLY valid JSON with no additional text:
-{{
-  "verdict": "approved" or "rejected",
-  "confidence": 0.0 to 1.0,
-  "rationale": "Brief explanation of the decision basis"
-}}"""
+{findings_instruction}Output ONLY valid JSON with no additional text:
+{json_schema}"""
 
 
 def _get_tie_breaker_chairman_prompt(

--- a/src/llm_council/verification/api.py
+++ b/src/llm_council/verification/api.py
@@ -721,6 +721,10 @@ async def _run_verification_pipeline(
         "unclear_reason": unclear_reason,
         "rubric_scores": verification_output["rubric_scores"],
         "blocking_issues": verification_output["blocking_issues"],
+        # ADR-051 (#486): structured findings + telemetry diagnostics (empty
+        # defaults when the flag is off ⇒ additive, non-breaking).
+        "findings": verification_output.get("findings", []),
+        "diagnostics": verification_output.get("diagnostics", {}),
         "rationale": verification_output["rationale"],
         "transcript_location": str(transcript_dir),
         "partial": False,

--- a/src/llm_council/verification/findings.py
+++ b/src/llm_council/verification/findings.py
@@ -64,12 +64,16 @@ def _extract_json_object(text: str) -> Any:
 
 
 def structured_findings_enabled() -> bool:
-    """Opt-in flag for the ADR-051 structured findings channel (default OFF)."""
-    return os.getenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "false").strip().lower() not in (
-        "false",
-        "0",
-        "no",
-        "",
+    """Opt-in flag for the ADR-051 structured findings channel (default OFF).
+
+    Explicit true-set (not "anything but false"): a default-OFF flag must
+    require a deliberate opt-in, so a typo can never silently enable it.
+    """
+    return os.getenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
     )
 
 
@@ -113,13 +117,16 @@ def parse_findings(
         severity = str(item.get("severity", "")).strip().lower()
         if severity not in _VALID_SEVERITIES:
             severity = "major"  # visible, never dropped
+        # `is not None` (not truthiness): keep a present-but-falsy value like
+        # 0/false rather than silently discarding it.
         location = item.get("location")
+        dimension = item.get("dimension")
         findings.append(
             Finding(
                 severity=severity,  # type: ignore[arg-type]
                 description=str(description),
-                location=str(location) if location else None,
-                dimension=(str(item["dimension"]) if item.get("dimension") else None),
+                location=str(location) if location is not None else None,
+                dimension=str(dimension) if dimension is not None else None,
             )
         )
     return findings, "structured", None

--- a/src/llm_council/verification/findings.py
+++ b/src/llm_council/verification/findings.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 from typing import Any, List, Optional, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -19,7 +18,6 @@ if TYPE_CHECKING:
 __all__ = ["structured_findings_enabled", "parse_findings"]
 
 _VALID_SEVERITIES = {"critical", "major", "minor", "info"}
-_FENCED_JSON = re.compile(r"```(?:json)?\s*(\{.*\})\s*```", re.DOTALL)
 
 
 def _extract_json_object(text: str) -> Any:
@@ -27,26 +25,36 @@ def _extract_json_object(text: str) -> Any:
 
     Unlike the flat verdict extractor (`verdict._extract_json_from_text`, whose
     `\\{[^{}]*\\}` pattern breaks on nested arrays of objects), this handles the
-    `findings` array via balanced-brace matching. Raises on no valid object.
+    `findings` array. It first tries the whole string, then scans for the first
+    balanced ``{…}`` with a **string-aware** matcher (braces inside JSON string
+    values, and escaped quotes, are ignored — a naive brace count miscounts a
+    description like ``"use {x}"``). No greedy regex (which spans multiple
+    fenced blocks). Raises on no valid object; the caller soft-fails.
     """
     stripped = text.strip()
-    m = _FENCED_JSON.search(stripped)
-    if m:
-        try:
-            return json.loads(m.group(1))
-        except json.JSONDecodeError:
-            pass
     try:
-        return json.loads(stripped)
+        return json.loads(stripped)  # fast path: the whole thing is JSON
     except json.JSONDecodeError:
         pass
     start = stripped.find("{")
     if start == -1:
         raise ValueError("no JSON object found")
     depth = 0
+    in_string = False
+    escaped = False
     for i in range(start, len(stripped)):
         c = stripped[i]
-        if c == "{":
+        if in_string:
+            if escaped:
+                escaped = False
+            elif c == "\\":
+                escaped = True
+            elif c == '"':
+                in_string = False
+            continue
+        if c == '"':
+            in_string = True
+        elif c == "{":
             depth += 1
         elif c == "}":
             depth -= 1
@@ -98,7 +106,9 @@ def parse_findings(
         if not isinstance(item, dict):
             continue
         description = item.get("description")
-        if not description:
+        # Skip only genuinely-empty descriptions (None / blank) — a useless
+        # finding, not data loss. Anything else is stringified below.
+        if description is None or str(description).strip() == "":
             continue
         severity = str(item.get("severity", "")).strip().lower()
         if severity not in _VALID_SEVERITIES:

--- a/src/llm_council/verification/findings.py
+++ b/src/llm_council/verification/findings.py
@@ -8,9 +8,51 @@ non-breaking until a later deliberate default-ON flip (a breaking release).
 
 from __future__ import annotations
 
+import json
 import os
+import re
+from typing import Any, List, Optional, Tuple, TYPE_CHECKING
 
-__all__ = ["structured_findings_enabled"]
+if TYPE_CHECKING:
+    from .schemas import Finding
+
+__all__ = ["structured_findings_enabled", "parse_findings"]
+
+_VALID_SEVERITIES = {"critical", "major", "minor", "info"}
+_FENCED_JSON = re.compile(r"```(?:json)?\s*(\{.*\})\s*```", re.DOTALL)
+
+
+def _extract_json_object(text: str) -> Any:
+    """Extract a (possibly nested) JSON object from chairman text.
+
+    Unlike the flat verdict extractor (`verdict._extract_json_from_text`, whose
+    `\\{[^{}]*\\}` pattern breaks on nested arrays of objects), this handles the
+    `findings` array via balanced-brace matching. Raises on no valid object.
+    """
+    stripped = text.strip()
+    m = _FENCED_JSON.search(stripped)
+    if m:
+        try:
+            return json.loads(m.group(1))
+        except json.JSONDecodeError:
+            pass
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        pass
+    start = stripped.find("{")
+    if start == -1:
+        raise ValueError("no JSON object found")
+    depth = 0
+    for i in range(start, len(stripped)):
+        c = stripped[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return json.loads(stripped[start : i + 1])
+    raise ValueError("unbalanced JSON object")
 
 
 def structured_findings_enabled() -> bool:
@@ -21,3 +63,53 @@ def structured_findings_enabled() -> bool:
         "no",
         "",
     )
+
+
+def parse_findings(
+    chairman_response: str,
+) -> Tuple[List["Finding"], str, Optional[str]]:
+    """Parse the chairman JSON's ``findings`` array (ADR-051 C2).
+
+    The chairman's BINARY verdict is already JSON; C2 asks it to include a
+    ``findings`` array in that same object. Returns ``(findings, source,
+    reason)`` where ``source`` is ``"structured"`` on a clean parse (including a
+    legitimately empty list) or ``"fallback"`` with a ``reason`` when the block
+    is missing/malformed. Soft-fail: never raises — the verdict path still works
+    via the legacy route when this returns fallback.
+
+    Robustness rules: an unknown severity is coerced to ``"major"`` (visible,
+    never silently dropped — the C3 mechanical gate can't act on what it can't
+    see); items without a description, or non-dict items, are skipped.
+    """
+    from .schemas import Finding
+
+    try:
+        data = _extract_json_object(chairman_response)
+    except Exception as exc:  # unparseable ⇒ legacy fallback
+        return [], "fallback", f"json_parse:{type(exc).__name__}"
+    if not isinstance(data, dict) or "findings" not in data:
+        return [], "fallback", "no_findings_key"
+    raw = data["findings"]
+    if not isinstance(raw, list):
+        return [], "fallback", "findings_not_list"
+
+    findings: List["Finding"] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        description = item.get("description")
+        if not description:
+            continue
+        severity = str(item.get("severity", "")).strip().lower()
+        if severity not in _VALID_SEVERITIES:
+            severity = "major"  # visible, never dropped
+        location = item.get("location")
+        findings.append(
+            Finding(
+                severity=severity,  # type: ignore[arg-type]
+                description=str(description),
+                location=str(location) if location else None,
+                dimension=(str(item["dimension"]) if item.get("dimension") else None),
+            )
+        )
+    return findings, "structured", None

--- a/src/llm_council/verification/findings.py
+++ b/src/llm_council/verification/findings.py
@@ -20,30 +20,28 @@ __all__ = ["structured_findings_enabled", "parse_findings"]
 _VALID_SEVERITIES = {"critical", "major", "minor", "info"}
 
 
-def _extract_json_object(text: str) -> Any:
-    """Extract a (possibly nested) JSON object from chairman text.
-
-    Unlike the flat verdict extractor (`verdict._extract_json_from_text`, whose
-    `\\{[^{}]*\\}` pattern breaks on nested arrays of objects), this handles the
-    `findings` array. It first tries the whole string, then scans for the first
-    balanced ``{…}`` with a **string-aware** matcher (braces inside JSON string
-    values, and escaped quotes, are ignored — a naive brace count miscounts a
-    description like ``"use {x}"``). No greedy regex (which spans multiple
-    fenced blocks). Raises on no valid object; the caller soft-fails.
-    """
-    stripped = text.strip()
+def _as_text(value: Any) -> str:
+    """Stringify a field, JSON-encoding non-strings so a dict/list doesn't leak
+    a Python repr (``str({'a':1})`` → ``"{'a': 1}"``) into a description."""
+    if isinstance(value, str):
+        return value
     try:
-        return json.loads(stripped)  # fast path: the whole thing is JSON
-    except json.JSONDecodeError:
-        pass
-    start = stripped.find("{")
-    if start == -1:
-        raise ValueError("no JSON object found")
+        return json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _matching_brace(text: str, start: int) -> int:
+    """Index of the ``}`` matching the ``{`` at ``start``, string-aware, or -1.
+
+    Braces inside JSON string values and escaped quotes are ignored, so a
+    description like ``"use {x}"`` doesn't miscount.
+    """
     depth = 0
     in_string = False
     escaped = False
-    for i in range(start, len(stripped)):
-        c = stripped[i]
+    for i in range(start, len(text)):
+        c = text[i]
         if in_string:
             if escaped:
                 escaped = False
@@ -59,8 +57,39 @@ def _extract_json_object(text: str) -> Any:
         elif c == "}":
             depth -= 1
             if depth == 0:
-                return json.loads(stripped[start : i + 1])
-    raise ValueError("unbalanced JSON object")
+                return i
+    return -1
+
+
+def _extract_json_object(text: str) -> Any:
+    """Extract a JSON object from chairman text (LLM-resilient).
+
+    Unlike the flat verdict extractor (`verdict._extract_json_from_text`, whose
+    `\\{[^{}]*\\}` pattern breaks on nested arrays), this tries the whole string,
+    then walks EVERY ``{`` position and returns the FIRST balanced span that
+    parses to a dict — so a natural-language ``{brace}`` before the real JSON
+    doesn't abort the search (it just isn't a dict). String-aware brace
+    matching; no greedy regex. Raises when no candidate parses to a dict.
+    """
+    stripped = text.strip()
+    try:
+        obj = json.loads(stripped)  # fast path: the whole thing is JSON
+        if isinstance(obj, dict):
+            return obj
+    except json.JSONDecodeError:
+        pass
+    idx = stripped.find("{")
+    while idx != -1:
+        end = _matching_brace(stripped, idx)
+        if end != -1:
+            try:
+                obj = json.loads(stripped[idx : end + 1])
+                if isinstance(obj, dict):
+                    return obj
+            except json.JSONDecodeError:
+                pass
+        idx = stripped.find("{", idx + 1)
+    raise ValueError("no JSON object found")
 
 
 def structured_findings_enabled() -> bool:
@@ -124,9 +153,11 @@ def parse_findings(
         findings.append(
             Finding(
                 severity=severity,  # type: ignore[arg-type]
-                description=str(description),
-                location=str(location) if location is not None else None,
-                dimension=str(dimension) if dimension is not None else None,
+                # A dict/list description would leak a Python repr via str();
+                # JSON-encode non-strings so the text stays valid data.
+                description=_as_text(description),
+                location=_as_text(location) if location is not None else None,
+                dimension=_as_text(dimension) if dimension is not None else None,
             )
         )
     return findings, "structured", None

--- a/src/llm_council/verification/verdict_extractor.py
+++ b/src/llm_council/verification/verdict_extractor.py
@@ -406,7 +406,7 @@ def build_verification_result(
     # extractors — a missing/None stage3_result must not raise, #434 review)
     rationale = (stage3_result or {}).get("response") or "No synthesis available."
 
-    return {
+    result = {
         "verdict": verdict,
         "confidence": confidence,
         # ADR-047 P2: None when no calibrator was applied here — the API
@@ -416,6 +416,26 @@ def build_verification_result(
         "blocking_issues": blocking_issues,
         "rationale": rationale,
     }
+
+    # ADR-051 C2 (#486): behind the flag, emit the chairman's structured
+    # findings + diagnostics. Verdict/blocking_issues still come from the legacy
+    # path in C2 (the mechanical verdict is C3); soft-fail to fallback.
+    from .findings import parse_findings, structured_findings_enabled
+
+    findings_dicts: List[Dict[str, Any]] = []
+    diagnostics: Dict[str, Any] = {"findings_source": "fallback", "verdict_source": "legacy"}
+    if structured_findings_enabled():
+        try:
+            parsed, source, reason = parse_findings((stage3_result or {}).get("response") or "")
+            findings_dicts = [f.model_dump() for f in parsed]
+            diagnostics["findings_source"] = source
+            if reason:
+                diagnostics["fallback_reason"] = reason
+        except Exception:  # telemetry must never break a verdict
+            diagnostics["fallback_reason"] = "findings_exception"
+    result["findings"] = findings_dicts
+    result["diagnostics"] = diagnostics
+    return result
 
 
 def derive_unclear_reason(

--- a/tests/test_findings_parser.py
+++ b/tests/test_findings_parser.py
@@ -98,3 +98,24 @@ class TestBuildResultWiring:
         r = build_verification_result([], [], self._stage3("no json here"))
         assert r["diagnostics"]["findings_source"] == "fallback"
         assert "fallback_reason" in r["diagnostics"]
+
+
+class TestExtractionRobustness:
+    def test_braces_inside_string_values(self):
+        # A description containing braces must not break brace-matching.
+        text = '{"verdict":"rejected","confidence":0.9,"rationale":"r",' \
+               '"findings":[{"severity":"critical","description":"use {x} and }{ here"}]}'
+        findings, source, _ = parse_findings(text)
+        assert source == "structured"
+        assert findings[0].description == "use {x} and }{ here"
+
+    def test_escaped_quote_in_string(self):
+        text = r'{"findings":[{"severity":"minor","description":"a \"quoted\" bit"}]}'
+        findings, source, _ = parse_findings(text)
+        assert source == "structured" and '"quoted"' in findings[0].description
+
+    def test_multiple_fenced_blocks_takes_first_object(self):
+        text = 'first:\n```json\n{"findings":[{"severity":"info","description":"d"}]}\n```\n' \
+               'second:\n```json\n{"other":1}\n```'
+        findings, source, _ = parse_findings(text)
+        assert source == "structured" and len(findings) == 1

--- a/tests/test_findings_parser.py
+++ b/tests/test_findings_parser.py
@@ -1,0 +1,100 @@
+"""ADR-051 C2 (#486): parse structured findings from the chairman JSON.
+
+The chairman's BINARY verdict is already JSON (parse_binary_verdict); C2 adds a
+`findings` array to that JSON and parses it. Soft-fail: a missing/malformed
+findings block degrades to `fallback` with a reason, never raises.
+"""
+
+from llm_council.verification.findings import parse_findings
+
+
+class TestParseFindings:
+    def test_well_formed(self):
+        text = '''{"verdict":"rejected","confidence":0.9,"rationale":"r",
+          "findings":[
+            {"severity":"critical","description":"null deref","location":"a.py:5"},
+            {"severity":"minor","description":"nit"}
+          ]}'''
+        findings, source, reason = parse_findings(text)
+        assert source == "structured" and reason is None
+        assert len(findings) == 2
+        assert findings[0].severity == "critical"
+        assert findings[0].location == "a.py:5"
+        assert findings[1].severity == "minor" and findings[1].location is None
+
+    def test_findings_in_fenced_json(self):
+        text = 'prose\n```json\n{"verdict":"approved","confidence":0.8,"rationale":"r",' \
+               '"findings":[{"severity":"major","description":"d"}]}\n```\ntrailing'
+        findings, source, _ = parse_findings(text)
+        assert source == "structured" and findings[0].severity == "major"
+
+    def test_no_findings_key_is_fallback(self):
+        findings, source, reason = parse_findings(
+            '{"verdict":"approved","confidence":0.8,"rationale":"r"}')
+        assert findings == [] and source == "fallback" and reason == "no_findings_key"
+
+    def test_unparseable_is_fallback(self):
+        findings, source, reason = parse_findings("not json at all")
+        assert findings == [] and source == "fallback"
+        assert reason.startswith("json_parse")
+
+    def test_findings_not_a_list_is_fallback(self):
+        findings, source, reason = parse_findings(
+            '{"verdict":"approved","confidence":0.8,"rationale":"r","findings":"oops"}')
+        assert source == "fallback" and reason == "findings_not_list"
+
+    def test_unknown_severity_coerced_visible_not_dropped(self):
+        # A blocker-ish unknown severity must stay visible (mapped to major),
+        # never silently dropped — the mechanical gate (C3) can't act on what
+        # it can't see.
+        text = '{"findings":[{"severity":"blocker","description":"d"}]}'
+        findings, source, _ = parse_findings(text)
+        assert source == "structured"
+        assert findings[0].severity == "major"  # coerced, not dropped
+
+    def test_items_without_description_skipped(self):
+        text = '{"findings":[{"severity":"critical"},{"severity":"minor","description":"d"}]}'
+        findings, source, _ = parse_findings(text)
+        assert len(findings) == 1 and findings[0].description == "d"
+
+    def test_non_dict_items_skipped(self):
+        text = '{"findings":["oops",{"severity":"info","description":"d"}]}'
+        findings, source, _ = parse_findings(text)
+        assert len(findings) == 1
+
+    def test_empty_findings_list_is_structured(self):
+        # An explicit empty list means "reviewed, nothing found" — structured.
+        findings, source, reason = parse_findings(
+            '{"verdict":"approved","confidence":0.9,"rationale":"r","findings":[]}')
+        assert findings == [] and source == "structured" and reason is None
+
+
+class TestBuildResultWiring:
+    def _stage3(self, response):
+        return {"response": response}
+
+    def test_flag_off_no_findings(self, monkeypatch):
+        monkeypatch.delenv("LLM_COUNCIL_STRUCTURED_FINDINGS", raising=False)
+        from llm_council.verification.verdict_extractor import build_verification_result
+        r = build_verification_result([], [], self._stage3(
+            '{"verdict":"rejected","confidence":0.9,"rationale":"r",'
+            '"findings":[{"severity":"critical","description":"d"}]}'))
+        assert r["findings"] == []
+        assert r["diagnostics"]["findings_source"] == "fallback"
+
+    def test_flag_on_findings_flow_through(self, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "true")
+        from llm_council.verification.verdict_extractor import build_verification_result
+        r = build_verification_result([], [], self._stage3(
+            '{"verdict":"rejected","confidence":0.9,"rationale":"r",'
+            '"findings":[{"severity":"critical","description":"boom","location":"a.py:1"}]}'))
+        assert r["diagnostics"]["findings_source"] == "structured"
+        assert len(r["findings"]) == 1
+        assert r["findings"][0]["severity"] == "critical"
+
+    def test_flag_on_malformed_is_fallback(self, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "true")
+        from llm_council.verification.verdict_extractor import build_verification_result
+        r = build_verification_result([], [], self._stage3("no json here"))
+        assert r["diagnostics"]["findings_source"] == "fallback"
+        assert "fallback_reason" in r["diagnostics"]

--- a/tests/test_findings_parser.py
+++ b/tests/test_findings_parser.py
@@ -132,3 +132,21 @@ class TestRound2Fixes:
         text = '{"findings":[{"severity":"minor","description":"d","location":0}]}'
         findings, source, _ = parse_findings(text)
         assert source == "structured" and findings[0].location == "0"
+
+
+class TestRound3Fixes:
+    def test_prose_braces_before_real_json(self):
+        # A natural-language {brace} before the real JSON must not abort the search.
+        text = 'I considered {options} carefully. Result:\n' \
+               '{"verdict":"rejected","confidence":0.9,"rationale":"r",' \
+               '"findings":[{"severity":"critical","description":"d"}]}'
+        findings, source, _ = parse_findings(text)
+        assert source == "structured" and findings[0].severity == "critical"
+
+    def test_dict_description_json_encoded_not_repr(self):
+        text = '{"findings":[{"severity":"minor","description":{"nested":"x"}}]}'
+        findings, source, _ = parse_findings(text)
+        assert source == "structured"
+        # JSON-encoded, not a Python repr ("{'nested': 'x'}")
+        assert findings[0].description == '{"nested": "x"}'
+        assert "'" not in findings[0].description

--- a/tests/test_findings_parser.py
+++ b/tests/test_findings_parser.py
@@ -119,3 +119,16 @@ class TestExtractionRobustness:
                'second:\n```json\n{"other":1}\n```'
         findings, source, _ = parse_findings(text)
         assert source == "structured" and len(findings) == 1
+
+
+class TestRound2Fixes:
+    def test_unrecognized_flag_value_is_off(self, monkeypatch):
+        from llm_council.verification.findings import structured_findings_enabled
+        for v in ("maybe", "ture", "enabled", "2"):
+            monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", v)
+            assert structured_findings_enabled() is False  # opt-in requires explicit true
+
+    def test_present_but_falsy_location_kept(self):
+        text = '{"findings":[{"severity":"minor","description":"d","location":0}]}'
+        findings, source, _ = parse_findings(text)
+        assert source == "structured" and findings[0].location == "0"


### PR DESCRIPTION
Closes #486 (epic #484, ADR-051 C2). Blocked-by #485 (merged).

## What
The chairman's BINARY verdict is already JSON, so behind `LLM_COUNCIL_STRUCTURED_FINDINGS` the prompt asks it to enumerate a `findings[]` array **first** (Proof-Before-Preference) and we parse it. **Verdict/blocking_issues still come from the legacy path in C2** — the mechanical verdict is C3.

- `findings.py` `parse_findings()`: **balanced-brace** JSON extraction (the flat verdict extractor's `\{[^{}]*\}` can't handle nested findings arrays). Soft-fail → fallback (unparseable / no-findings-key / not-a-list). Robustness: unknown severity coerced to `major` (visible, never silently dropped); description-less / non-dict items skipped; an explicit empty list is `structured`.
- `verdict.py`: findings-first JSON schema when the flag is on.
- `verdict_extractor` + `api.py`: thread `findings` + `diagnostics` into the result behind the flag; **flag-off ⇒ empty findings, byte-identical**.

## Tests (15)
parser: well-formed/fenced/nested, all fallback modes, severity coercion, skips; wiring: flag-off no-op, flag-on flow-through, malformed→fallback.

## Gates
`make lint` clean · `make test-fast` 3300 passed. Council to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E43uRciABobxwpUCHPQAwh