### PR TITLE
feat(verify): ADR-051 C3 — mechanical verdict + derive blocking_issues (3/6)

### DIFF
--- a/src/llm_council/verification/findings.py
+++ b/src/llm_council/verification/findings.py
@@ -42,7 +42,11 @@ def _normalize_severity(raw: Any) -> str:
     # Anything that LOOKS like a blocker ⇒ critical (never silently downgraded).
     if s.startswith("crit") or "block" in s or "fatal" in s or "sever" in s:
         return "critical"
-    return "major"  # unknown, non-blocker-looking: visible, not auto-failing
+    # Deliberate: a missing/blank or unrecognized-non-blocker severity ⇒ "major"
+    # (visible for human review, not auto-failing). Defaulting to "critical"
+    # here would auto-FAIL the build for any model that merely omits the field —
+    # an unusably noisy gate — while a genuine blocker is still caught above.
+    return "major"
 
 
 def verdict_policy(findings: "List[Finding]") -> str:
@@ -137,7 +141,11 @@ def _extract_json_object(text: str, preferred_key: Optional[str] = None) -> Any:
                     return hit
             except json.JSONDecodeError:
                 pass
-        idx = stripped.find("{", idx + 1)
+            # Advance PAST this whole object, not to idx+1 (which would rescan
+            # its nested braces — an O(n^2) walk).
+            idx = stripped.find("{", end + 1)
+        else:
+            idx = stripped.find("{", idx + 1)  # unbalanced from here: step by one
     if first_dict is not None:
         return first_dict
     raise ValueError("no JSON object found")

--- a/src/llm_council/verification/findings.py
+++ b/src/llm_council/verification/findings.py
@@ -19,6 +19,31 @@ __all__ = ["structured_findings_enabled", "parse_findings", "verdict_policy"]
 
 _VALID_SEVERITIES = {"critical", "major", "minor", "info"}
 
+# Severity synonyms → canonical. Because the mechanical gate (C3) fails only on
+# `critical`, an unknown blocker-ish label MUST map to critical (fail-safe) — a
+# typo of "critical" or a "fatal"/"blocker" tag silently becoming "major" would
+# be a FALSE PASS on a real blocker (Council C3 finding).
+_SEVERITY_SYNONYMS = {
+    "blocker": "critical", "blocking": "critical", "fatal": "critical",
+    "severe": "critical", "high": "critical", "error": "critical",
+    "moderate": "major", "medium": "major", "warning": "major", "warn": "major",
+    "low": "minor", "nit": "minor", "nitpick": "minor", "trivial": "minor",
+    "informational": "info", "note": "info", "notice": "info",
+}
+
+
+def _normalize_severity(raw: Any) -> str:
+    """Map a model-supplied severity to a canonical value, fail-safe for blockers."""
+    s = str(raw).strip().lower()
+    if s in _VALID_SEVERITIES:
+        return s
+    if s in _SEVERITY_SYNONYMS:
+        return _SEVERITY_SYNONYMS[s]
+    # Anything that LOOKS like a blocker ⇒ critical (never silently downgraded).
+    if s.startswith("crit") or "block" in s or "fatal" in s or "sever" in s:
+        return "critical"
+    return "major"  # unknown, non-blocker-looking: visible, not auto-failing
+
 
 def verdict_policy(findings: "List[Finding]") -> str:
     """The mechanical gate (ADR-051 C3): the verdict is a PURE function of the
@@ -72,21 +97,34 @@ def _matching_brace(text: str, start: int) -> int:
     return -1
 
 
-def _extract_json_object(text: str) -> Any:
+def _extract_json_object(text: str, preferred_key: Optional[str] = None) -> Any:
     """Extract a JSON object from chairman text (LLM-resilient).
 
     Unlike the flat verdict extractor (`verdict._extract_json_from_text`, whose
     `\\{[^{}]*\\}` pattern breaks on nested arrays), this tries the whole string,
-    then walks EVERY ``{`` position and returns the FIRST balanced span that
-    parses to a dict — so a natural-language ``{brace}`` before the real JSON
-    doesn't abort the search (it just isn't a dict). String-aware brace
-    matching; no greedy regex. Raises when no candidate parses to a dict.
+    then walks EVERY ``{`` position with string-aware brace matching. When
+    ``preferred_key`` is given it returns the first parsed dict that CONTAINS
+    that key (so a decoy object before the real verdict payload — which would
+    cause a silent empty-findings false pass, Council C3 finding — is skipped);
+    if none has the key, it returns the first dict. Raises when nothing parses.
     """
     stripped = text.strip()
-    try:
-        obj = json.loads(stripped)  # fast path: the whole thing is JSON
-        if isinstance(obj, dict):
+    first_dict: Any = None
+
+    def _consider(obj: Any) -> Optional[Any]:
+        nonlocal first_dict
+        if not isinstance(obj, dict):
+            return None
+        if preferred_key is None or preferred_key in obj:
             return obj
+        if first_dict is None:
+            first_dict = obj
+        return None
+
+    try:
+        hit = _consider(json.loads(stripped))  # fast path: the whole thing is JSON
+        if hit is not None:
+            return hit
     except json.JSONDecodeError:
         pass
     idx = stripped.find("{")
@@ -94,12 +132,14 @@ def _extract_json_object(text: str) -> Any:
         end = _matching_brace(stripped, idx)
         if end != -1:
             try:
-                obj = json.loads(stripped[idx : end + 1])
-                if isinstance(obj, dict):
-                    return obj
+                hit = _consider(json.loads(stripped[idx : end + 1]))
+                if hit is not None:
+                    return hit
             except json.JSONDecodeError:
                 pass
         idx = stripped.find("{", idx + 1)
+    if first_dict is not None:
+        return first_dict
     raise ValueError("no JSON object found")
 
 
@@ -129,14 +169,14 @@ def parse_findings(
     is missing/malformed. Soft-fail: never raises — the verdict path still works
     via the legacy route when this returns fallback.
 
-    Robustness rules: an unknown severity is coerced to ``"major"`` (visible,
-    never silently dropped — the C3 mechanical gate can't act on what it can't
-    see); items without a description, or non-dict items, are skipped.
+    Robustness: severity is normalized fail-safe (blocker-ish labels →
+    ``critical`` so the mechanical gate can't false-pass them); items without a
+    description, or non-dict items, are skipped.
     """
     from .schemas import Finding
 
     try:
-        data = _extract_json_object(chairman_response)
+        data = _extract_json_object(chairman_response, preferred_key="findings")
     except Exception as exc:  # unparseable ⇒ legacy fallback
         return [], "fallback", f"json_parse:{type(exc).__name__}"
     if not isinstance(data, dict) or "findings" not in data:
@@ -154,9 +194,7 @@ def parse_findings(
         # finding, not data loss. Anything else is stringified below.
         if description is None or str(description).strip() == "":
             continue
-        severity = str(item.get("severity", "")).strip().lower()
-        if severity not in _VALID_SEVERITIES:
-            severity = "major"  # visible, never dropped
+        severity = _normalize_severity(item.get("severity", ""))
         # `is not None` (not truthiness): keep a present-but-falsy value like
         # 0/false rather than silently discarding it.
         location = item.get("location")

--- a/src/llm_council/verification/findings.py
+++ b/src/llm_council/verification/findings.py
@@ -194,10 +194,11 @@ def parse_findings(
         if not isinstance(item, dict):
             continue
         description = item.get("description")
-        # Skip only genuinely-empty descriptions (None / blank) — a useless
-        # finding, not data loss. Anything else is stringified below.
+        # Fail-safe: NEVER drop a finding for a missing description — a critical
+        # with no text would silently vanish and false-pass. Keep it with a
+        # placeholder so its severity still gates (Council C3 finding).
         if description is None or str(description).strip() == "":
-            continue
+            description = "(no description provided)"
         severity = _normalize_severity(item.get("severity", ""))
         # `is not None` (not truthiness): keep a present-but-falsy value like
         # 0/false rather than silently discarding it.

--- a/src/llm_council/verification/findings.py
+++ b/src/llm_council/verification/findings.py
@@ -52,8 +52,16 @@ def verdict_policy(findings: "List[Finding]") -> str:
     This is the whole point of the mechanical gate: the verdict cannot be
     decoupled from the evidence because it is *computed* from it, not generated.
     Confidence-based softening to ``unclear`` is applied by the caller.
+
+    ``Finding.severity`` is a pydantic ``Literal`` so it is already canonical,
+    but we normalize defensively here too — should a ``Finding`` ever be built
+    outside ``parse_findings`` with a raw label, it must still fail closed.
     """
-    return "fail" if any(f.severity == "critical" for f in findings) else "pass"
+    return (
+        "fail"
+        if any(_normalize_severity(f.severity) == "critical" for f in findings)
+        else "pass"
+    )
 
 
 def _as_text(value: Any) -> str:

--- a/src/llm_council/verification/findings.py
+++ b/src/llm_council/verification/findings.py
@@ -19,13 +19,9 @@ __all__ = ["structured_findings_enabled", "parse_findings", "verdict_policy"]
 
 _VALID_SEVERITIES = {"critical", "major", "minor", "info"}
 
-# Severity synonyms → canonical. Because the mechanical gate (C3) fails only on
-# `critical`, an unknown blocker-ish label MUST map to critical (fail-safe) — a
-# typo of "critical" or a "fatal"/"blocker" tag silently becoming "major" would
-# be a FALSE PASS on a real blocker (Council C3 finding).
-_SEVERITY_SYNONYMS = {
-    "blocker": "critical", "blocking": "critical", "fatal": "critical",
-    "severe": "critical", "high": "critical", "error": "critical",
+# Explicit NON-critical synonyms → canonical. Everything NOT resolvable to one
+# of these (or a canonical value) fails safe to `critical` in _normalize_severity.
+_NONCRITICAL_SYNONYMS = {
     "moderate": "major", "medium": "major", "warning": "major", "warn": "major",
     "low": "minor", "nit": "minor", "nitpick": "minor", "trivial": "minor",
     "informational": "info", "note": "info", "notice": "info",
@@ -33,20 +29,20 @@ _SEVERITY_SYNONYMS = {
 
 
 def _normalize_severity(raw: Any) -> str:
-    """Map a model-supplied severity to a canonical value, fail-safe for blockers."""
+    """Map a model-supplied severity to a canonical value, **fail-safe** for a gate.
+
+    The mechanical gate (C3) fails only on ``critical``, so anything ambiguous
+    must map UP, not down: a missing/blank field, a typo of "critical", a
+    "blocker"/"fatal" tag, or any unrecognized label ⇒ ``critical`` — a real
+    blocker can never silently false-pass (Council C3 finding, 3-round
+    consensus). Only an EXPLICIT known non-critical label is downgraded.
+    """
     s = str(raw).strip().lower()
     if s in _VALID_SEVERITIES:
         return s
-    if s in _SEVERITY_SYNONYMS:
-        return _SEVERITY_SYNONYMS[s]
-    # Anything that LOOKS like a blocker ⇒ critical (never silently downgraded).
-    if s.startswith("crit") or "block" in s or "fatal" in s or "sever" in s:
-        return "critical"
-    # Deliberate: a missing/blank or unrecognized-non-blocker severity ⇒ "major"
-    # (visible for human review, not auto-failing). Defaulting to "critical"
-    # here would auto-FAIL the build for any model that merely omits the field —
-    # an unusably noisy gate — while a genuine blocker is still caught above.
-    return "major"
+    if s in _NONCRITICAL_SYNONYMS:
+        return _NONCRITICAL_SYNONYMS[s]
+    return "critical"  # missing / unrecognized ⇒ fail closed
 
 
 def verdict_policy(findings: "List[Finding]") -> str:

--- a/src/llm_council/verification/findings.py
+++ b/src/llm_council/verification/findings.py
@@ -15,9 +15,20 @@ from typing import Any, List, Optional, Tuple, TYPE_CHECKING
 if TYPE_CHECKING:
     from .schemas import Finding
 
-__all__ = ["structured_findings_enabled", "parse_findings"]
+__all__ = ["structured_findings_enabled", "parse_findings", "verdict_policy"]
 
 _VALID_SEVERITIES = {"critical", "major", "minor", "info"}
+
+
+def verdict_policy(findings: "List[Finding]") -> str:
+    """The mechanical gate (ADR-051 C3): the verdict is a PURE function of the
+    findings — ``"fail"`` iff any finding is ``critical``, else ``"pass"``.
+
+    This is the whole point of the mechanical gate: the verdict cannot be
+    decoupled from the evidence because it is *computed* from it, not generated.
+    Confidence-based softening to ``unclear`` is applied by the caller.
+    """
+    return "fail" if any(f.severity == "critical" for f in findings) else "pass"
 
 
 def _as_text(value: Any) -> str:

--- a/src/llm_council/verification/verdict_extractor.py
+++ b/src/llm_council/verification/verdict_extractor.py
@@ -417,10 +417,11 @@ def build_verification_result(
         "rationale": rationale,
     }
 
-    # ADR-051 C2 (#486): behind the flag, emit the chairman's structured
-    # findings + diagnostics. Verdict/blocking_issues still come from the legacy
-    # path in C2 (the mechanical verdict is C3); soft-fail to fallback.
-    from .findings import parse_findings, structured_findings_enabled
+    # ADR-051 (#486 C2 emission / #487 C3 mechanical verdict): behind the flag,
+    # parse the chairman's structured findings and — when they parse cleanly —
+    # DERIVE the verdict and blocking_issues from them (the mechanical gate),
+    # replacing the legacy prose-scraped values. Soft-fail to the legacy path.
+    from .findings import parse_findings, structured_findings_enabled, verdict_policy
 
     findings_dicts: List[Dict[str, Any]] = []
     diagnostics: Dict[str, Any] = {"findings_source": "fallback", "verdict_source": "legacy"}
@@ -431,6 +432,25 @@ def build_verification_result(
             diagnostics["findings_source"] = source
             if reason:
                 diagnostics["fallback_reason"] = reason
+            if source == "structured":
+                # C3 mechanical gate: verdict = policy(findings) (pure host
+                # code); blocking_issues = the critical subset. The confidence
+                # softening to "unclear" is the SAME rule as the legacy path.
+                mechanical = verdict_policy(parsed)
+                eff = calibrate(confidence) if calibrate is not None else confidence
+                if mechanical == "pass" and eff < confidence_threshold:
+                    mechanical = "unclear"
+                result["verdict"] = mechanical
+                result["blocking_issues"] = [
+                    {
+                        "severity": f.severity,
+                        "description": f.description,
+                        "location": f.location,
+                    }
+                    for f in parsed
+                    if f.severity == "critical"
+                ]
+                diagnostics["verdict_source"] = "mechanical"
         except Exception:  # telemetry must never break a verdict
             diagnostics["fallback_reason"] = "findings_exception"
     result["findings"] = findings_dicts

--- a/tests/test_findings_parser.py
+++ b/tests/test_findings_parser.py
@@ -166,3 +166,17 @@ class TestC3Fixes:
         findings, source, _ = parse_findings(text)
         assert source == "structured"
         assert len(findings) == 1 and findings[0].description == "real"
+
+
+class TestC3Round2:
+    def test_multiple_sequential_objects_scanned_efficiently(self):
+        # Several decoy objects before the payload — must still find it.
+        decoys = "".join('{"x":%d}\n' % i for i in range(20))
+        text = decoys + '{"findings":[{"severity":"critical","description":"real"}]}'
+        findings, source, _ = parse_findings(text)
+        assert source == "structured" and findings[0].description == "real"
+
+    def test_missing_severity_is_major(self):
+        text = '{"findings":[{"description":"no severity field"}]}'
+        findings, _, _ = parse_findings(text)
+        assert findings[0].severity == "major"

--- a/tests/test_findings_parser.py
+++ b/tests/test_findings_parser.py
@@ -62,10 +62,13 @@ class TestParseFindings:
             findings, _, _ = parse_findings(text)
             assert findings[0].severity == want
 
-    def test_items_without_description_skipped(self):
+    def test_description_less_finding_kept_with_placeholder(self):
+        # Fail-safe: a critical with no description must NOT vanish.
         text = '{"findings":[{"severity":"critical"},{"severity":"minor","description":"d"}]}'
         findings, source, _ = parse_findings(text)
-        assert len(findings) == 1 and findings[0].description == "d"
+        assert len(findings) == 2
+        crit = [f for f in findings if f.severity == "critical"][0]
+        assert crit.description == "(no description provided)"
 
     def test_non_dict_items_skipped(self):
         text = '{"findings":["oops",{"severity":"info","description":"d"}]}'

--- a/tests/test_findings_parser.py
+++ b/tests/test_findings_parser.py
@@ -43,14 +43,18 @@ class TestParseFindings:
             '{"verdict":"approved","confidence":0.8,"rationale":"r","findings":"oops"}')
         assert source == "fallback" and reason == "findings_not_list"
 
-    def test_unknown_severity_coerced_visible_not_dropped(self):
-        # A blocker-ish unknown severity must stay visible (mapped to major),
-        # never silently dropped — the mechanical gate (C3) can't act on what
-        # it can't see.
-        text = '{"findings":[{"severity":"blocker","description":"d"}]}'
-        findings, source, _ = parse_findings(text)
-        assert source == "structured"
-        assert findings[0].severity == "major"  # coerced, not dropped
+    def test_blocker_synonym_maps_to_critical_failsafe(self):
+        # C3 fail-safe: a blocker-ish label must map to CRITICAL, not major —
+        # else the mechanical gate (fails only on critical) false-passes it.
+        for sev in ("blocker", "fatal", "critcal", "BLOCKING"):
+            text = '{"findings":[{"severity":"%s","description":"d"}]}' % sev
+            findings, source, _ = parse_findings(text)
+            assert source == "structured" and findings[0].severity == "critical"
+
+    def test_unknown_non_blocker_severity_is_major(self):
+        text = '{"findings":[{"severity":"weird","description":"d"}]}'
+        findings, _, _ = parse_findings(text)
+        assert findings[0].severity == "major"
 
     def test_items_without_description_skipped(self):
         text = '{"findings":[{"severity":"critical"},{"severity":"minor","description":"d"}]}'
@@ -150,3 +154,15 @@ class TestRound3Fixes:
         # JSON-encoded, not a Python repr ("{'nested': 'x'}")
         assert findings[0].description == '{"nested": "x"}'
         assert "'" not in findings[0].description
+
+
+class TestC3Fixes:
+    def test_prefers_findings_bearing_object_over_decoy(self):
+        # A decoy JSON object before the real payload must not shadow it (a
+        # silent empty-findings false pass).
+        text = '{"note":"thinking..."}\n' \
+               '{"verdict":"rejected","confidence":0.9,"rationale":"r",' \
+               '"findings":[{"severity":"critical","description":"real"}]}'
+        findings, source, _ = parse_findings(text)
+        assert source == "structured"
+        assert len(findings) == 1 and findings[0].description == "real"

--- a/tests/test_findings_parser.py
+++ b/tests/test_findings_parser.py
@@ -51,10 +51,16 @@ class TestParseFindings:
             findings, source, _ = parse_findings(text)
             assert source == "structured" and findings[0].severity == "critical"
 
-    def test_unknown_non_blocker_severity_is_major(self):
+    def test_unrecognized_severity_fails_safe_to_critical(self):
         text = '{"findings":[{"severity":"weird","description":"d"}]}'
         findings, _, _ = parse_findings(text)
-        assert findings[0].severity == "major"
+        assert findings[0].severity == "critical"  # fail-safe for a gate
+
+    def test_explicit_noncritical_synonym_downgrades(self):
+        for sev, want in (("warning", "major"), ("nit", "minor"), ("note", "info")):
+            text = '{"findings":[{"severity":"%s","description":"d"}]}' % sev
+            findings, _, _ = parse_findings(text)
+            assert findings[0].severity == want
 
     def test_items_without_description_skipped(self):
         text = '{"findings":[{"severity":"critical"},{"severity":"minor","description":"d"}]}'
@@ -176,7 +182,9 @@ class TestC3Round2:
         findings, source, _ = parse_findings(text)
         assert source == "structured" and findings[0].description == "real"
 
-    def test_missing_severity_is_major(self):
+    def test_missing_severity_fails_safe_to_critical(self):
+        # Fail-safe for a gate: an omitted severity ⇒ critical, never silently
+        # non-blocking (Council 3-round consensus).
         text = '{"findings":[{"description":"no severity field"}]}'
         findings, _, _ = parse_findings(text)
-        assert findings[0].severity == "major"
+        assert findings[0].severity == "critical"

--- a/tests/test_mechanical_verdict.py
+++ b/tests/test_mechanical_verdict.py
@@ -1,0 +1,104 @@
+"""ADR-051 C3 (#487): mechanical verdict — verdict = policy(findings).
+
+Under the flag, when the chairman's findings parse cleanly, the verdict and
+blocking_issues are DERIVED from them (pure host code), not prose-scraped:
+any critical ⇒ fail; blocking_issues = the critical subset. Flag-off and the
+parse-fallback path keep the legacy behavior (#355 regression preserved).
+"""
+
+import pytest
+
+from llm_council.verification.findings import verdict_policy
+from llm_council.verification.schemas import Finding
+from llm_council.verification.verdict_extractor import build_verification_result
+
+
+def _f(sev, desc="d"):
+    return Finding(severity=sev, description=desc)
+
+
+class TestVerdictPolicy:
+    def test_critical_fails(self):
+        assert verdict_policy([_f("critical"), _f("minor")]) == "fail"
+
+    def test_no_critical_passes(self):
+        assert verdict_policy([_f("major"), _f("minor"), _f("info")]) == "pass"
+
+    def test_empty_passes(self):
+        assert verdict_policy([]) == "pass"
+
+    def test_is_pure_function(self):
+        fs = [_f("critical")]
+        assert verdict_policy(fs) == verdict_policy(fs) == "fail"
+
+
+def _stage3(findings_json, verdict="approved"):
+    # The chairman's JSON: a verdict the mechanical gate should IGNORE, plus
+    # the findings it derives from.
+    import json
+    return {"response": json.dumps(
+        {"verdict": verdict, "confidence": 0.9, "rationale": "r", "findings": findings_json})}
+
+
+class TestMechanicalGate:
+    def test_critical_finding_forces_fail_even_if_chairman_said_approved(self, monkeypatch):
+        # The Yes-Man contradiction is impossible: chairman "approved" but a
+        # critical finding ⇒ mechanical FAIL.
+        monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "true")
+        r = build_verification_result([], [], _stage3(
+            [{"severity": "critical", "description": "boom", "location": "a.py:1"}],
+            verdict="approved"))
+        assert r["verdict"] == "fail"
+        assert r["diagnostics"]["verdict_source"] == "mechanical"
+        assert len(r["blocking_issues"]) == 1
+        assert r["blocking_issues"][0]["severity"] == "critical"
+
+    def test_no_critical_passes_with_empty_blocking(self, monkeypatch):
+        # threshold 0.0 isolates the mechanical verdict from confidence softening.
+        monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "true")
+        r = build_verification_result([], [], _stage3(
+            [{"severity": "major", "description": "d"}], verdict="rejected"),
+            confidence_threshold=0.0)
+        assert r["verdict"] == "pass"
+        assert r["blocking_issues"] == []
+        assert r["diagnostics"]["verdict_source"] == "mechanical"
+
+    def test_pass_softens_to_unclear_below_threshold(self, monkeypatch):
+        # No critical ⇒ mechanical pass, but low confidence ⇒ softened to unclear
+        # (same rule as the legacy path); still verdict_source=mechanical.
+        monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "true")
+        r = build_verification_result([], [], _stage3(
+            [{"severity": "minor", "description": "d"}]), confidence_threshold=0.99)
+        assert r["verdict"] == "unclear"
+        assert r["blocking_issues"] == []  # no critical
+        assert r["diagnostics"]["verdict_source"] == "mechanical"
+
+    def test_findings_superset_of_blocking(self, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "true")
+        r = build_verification_result([], [], _stage3([
+            {"severity": "critical", "description": "c"},
+            {"severity": "minor", "description": "m"},
+        ]))
+        assert len(r["findings"]) == 2
+        assert len(r["blocking_issues"]) == 1  # critical subset only
+
+    def test_fallback_keeps_legacy_verdict(self, monkeypatch):
+        # Unparseable findings ⇒ legacy verdict_source, no mechanical override.
+        monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "true")
+        r = build_verification_result([], [], {"response": "no json here"})
+        assert r["diagnostics"]["verdict_source"] == "legacy"
+
+    def test_flag_off_no_mechanical(self, monkeypatch):
+        monkeypatch.delenv("LLM_COUNCIL_STRUCTURED_FINDINGS", raising=False)
+        r = build_verification_result([], [], _stage3(
+            [{"severity": "critical", "description": "c"}]))
+        assert r["diagnostics"]["verdict_source"] == "legacy"
+        assert r["findings"] == []
+
+    def test_355_regression_no_fabricated_criticals_on_fallback(self, monkeypatch):
+        # Approval prose on the fallback path must not fabricate blocking issues.
+        monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "true")
+        r = build_verification_result([], [], {
+            "response": "The critical issues have all been resolved. Looks great."})
+        # No parseable JSON ⇒ fallback ⇒ legacy path; a pass has no blocking.
+        assert r["diagnostics"]["verdict_source"] == "legacy"


### PR DESCRIPTION
Closes #487 (epic #484, ADR-051 C3 — the core of the mechanical gate). Blocked-by #486 (merged).

## What
When the flag is on and the chairman's findings parse cleanly, the **verdict is computed from them by host code**, not prose-scraped: `verdict = policy(findings)` — any `critical` ⇒ `fail`, else `pass`. `blocking_issues` = the critical subset. The **Yes-Man contradiction is now structurally impossible**: a chairman "approved" with a critical finding ⇒ mechanical **FAIL**.

- `findings.py` `verdict_policy()`: pure function.
- `build_verification_result`: when `findings_source == structured`, override verdict + `blocking_issues` (`verdict_source: mechanical`); the confidence→unclear softening is the **same rule** as legacy. Fallback / flag-off keep the legacy prose path (**#355 regression preserved**). Confidence still from the deliberation signal.

This is the child that actually fixes the reported defect: FAIL now carries real `blocking_issues` derived from the findings.

## Tests (11)
`verdict_policy` purity; critical-forces-fail-over-"approved"; no-critical pass (threshold-isolated) + softens-to-unclear; findings ⊇ blocking; fallback + flag-off keep legacy; #355 no fabricated criticals.

## Gates
`make lint` clean · `make test-fast` 3318 passed. Council to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E43uRciABobxwpUCHPQAwh