### PR TITLE
feat(verify): ADR-051 C4 — consistency invariant + severity telemetry (4/6)

### DIFF
--- a/src/llm_council/verification/schemas.py
+++ b/src/llm_council/verification/schemas.py
@@ -327,6 +327,9 @@ class VerifyDiagnostics(BaseModel):
     verdict_source: Literal["mechanical", "legacy"] = Field(
         default="legacy", description="mechanical = policy(findings); legacy = prose parse"
     )
+    # ADR-051 C4 (#488): severity distribution — surfaces severity mis-labelling
+    # (the mechanical gate's residual failure mode) over time.
+    findings_by_severity: Dict[str, int] = Field(default_factory=dict)
 
 
 class VerifyResponse(BaseModel):

--- a/src/llm_council/verification/verdict_extractor.py
+++ b/src/llm_council/verification/verdict_extractor.py
@@ -7,9 +7,12 @@ council stage outputs for verification results.
 
 from __future__ import annotations
 
+import logging
 import re
 import statistics
 from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 
 # Verdict patterns in synthesis text
@@ -451,6 +454,24 @@ def build_verification_result(
                     if f.severity == "critical"
                 ]
                 diagnostics["verdict_source"] = "mechanical"
+                # C4: severity-distribution telemetry (mis-labelling signal).
+                by_sev: Dict[str, int] = {}
+                for f in parsed:
+                    by_sev[f.severity] = by_sev.get(f.severity, 0) + 1
+                diagnostics["findings_by_severity"] = by_sev
+                # C4: defensive invariant — under the mechanical gate a `fail`
+                # iff a critical exists is guaranteed; if it's ever violated
+                # that's a gate-policy BUG (never model behavior), so mark it.
+                has_critical = any(f.severity == "critical" for f in parsed)
+                if (mechanical == "fail") != has_critical:
+                    diagnostics["verdict_evidence_mismatch"] = (
+                        "fail_without_critical" if mechanical == "fail" else "nonfail_with_critical"
+                    )
+                    logger.error(
+                        "ADR-051 mechanical-gate invariant violated: verdict=%s has_critical=%s",
+                        mechanical,
+                        has_critical,
+                    )
         except Exception:  # telemetry must never break a verdict
             diagnostics["fallback_reason"] = "findings_exception"
     result["findings"] = findings_dicts

--- a/tests/test_mechanical_verdict.py
+++ b/tests/test_mechanical_verdict.py
@@ -102,3 +102,36 @@ class TestMechanicalGate:
             "response": "The critical issues have all been resolved. Looks great."})
         # No parseable JSON ⇒ fallback ⇒ legacy path; a pass has no blocking.
         assert r["diagnostics"]["verdict_source"] == "legacy"
+
+
+class TestC4ConsistencyAndTelemetry:
+    def test_severity_distribution_emitted(self, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "true")
+        r = build_verification_result([], [], _stage3([
+            {"severity": "critical", "description": "c"},
+            {"severity": "minor", "description": "m1"},
+            {"severity": "minor", "description": "m2"},
+        ]))
+        assert r["diagnostics"]["findings_by_severity"] == {"critical": 1, "minor": 2}
+
+    def test_invariant_does_not_fire_on_fail(self, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "true")
+        r = build_verification_result([], [], _stage3(
+            [{"severity": "critical", "description": "c"}]))
+        assert r["verdict"] == "fail"
+        assert r["diagnostics"].get("verdict_evidence_mismatch") is None
+
+    def test_invariant_does_not_fire_on_pass(self, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "true")
+        r = build_verification_result([], [], _stage3(
+            [{"severity": "minor", "description": "m"}]), confidence_threshold=0.0)
+        assert r["verdict"] == "pass"
+        assert r["diagnostics"].get("verdict_evidence_mismatch") is None
+
+    def test_invariant_does_not_fire_on_softened_unclear(self, monkeypatch):
+        # unclear (softened pass, no critical) is consistent — not a mismatch.
+        monkeypatch.setenv("LLM_COUNCIL_STRUCTURED_FINDINGS", "true")
+        r = build_verification_result([], [], _stage3(
+            [{"severity": "minor", "description": "m"}]), confidence_threshold=0.99)
+        assert r["verdict"] == "unclear"
+        assert r["diagnostics"].get("verdict_evidence_mismatch") is None


### PR DESCRIPTION
Closes #488 (epic #484, ADR-051 C4). Blocked-by #487 (merged).

## What
Under the mechanical gate `fail ⇔ critical` is guaranteed, so the old verdict–evidence inconsistency becomes a **defensive invariant**: if `(verdict==fail) != has_critical` ever holds it's a gate-policy bug — set `diagnostics.verdict_evidence_mismatch` + `logger.error`, never crash. Plus **severity-distribution telemetry** (`diagnostics.findings_by_severity`) so severity **mis-labelling** — the mechanical gate's named residual failure mode — is observable over time.

- `schemas.py` `VerifyDiagnostics.findings_by_severity`.
- `verdict_extractor`: per-severity counts + invariant check in the mechanical block; softened `unclear` (no critical) is consistent, doesn't fire.

## Tests (4)
distribution emitted; invariant silent on fail / pass / softened-unclear.

## Gates
`make lint` clean · `make test-fast` 3327 passed. Council to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E43uRciABobxwpUCHPQAwh