### PR TITLE
Release v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.37.0] - 2026-07-05
 
 **Verify Findings Channel — telemetry, diagnostics & docs (ADR-051, C4–C6 of epic [#484](https://github.com/amiable-dev/llm-council/issues/484))** — completes the epic on top of the v0.36.0 mechanical gate. Still behind `LLM_COUNCIL_STRUCTURED_FINDINGS` (**default OFF; flag-off byte-identical**); the whole epic remains non-breaking and the default-ON flip is a separate later release.
 

--- a/docs/adr/ADR-051-verify-findings-channel.md
+++ b/docs/adr/ADR-051-verify-findings-channel.md
@@ -1,6 +1,6 @@
 # ADR-051: Verify Findings Channel & Verdict–Evidence Consistency
 
-**Status:** Proposed 2026-07-04 (rev 2: literature claims verified via adversarial deep-research, 105 agents, 3-vote, checked 2026-07-04, with the anchor paper's numbers independently confirmed against the primary arXiv source. See "Research verification".)
+**Status:** Implemented 2026-07-05 (epic [#484](https://github.com/amiable-dev/llm-council/issues/484), C1–C6; C1–C3 in v0.36.0, C4–C6 in v0.37.0. Behind `LLM_COUNCIL_STRUCTURED_FINDINGS`, default-OFF; the default-ON flip is a separate future breaking release.) — proposed 2026-07-04 (rev 2: literature claims verified via adversarial deep-research, 105 agents, 3-vote, checked 2026-07-04, with the anchor paper's numbers independently confirmed against the primary arXiv source. See "Research verification".)
 **Date:** 2026-07-04
 **Decision Makers:** llm-council maintainers (review requested)
 **Proposed by:** maintainer triage of a downstream field report (amiable-dev/epic-loop)


### PR DESCRIPTION
Completes the **ADR-051 Verify Findings Channel** epic ([#484](https://github.com/amiable-dev/llm-council/issues/484)) — C4–C6 on top of the v0.36.0 mechanical gate.

## What's in this release
- **C4 (#488)** — `diagnostics.findings_by_severity` per-severity counts + defensive `verdict_evidence_mismatch` invariant marker.
- **C5 (#489)** — `diagnostics.inner_verdict`/`inner_confidence`/`inner_confidence_calibrated` (structured verdict before UNCLEAR softening); mechanical block now mutates `result` atomically (calibrate once, throw-free apply).
- **C6 (#490)** — full `verify` response contract documented field-by-field in `docs/guides/verify.md`; new `TestVerifyResponseFieldDrift` guard reds CI on any undocumented response field; consumer migration note (*stop keying on `blocking_issues == []`; key on `verdict` + `findings`/`severity`*) propagated across the doc + skill surface.

## Guarantees
- Flag `LLM_COUNCIL_STRUCTURED_FINDINGS` stays **default-OFF** — non-breaking; flag-off is byte-identical. The default-ON flip is a separate future breaking release.
- ADR-051 Status flipped **Proposed → Implemented**.

Tag `v0.37.0` after merge triggers `publish.yml` → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)