### PR TITLE
docs(site): acquisition-focused landing refactor + version fixes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,68 +1,140 @@
 <div class="hero" markdown>
-  <img src="img/logo.svg" alt="LLM Council">
+  <img src="img/logo.svg" alt="llm-council">
   <h1>llm-council</h1>
-  <p>Multi-LLM deliberation through peer review and synthesis</p>
+  <p>Don't ship on one model's guess. Multiple LLMs debate, anonymously peer-review each answer, and a chairman synthesizes the result — so you get an answer you can trust, or a machine-actionable <strong>pass / fail / unclear</strong> verdict with calibrated confidence for your CI.</p>
   <div class="hero-buttons">
-    <a href="getting-started/quickstart/" class="primary">Get Started</a>
-    <a href="https://github.com/amiable-dev/llm-council" class="secondary">GitHub</a>
+    <a href="getting-started/quickstart/" class="primary">Get Started →</a>
+    <a href="https://github.com/amiable-dev/llm-council" class="secondary">★ Star on GitHub</a>
   </div>
 </div>
 
-## What is LLM Council?
+<p align="center">
+<a href="https://pypi.org/project/llm-council-core/"><img src="https://img.shields.io/pypi/v/llm-council-core.svg?label=pypi" alt="PyPI version"></a>
+<a href="https://pypi.org/project/llm-council-core/"><img src="https://img.shields.io/pypi/dm/llm-council-core.svg?color=blue" alt="Downloads"></a>
+<a href="https://pypi.org/project/llm-council-core/"><img src="https://img.shields.io/pypi/pyversions/llm-council-core.svg" alt="Python versions"></a>
+<a href="https://github.com/amiable-dev/llm-council/actions/workflows/ci.yml"><img src="https://github.com/amiable-dev/llm-council/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+<a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/pypi/l/llm-council-core.svg?color=green" alt="License: MIT"></a>
+<a href="https://discord.gg/y467DGHF"><img src="https://img.shields.io/badge/Discord-join-7289da?logo=discord&logoColor=white" alt="Discord"></a>
+</p>
 
-Instead of asking a single LLM for answers, LLM Council:
+## Start in 60 seconds
 
-1. **Stage 1**: Sends your question to multiple LLMs in parallel (GPT, Claude, Gemini, Grok, etc.)
-2. **Stage 2**: Each LLM reviews and ranks the other responses (anonymized to prevent bias)
-3. **Stage 3**: A Chairman LLM synthesizes all responses into a final, high-quality answer
+=== "Claude Code / Cursor (MCP)"
 
-## Key Features
+    ```bash
+    pip install "llm-council-core[mcp,secure]"
+    export OPENROUTER_API_KEY="sk-or-v1-..."
+    claude mcp add llm-council --scope user -- llm-council
+    ```
 
-- **Multi-model deliberation** - Get answers validated across multiple AI models
-- **Peer review** - Anonymous evaluation prevents model favoritism
-- **Flexible integration** - Use as MCP server, HTTP API, or Python library
-- **Confidence tiers** - Quick, balanced, high, and reasoning modes
-- **Jury mode** - Binary verdicts for go/no-go decisions
-- **Verification & CI gating** - Machine-actionable pass/fail/unclear verdicts with calibrated confidence ([guide](guides/verify.md))
-- **Cost transparency** - Real per-model/per-stage token + USD accounting on every response (ADR-011)
-- **Live streaming** - Watch the deliberation unfold: per-model SSE events and chairman token streaming ([guide](guides/streaming.md))
-- **Quality benchmark** - Golden-dataset drift regression and a quality-per-dollar matrix ([guide](guides/bench.md))
-- **MCP 2026-ready** - Server Card discovery, durable task store, stateless-deployment audit (ADR-045)
+    Then just ask your agent:
 
-## Quick Start
+    > *Consult the council on whether this database migration is safe to ship.*
 
-```bash
-# Install
-pip install "llm-council-core[mcp,secure]"
+    Your agent gets a synthesized, peer-reviewed answer instead of one model's hot take.
 
-# Set API key
-export OPENROUTER_API_KEY="sk-or-v1-..."
+=== "Python"
 
-# Use with Claude Code
-claude mcp add llm-council --scope user -- llm-council
+    ```python
+    from llm_council import consult_council
+
+    result = await consult_council(
+        "What's the most robust way to make retries idempotent?",
+        confidence="balanced",
+    )
+
+    print(result.synthesis)    # the chairman's synthesized answer
+    print(result.confidence)   # calibrated 0.0–1.0
+    ```
+
+=== "CI gate"
+
+    ```bash
+    pip install "llm-council-core[secure]"
+    llm-council gate --snapshot HEAD --file-paths src/ --tier balanced
+    # exit 0 = pass · 1 = fail · 2 = unclear  →  drop straight into your pipeline
+    ```
+
+## See it decide
+
+`verify` doesn't hand you prose to parse — it returns a verdict your pipeline can act on, with the exact findings that produced it:
+
+```text
+$ llm-council gate --snapshot HEAD --file-paths src/auth.py --tier balanced
+
+Council Verification: FAIL ❌   (exit code 1)
+  Verdict       fail
+  Confidence    0.82   (calibrated)
+  Findings      3 critical · 1 major
+
+  ✗ critical   src/auth.py:14   SQL injection — user input concatenated into the query
+  ✗ critical   src/auth.py:22   Command injection via os.system on unsanitized host
+  ✗ critical   src/auth.py:31   Hardcoded AWS secret committed to source
+
+  → Verdict is computed mechanically: any critical finding ⇒ fail.
+    The verdict can't disagree with the evidence, because it's derived from it.
 ```
 
-Then in Claude Code:
+The same result is available as JSON (verdict, `blocking_issues`, calibrated confidence, `unclear_reason`) over the [MCP tool](guides/mcp.md) and the [HTTP API](guides/http-api.md) — see the [verification guide](guides/verify.md).
 
-```
-Consult the LLM council about best practices for error handling
-```
+## Pick your path
 
-## Use Cases
+<div class="grid cards" markdown>
 
-- **Code review** - Get multiple AI perspectives on code changes
-- **Architecture decisions** - Validate design choices with AI jury
-- **Content validation** - Check factual accuracy across models
-- **Complex problem solving** - Leverage diverse AI reasoning
+-   🤖 __I use an AI coding agent__
+
+    ---
+
+    Add a trustworthy second opinion to Claude Code, Cursor, or any MCP client — no code required.
+
+    [MCP setup →](guides/mcp.md)
+
+-   🐍 __I'm building an app__
+
+    ---
+
+    Call the council from Python or a stateless HTTP API, with streaming and full cost accounting.
+
+    [Python library →](guides/python.md) · [HTTP API →](guides/http-api.md)
+
+-   ✅ __I want to gate CI__
+
+    ---
+
+    Turn "does this change look right?" into an exit code — pass / fail / unclear with calibrated confidence.
+
+    [Verification & CI gating →](guides/verify.md)
+
+</div>
+
+## Why llm-council
+
+- **Anonymized peer review** — in Stage 2, models rank "Response A / B / C…", never each other by name, so they can't play favorites. Bias is the failure mode of naive ensembling; this is the fix.
+- **A verdict you can gate on** — `verify` returns `pass` / `fail` / `unclear` with an exit code, `blocking_issues`, and calibrated confidence — machine-actionable, not prose to regex.
+- **Calibrated confidence** — an isotonic fit against real human dispositions, so a 0.8 means 0.8. Every response also reports the raw value.
+- **Cost transparency** — real per-model and per-stage token + USD accounting on every response, with provider ground-truth where available.
+- **Runs where you work** — one package, four surfaces: MCP server, HTTP API, Python library, and CLI.
+- **Any model, any router** — GPT, Claude, Gemini, Grok, DeepSeek, or local Ollama, via OpenRouter, Requesty, or direct provider APIs.
+
+## How it works
+
+Three stages, fully parallel wherever possible:
+
+1. **Deliberate** — your question goes to several frontier LLMs at once.
+2. **Peer-review (anonymized)** — each model evaluates and ranks the others' responses, blind to who wrote them. Rankings are aggregated with Borda counting.
+3. **Synthesize** — a Chairman model composes the final answer from the full, ranked context — and for `verify`, host code computes the verdict *mechanically* from the findings.
+
+Choose a **confidence tier** — `quick`, `balanced`, `high`, or `reasoning` — to trade latency and cost for depth. [How it works in depth →](architecture/overview.md)
 
 ## Community
 
-- **[Discord](https://discord.gg/y467DGHF)** - Real-time chat and support
-- **[GitHub Discussions](https://github.com/amiable-dev/llm-council/discussions)** - Q&A and ideas
-- **[Contributing Guide](contributing.md)** - Help improve LLM Council
+- **[Discord](https://discord.gg/y467DGHF)** — real-time chat and support
+- **[GitHub Discussions](https://github.com/amiable-dev/llm-council/discussions)** — Q&A and ideas
+- **[Contributing Guide](contributing.md)** — help improve llm-council
 
-## Next Steps
+## Next steps
 
-- [Installation](getting-started/installation.md) - Detailed setup instructions
-- [Quick Start](getting-started/quickstart.md) - Get up and running in 5 minutes
-- [Configuration](getting-started/configuration.md) - Customize your council
+- [Installation](getting-started/installation.md) — extras, keys, and the keychain-secured setup
+- [Quick Start](getting-started/quickstart.md) — your first verdict in five minutes
+- [Verification & CI Gating](guides/verify.md) — the machine-actionable verdict contract
+- [Configuration](getting-started/configuration.md) — models, tiers, and `llm_council.yaml`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,11 +71,6 @@ nav:
     - Installation: getting-started/installation.md
     - Quick Start: getting-started/quickstart.md
     - Configuration: getting-started/configuration.md
-  - Deployment:
-    - Overview: deployment/index.md
-    - Railway: deployment/railway.md
-    - Render: deployment/render.md
-    - Local Docker: deployment/local.md
   - Guides:
     - MCP Server: guides/mcp.md
     - HTTP API: guides/http-api.md
@@ -88,6 +83,28 @@ nav:
   - Integrations:
     - Overview: integrations/index.md
     - n8n: integrations/n8n.md
+  - Reference:
+    - Environment Variables: reference/environment-variables.md
+    - API Reference: api.md
+  - Benchmark Results: bench-results.md
+  - Deployment:
+    - Overview: deployment/index.md
+    - Railway: deployment/railway.md
+    - Render: deployment/render.md
+    - Local Docker: deployment/local.md
+  - Blog:
+    - Multi-Model Architecture: blog/01-multi-model-architecture.md
+    - Fault-Tolerant Gateway: blog/02-fault-tolerant-gateway.md
+    - Voting Logic (Borda): blog/03-voting-logic-borda.md
+    - Latency Tax & Parallel Execution: blog/04-latency-tax-parallel.md
+    - Detecting Evaluator Bias: blog/05-detecting-evaluator-bias.md
+    - Accuracy Ceiling: blog/06-accuracy-ceiling.md
+    - Shadow Mode Auditions: blog/07-shadow-mode-auditions.md
+    - n8n Workflow Automation: blog/08-n8n-workflow-automation.md
+    - One-Click Deployment: blog/09-one-click-deployment.md
+    - Agent Skills Introduction: blog/10-agent-skills-introduction.md
+    - Verification Security Architecture: blog/11-verification-security-architecture.md
+    - CI/CD Quality Gates: blog/12-cicd-quality-gates.md
   - Architecture:
     - Overview: architecture/overview.md
     - ADRs:
@@ -144,23 +161,6 @@ nav:
       - ADR-052 Implementation Spec: adr/ADR-052-implementation-spec.md
     - Roadmap 2026-H2: roadmap-2026-h2.md
     - Stateless Audit (ADR-045 P3): adr-045-p3-state-inventory.md
-  - Reference:
-    - Environment Variables: reference/environment-variables.md
-  - Benchmark Results: bench-results.md
-  - Blog:
-    - Multi-Model Architecture: blog/01-multi-model-architecture.md
-    - Fault-Tolerant Gateway: blog/02-fault-tolerant-gateway.md
-    - Voting Logic (Borda): blog/03-voting-logic-borda.md
-    - Latency Tax & Parallel Execution: blog/04-latency-tax-parallel.md
-    - Detecting Evaluator Bias: blog/05-detecting-evaluator-bias.md
-    - Accuracy Ceiling: blog/06-accuracy-ceiling.md
-    - Shadow Mode Auditions: blog/07-shadow-mode-auditions.md
-    - n8n Workflow Automation: blog/08-n8n-workflow-automation.md
-    - One-Click Deployment: blog/09-one-click-deployment.md
-    - Agent Skills Introduction: blog/10-agent-skills-introduction.md
-    - Verification Security Architecture: blog/11-verification-security-architecture.md
-    - CI/CD Quality Gates: blog/12-cicd-quality-gates.md
-  - API Reference: api.md
   - Contributing: contributing.md
 
 extra:

--- a/server-card.json
+++ b/server-card.json
@@ -3,7 +3,7 @@
   "name": "io.github.amiable-dev/llm-council",
   "title": "LLM Council",
   "description": "Multi-model deliberation council with anonymized peer review, exposed as MCP tools.",
-  "version": "0.33.0",
+  "version": "0.37.1",
   "websiteUrl": "https://github.com/amiable-dev/llm-council",
   "repository": {
     "source": "github",


### PR DESCRIPTION
Fixes the two stale version surfaces and refactors the docs landing page for **developer acquisition**, informed by research into how FastAPI, uv/Ruff, Instructor, LiteLLM, DSPy, tRPC, Prisma, Supabase et al. structure their docs (LLM-domain peers weighted heavily; LangChain studied as the sprawl anti-pattern).

## Version fixes (the reported problem)
- **GitHub Releases** — backfilled every missing release from where they stopped (v0.24.44) → **v0.37.1 is now Latest**, complete history, CHANGELOG-sourced notes. *(done via API; not in this diff.)*
- **`server-card.json`** — was pinned at `0.33.0` (the MCP discovery/registry artifact; the drift test *masks* the version field, so it silently drifted). Regenerated → **0.37.1**.
- **Durable fix** — the landing hero now carries a **self-updating PyPI version badge**, so the site can never show a stale version again. (The homepage previously showed *no* version at all.)

## Landing page (`docs/index.md`)
- **Benefit-first hero** naming the villain (*"don't ship on one model's guess"*) and leading with the differentiator — a machine-actionable **pass / fail / unclear** verdict with calibrated confidence.
- **Self-updating badge row** (version, downloads, python, CI, license, Discord).
- **"Start in 60 seconds"** with persona tabs (MCP / Python / CI) — each showing expected **output**, not just input.
- **"See it decide"** — a real `verify` verdict block (show, don't tell — the research's most consistent excellence marker).
- **Three persona doors** as grid cards (agent user / app builder / CI gater); **benefit-led** feature bullets (bold lead + concrete claim).

## Nav IA (`mkdocs.yml`) — the canonical newcomer→expert ladder
Guides promoted to 2nd; **Deployment demoted** below Reference/Benchmark; API Reference folded into Reference; the **50+ ADR Architecture block moved to second-to-last** so architectural depth enriches experts without drowning newcomers (the LangChain failure mode).

## Safety
- Builds clean under `mkdocs build --strict`; every existing page preserved (no nav link removed).
- `test_docs_drift.py` (ADR-nav + response-field guards) and `test_server_card.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)