### PR TITLE
feat: route council queries through configured gateway (requesty)

### DIFF
--- a/src/llm_council/openrouter.py
+++ b/src/llm_council/openrouter.py
@@ -24,6 +24,46 @@ def _get_openrouter_api_key() -> str:
 OPENROUTER_API_KEY = _get_openrouter_api_key()
 
 
+# Default Requesty API URL (used when gateways.providers.requesty.base_url is unset)
+REQUESTY_DEFAULT_API_URL = "https://router.requesty.ai/v1/chat/completions"
+
+
+def _resolve_endpoint() -> tuple:
+    """Resolve (api_url, api_key, route_label) from the configured gateway.
+
+    Honors gateways.default and providers.<gw>.base_url / api_key. Falls back
+    to OpenRouter defaults when the configured gateway is unknown or disabled,
+    so behavior is unchanged for existing OpenRouter deployments.
+    """
+    config = get_config()
+    gw = config.gateways.default
+    providers = config.gateways.providers or {}
+    provider = providers.get(gw)
+
+    if gw == "requesty" and provider is not None and getattr(provider, "enabled", False):
+        url = provider.base_url or REQUESTY_DEFAULT_API_URL
+        key = get_api_key("requesty") or (provider.api_key or "")
+        return url, key, "requesty"
+
+    return OPENROUTER_API_URL, _get_openrouter_api_key(), "openrouter"
+
+
+def _resolve_model_name(model: str, route: str) -> str:
+    """Translate a model id to the name expected by the active gateway.
+
+    OpenRouter uses a ":free" suffix to select free variants; Requesty rejects
+    that suffix (HTTP 400) and expects provider-prefixed names for some models.
+    A per-gateway model_name_map in config rewrites ids; unknown ids pass
+    through unchanged.
+    """
+    if route == "requesty":
+        config = get_config()
+        mapping = (config.gateways.model_name_map or {}).get("requesty", {})
+        if mapping:
+            return mapping.get(model, model)
+    return model
+
+
 def _extract_cached_tokens(usage: Dict[str, Any]) -> int:
     """Cached prompt tokens from an OpenRouter usage object (0 if absent).
 
@@ -50,6 +90,7 @@ def _extract_cache_write_tokens(usage: Dict[str, Any]) -> int:
        observed 2026-07-04, not vendor-documented — ADR-049 §Compliance
        drift guard re-probes quarterly).
     """
+
     def _count(value: Any) -> int:
         # Provider payloads are untrusted: a non-numeric value degrades to 0
         # rather than crashing usage capture (same posture as missing).
@@ -62,6 +103,7 @@ def _extract_cache_write_tokens(usage: Dict[str, Any]) -> int:
     if isinstance(sub, dict) and sub:
         return sum(_count(v) for k, v in sub.items() if k.endswith("_input_tokens"))
     return _count((usage.get("prompt_tokens_details") or {}).get("cache_write_tokens"))
+
 
 if TYPE_CHECKING:
     from llm_council.gateway.types import ReasoningParams
@@ -130,8 +172,11 @@ async def query_model_with_status(
     Returns:
         Response dict with 'status', 'content', 'latency_ms', 'usage', and optional 'error'
     """
+    api_url, api_key, route = _resolve_endpoint()
+    model = _resolve_model_name(model, route)
+
     headers = {
-        "Authorization": f"Bearer {_get_openrouter_api_key()}",
+        "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
 
@@ -149,7 +194,7 @@ async def query_model_with_status(
 
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.post(OPENROUTER_API_URL, headers=headers, json=payload)
+            response = await client.post(api_url, headers=headers, json=payload)
             latency_ms = int((time.time() - start_time) * 1000)
 
             # Handle specific HTTP status codes (ADR-012 failure taxonomy)
@@ -194,7 +239,7 @@ async def query_model_with_status(
                 "content": message.get("content"),
                 "reasoning_details": message.get("reasoning_details"),
                 "latency_ms": latency_ms,
-                "route": "openrouter",
+                "route": route,
                 "session_id": cache_ctx.session_id if cache_ctx else None,
                 "usage": {
                     "prompt_tokens": usage.get("prompt_tokens", 0),

--- a/src/llm_council/unified_config.py
+++ b/src/llm_council/unified_config.py
@@ -333,6 +333,12 @@ class GatewayConfig(BaseModel):
         default_factory=dict
     )
     model_routing: Dict[str, str] = Field(default_factory=dict)
+    # Per-gateway model id translation. Keys are gateway names (e.g.
+    # "requesty"); values map a canonical model id (as used in tier pools)
+    # to the id the gateway expects. Unknown ids pass through unchanged.
+    # Lets one tier pool serve gateways that reject OpenRouter's ":free"
+    # suffix or use provider-prefixed names.
+    model_name_map: Dict[str, Dict[str, str]] = Field(default_factory=dict)
     fallback: FallbackConfig = Field(default_factory=FallbackConfig)
 
     @field_validator("default")


### PR DESCRIPTION
openrouter.py hardcoded the OpenRouter URL and key, ignoring the gateways.default / providers config. Add _resolve_endpoint() to pick URL+key from the configured gateway and _resolve_model_name() to translate model ids via a per-gateway model_name_map (Requesty rejects OpenRouter's ":free" suffix and uses provider-prefixed names for some models). Add model_name_map field to GatewayConfig.

Tests run:
- py_compile on patched modules
- load_config(strict=True) validates new field
- query_model_with_status on all 5 free models (route=requesty, cost~0)
- pre-commit run (ruff, ruff-format, gitleaks) -- passed

AI-Generated-By: Codex

## Summary

Brief description of the changes in this PR.

## Related Issues

- Closes #XXX (if applicable)
- Related to #XXX

## Changes Made

- Change 1
- Change 2
- Change 3

## Test Plan

Describe how you tested these changes:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Code follows project style guidelines
- [ ] Tests pass locally (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (for user-facing changes)
- [ ] Commit messages follow conventional commit format
- [ ] DCO sign-off included (`git commit -s`)

## Screenshots (if applicable)

Add screenshots for UI changes.

## Additional Notes

Any additional context or notes for reviewers.
