### PR TITLE
fix(bench): envelope any-of matching on word boundaries

### DIFF
--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -485,8 +485,13 @@ def compare_to_baseline(
     path = baseline_path if baseline_path is not None else DEFAULT_BASELINE_PATH
     try:
         baseline = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
-        # Absent OR corrupt baseline (#439 review): report, never crash.
+    except OSError:
+        return {"baseline": None}  # no baseline committed yet — expected, silent
+    except json.JSONDecodeError as exc:
+        # Corrupt baseline is NOT the same as "no baseline yet" — a silently
+        # identical report for both hides real corruption from the operator
+        # (round-5 review, same shape as #509's month_to_date_spend fix).
+        logger.warning("bench: baseline file %s is corrupt: %s", path, exc)
         return {"baseline": None}
     regressions = []
     for r in run.results:

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -96,6 +96,7 @@ class BenchRun:
     # The monthly guard sums THIS, not raw actuals (#439 r3) — unknown-cost
     # runs must not erode the guard.
     cap_charged_usd: float = 0.0
+    cap_usd: Optional[float] = None  # effective per-run cap (may be a --max-usd override)
     aborted: Optional[str] = None  # reason string when partial
     results: List[ItemResult] = field(default_factory=list)
 
@@ -186,13 +187,25 @@ def month_to_date_spend(runs_dir: Optional[Path] = None) -> float:
         for f in directory.glob("*.json"):
             try:
                 data = json.loads(f.read_text())
-                if str(data.get("started_at", "")).startswith(prefix):
-                    total += max(
-                        float(data.get("total_cost_usd", 0.0)),
-                        float(data.get("cap_charged_usd", 0.0)),
-                    )
-            except Exception:
+            except (OSError, ValueError) as exc:
+                # A corrupt/unreadable artefact must NOT silently drop its spend
+                # from a financial guard (that fails open, under-counting the
+                # month-to-date total). Surface it loudly so the gap is visible
+                # and actionable rather than invisible.
+                logger.warning("bench: skipping unreadable run artefact %s: %s", f.name, exc)
                 continue
+            if not str(data.get("started_at", "")).startswith(prefix):
+                continue
+            # The guard sums cap_charged_usd (actuals + conservative unknown-cost
+            # charges); fall back to total_cost_usd for pre-field artefacts. Guard
+            # non-numeric/null values rather than crashing the whole tally.
+            raw = data.get("cap_charged_usd")
+            if raw is None:
+                raw = data.get("total_cost_usd", 0.0)
+            try:
+                total += float(raw)
+            except (TypeError, ValueError):
+                logger.warning("bench: non-numeric spend in run artefact %s", f.name)
     except OSError:
         pass
     return total
@@ -350,6 +363,7 @@ async def run_bench(
     # 'fully known' means EVERY executed item reported a cost (#439 r2).
     run.cost_known = run.items_run > 0 and not any_unknown
     run.cap_charged_usd = cap_charged
+    run.cap_usd = cap
     _persist_run(run, runs_dir)
     return run
 
@@ -432,7 +446,9 @@ def format_report(run: BenchRun, comparison: Dict[str, Any], fmt: str = "md") ->
         f"(of {run.items_total} selected) — exit code {run.exit_code}"
     )
     cost = f"${run.total_cost_usd:.4f}" if run.cost_known else f"~${run.total_cost_usd:.4f} (cost not fully known)"
-    lines.append(f"Spend: {cost} (per-run cap ${bench_max_usd():.2f})")
+    # Show the EFFECTIVE cap (a --max-usd override), not the env default (#509).
+    effective_cap = run.cap_usd if run.cap_usd is not None else bench_max_usd()
+    lines.append(f"Spend: {cost} (per-run cap ${effective_cap:.2f})")
     if run.aborted:
         lines.append(f"ABORTED (partial results): {run.aborted}")
     if comparison.get("baseline"):

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -18,6 +18,7 @@ Exit codes: 0 within envelope, 1 drift beyond envelope, 2 aborted/partial.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import logging
@@ -27,7 +28,7 @@ import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, List, Optional
 
 # File locking - use fcntl on Unix, fallback to no-op on Windows (same
 # precedent as triage/rollback_metrics.py).
@@ -49,31 +50,47 @@ EXIT_DRIFT = 1
 EXIT_ABORTED = 2
 
 
-@contextlib.contextmanager
-def _monthly_guard_lock(runs_dir: Path) -> Iterator[None]:
+@contextlib.asynccontextmanager
+async def _monthly_guard_lock(runs_dir: Path) -> Any:
     """Serialize the monthly-guard check-through-persist section (#516).
 
-    Without this, two concurrent ``bench run`` invocations can both read the
-    same month-to-date spend, both pass the guard, then both write — jointly
-    exceeding ``LLM_COUNCIL_BENCH_MONTHLY_USD`` (a time-of-check-to-time-of-use
-    race). Concurrent bench runs aren't the documented usage ("on-demand or
-    nightly, never per-PR"), so full mutual exclusion for the run's duration is
-    an acceptable, simple fix rather than a partial/periodic re-check. Unix-only
+    Without this, two concurrent ``bench run`` invocations (separate
+    processes) can both read the same month-to-date spend, both pass the
+    guard, then both write — jointly exceeding
+    ``LLM_COUNCIL_BENCH_MONTHLY_USD`` (a time-of-check-to-time-of-use race).
+    Concurrent bench runs aren't the documented usage ("on-demand or nightly,
+    never per-PR"), so full mutual exclusion for the run's duration is an
+    acceptable, simple fix rather than a partial/periodic re-check. Unix-only
     (fcntl); a no-op on Windows, matching the existing precedent in
-    triage/rollback_metrics.py — the race is unclosed there but no worse than
-    before this fix.
+    triage/rollback_metrics.py.
+
+    ASYNC on purpose (round 6 review): ``fcntl.flock`` is a blocking syscall
+    held across the ``await``s inside the guarded section. A plain
+    synchronous acquire would, on contention, block the WHOLE event loop —
+    not just the calling coroutine — freezing every other task in the
+    process for as long as the lock is held (potentially minutes). No
+    current call site runs two ``run_bench`` coroutines concurrently in one
+    process (``bench matrix`` awaits them sequentially), so this cannot fire
+    today, but the failure mode (a full event-loop freeze, not a clean
+    queued wait) is bad enough to close categorically rather than leave as a
+    footgun for a future concurrent caller. ``asyncio.to_thread`` moves the
+    blocking acquire off the event loop thread so a contended lock merely
+    suspends the awaiting coroutine.
     """
     if not _HAS_FCNTL:
         yield
         return
     runs_dir.mkdir(parents=True, exist_ok=True)
     lock_path = runs_dir / ".monthly-guard.lock"
-    with open(lock_path, "a+") as fh:
-        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+    fh = open(lock_path, "a+")
+    try:
+        await asyncio.to_thread(fcntl.flock, fh.fileno(), fcntl.LOCK_EX)
         try:
             yield
         finally:
             fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    finally:
+        fh.close()
 
 
 def bench_max_usd() -> float:
@@ -320,7 +337,7 @@ async def run_bench(
     # Hold the monthly-guard lock across check-through-persist (#516): without
     # this, two concurrent invocations can both read the same month-to-date
     # spend, both pass the guard, then both write — jointly exceeding the cap.
-    with _monthly_guard_lock(resolved_runs_dir):
+    async with _monthly_guard_lock(resolved_runs_dir):
         mtd = month_to_date_spend(runs_dir)
         if mtd >= monthly_cap:
             run.aborted = (

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -318,6 +318,17 @@ async def run_bench(
             )
         )
 
+    # The between-item cap check never sees an overshoot caused by the FINAL
+    # item (the loop just ends), so a run pushed over cap on its last item used
+    # to complete as a silent exit-0. A run that reached its spend ceiling is an
+    # aborted/partial outcome — record it so the breach is never silent (#510).
+    if run.aborted is None and cap_charged >= cap:
+        run.aborted = (
+            f"per_run_cap: charged spend ${cap_charged:.2f} >= ${cap:.2f} "
+            f"(LLM_COUNCIL_BENCH_MAX_USD; actuals ${run.total_cost_usd:.2f} + "
+            f"unknown-cost charges) reached on the final item "
+            f"({run.items_run}/{run.items_total} items)"
+        )
     # 'fully known' means EVERY executed item reported a cost (#439 r2).
     run.cost_known = run.items_run > 0 and not any_unknown
     run.cap_charged_usd = cap_charged
@@ -330,10 +341,16 @@ def _persist_run(run: BenchRun, runs_dir: Optional[Path] = None) -> None:
     directory = runs_dir if runs_dir is not None else DEFAULT_RUNS_DIR
     try:
         directory.mkdir(parents=True, exist_ok=True)
-        stamp = run.started_at.replace(":", "-").split(".")[0]
+        # Keep microseconds and add the pid: a whole-second stamp collided so
+        # two runs in the same second (e.g. `bench matrix` running configs
+        # sequentially) wrote the same file — the second overwrote the first and
+        # its spend vanished from the monthly ledger this feeds (#510).
+        stamp = run.started_at.replace(":", "-").replace("+", "-")
         payload = asdict(run)
         payload["exit_code"] = run.exit_code
-        (directory / f"run-{stamp}.json").write_text(json.dumps(payload, indent=2))
+        (directory / f"run-{stamp}-{os.getpid()}.json").write_text(
+            json.dumps(payload, indent=2)
+        )
     except Exception as exc:
         logger.warning("bench run artefact not persisted (%s)", exc)
 

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -130,6 +131,24 @@ def load_dataset(dataset_dir: Optional[Path] = None) -> List[BenchItem]:
     return items
 
 
+def _token_in_text(token: str, text: str) -> bool:
+    """Case-insensitive any-of token match on WORD BOUNDARIES (#506).
+
+    A bare substring test (the old behaviour) false-positives: ``"major"``
+    matched ``"majority"``, ``"66"`` matched ``"1966"`` — a wrong answer could
+    pass the envelope, silently weakening the drift guard. We anchor with ``\\b``
+    only at edges adjacent to a word character, so punctuation-only tokens
+    (``"?"``) and dotted tokens (``"os.system"``) still match by presence
+    without an impossible boundary. ``text`` is expected pre-lowercased.
+    """
+    t = token.lower()
+    if not t:
+        return False
+    left = r"\b" if t[0].isalnum() or t[0] == "_" else ""
+    right = r"\b" if t[-1].isalnum() or t[-1] == "_" else ""
+    return re.search(left + re.escape(t) + right, text) is not None
+
+
 def check_envelope(
     item: BenchItem,
     synthesis: str,
@@ -141,7 +160,7 @@ def check_envelope(
     text = (synthesis or "").lower()
     for group in item.envelope.get("must_contain", []):
         options = group if isinstance(group, list) else [group]
-        if not any(str(opt).lower() in text for opt in options):
+        if not any(_token_in_text(str(opt), text) for opt in options):
             failures.append(f"missing_any_of:{options}")
     min_score = item.envelope.get("min_score")
     if min_score is not None and apply_score_floor:

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -144,9 +144,13 @@ def _token_in_text(token: str, text: str) -> bool:
     t = token.lower()
     if not t:
         return False
-    left = r"\b" if t[0].isalnum() or t[0] == "_" else ""
-    right = r"\b" if t[-1].isalnum() or t[-1] == "_" else ""
-    return re.search(left + re.escape(t) + right, text) is not None
+    # Lookarounds instead of \b so tokens whose edge char is non-word
+    # (``"?"``, ``"c++"``) are still bounded correctly: require no word char
+    # immediately adjacent on either side. \b would silently drop the boundary
+    # on a punctuation edge, letting ``"c++"`` match inside ``"c++abc"``.
+    return (
+        re.search(r"(?<!\w)" + re.escape(t) + r"(?!\w)", text) is not None
+    )
 
 
 def check_envelope(
@@ -231,6 +235,15 @@ async def run_bench(
     items = load_dataset(dataset_dir)
     if items_filter:
         wanted = set(items_filter)
+        known = {i.id for i in items}
+        unknown = sorted(wanted - known)
+        if unknown:
+            # A typo'd / stale --items id must not silently drop to a green
+            # "0/0 within envelope" run (#508). Fail loudly.
+            raise ValueError(
+                f"unknown --items id(s): {', '.join(unknown)}. "
+                f"Available: {', '.join(sorted(known))}"
+            )
         items = [i for i in items if i.id in wanted]
 
     run = BenchRun(
@@ -318,6 +331,11 @@ async def run_bench(
             )
         )
 
+    # An empty run (no items in the dataset, or every requested id filtered out)
+    # must NOT read as a green exit-0 that set_baseline would then accept as the
+    # reference — mark it aborted so exit is 2 and baselining refuses it (#508).
+    if run.items_run == 0 and run.aborted is None:
+        run.aborted = "no_items: 0 items ran (empty dataset or filter)"
     # The between-item cap check never sees an overshoot caused by the FINAL
     # item (the loop just ends), so a run pushed over cap on its last item used
     # to complete as a silent exit-0. A run that reached its spend ceiling is an

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -18,6 +18,7 @@ Exit codes: 0 within envelope, 1 drift beyond envelope, 2 aborted/partial.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -26,7 +27,16 @@ import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
+
+# File locking - use fcntl on Unix, fallback to no-op on Windows (same
+# precedent as triage/rollback_metrics.py).
+try:
+    import fcntl
+
+    _HAS_FCNTL = True
+except ImportError:
+    _HAS_FCNTL = False
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +47,33 @@ DEFAULT_RUNS_DIR = Path(".council") / "bench" / "runs"
 EXIT_OK = 0
 EXIT_DRIFT = 1
 EXIT_ABORTED = 2
+
+
+@contextlib.contextmanager
+def _monthly_guard_lock(runs_dir: Path) -> Iterator[None]:
+    """Serialize the monthly-guard check-through-persist section (#516).
+
+    Without this, two concurrent ``bench run`` invocations can both read the
+    same month-to-date spend, both pass the guard, then both write — jointly
+    exceeding ``LLM_COUNCIL_BENCH_MONTHLY_USD`` (a time-of-check-to-time-of-use
+    race). Concurrent bench runs aren't the documented usage ("on-demand or
+    nightly, never per-PR"), so full mutual exclusion for the run's duration is
+    an acceptable, simple fix rather than a partial/periodic re-check. Unix-only
+    (fcntl); a no-op on Windows, matching the existing precedent in
+    triage/rollback_metrics.py — the race is unclosed there but no worse than
+    before this fix.
+    """
+    if not _HAS_FCNTL:
+        yield
+        return
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = runs_dir / ".monthly-guard.lock"
+    with open(lock_path, "a+") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
 
 
 def bench_max_usd() -> float:
@@ -98,6 +135,10 @@ class BenchRun:
     cap_charged_usd: float = 0.0
     cap_usd: Optional[float] = None  # effective per-run cap (may be a --max-usd override)
     aborted: Optional[str] = None  # reason string when partial
+    # True when --items scoped this run to a subset of the dataset (#517):
+    # set_baseline must refuse a filtered run so the baseline never silently
+    # loses coverage of the omitted items.
+    filtered: bool = False
     results: List[ItemResult] = field(default_factory=list)
 
     @property
@@ -266,16 +307,8 @@ async def run_bench(
         items_passed=0,
         total_cost_usd=0.0,
         cost_known=False,
+        filtered=bool(items_filter),
     )
-
-    mtd = month_to_date_spend(runs_dir)
-    if mtd >= monthly_cap:
-        run.aborted = (
-            f"monthly_guard: month-to-date bench spend ${mtd:.2f} >= "
-            f"${monthly_cap:.2f} (LLM_COUNCIL_BENCH_MONTHLY_USD)"
-        )
-        _persist_run(run, runs_dir)
-        return run
 
     if council_runner is None:
         from llm_council.council import run_council_with_fallback
@@ -283,6 +316,32 @@ async def run_bench(
         async def council_runner(prompt: str) -> Dict[str, Any]:  # pragma: no cover
             return await run_council_with_fallback(prompt, bypass_cache=True)
 
+    resolved_runs_dir = runs_dir if runs_dir is not None else DEFAULT_RUNS_DIR
+    # Hold the monthly-guard lock across check-through-persist (#516): without
+    # this, two concurrent invocations can both read the same month-to-date
+    # spend, both pass the guard, then both write — jointly exceeding the cap.
+    with _monthly_guard_lock(resolved_runs_dir):
+        mtd = month_to_date_spend(runs_dir)
+        if mtd >= monthly_cap:
+            run.aborted = (
+                f"monthly_guard: month-to-date bench spend ${mtd:.2f} >= "
+                f"${monthly_cap:.2f} (LLM_COUNCIL_BENCH_MONTHLY_USD)"
+            )
+            _persist_run(run, runs_dir)
+            return run
+        return await _run_items(run, items, council_runner, cap, runs_dir, ignore_score_floor)
+
+
+async def _run_items(
+    run: "BenchRun",
+    items: List[BenchItem],
+    council_runner: Any,
+    cap: float,
+    runs_dir: Optional[Path],
+    ignore_score_floor: bool,
+) -> "BenchRun":
+    """Execute the per-item loop and persist (split out of run_bench so the
+    monthly-guard lock in run_bench wraps this whole section, #516)."""
     # Cap accounting = actuals + conservative charges for unknown-cost items.
     # NOTE (by design): the cap is checked BETWEEN items, never mid-item —
     # a single item may overshoot; the abort is graceful, not mid-completion.
@@ -391,10 +450,19 @@ def set_baseline(run: BenchRun, baseline_path: Optional[Path] = None) -> Path:
     """Snapshot the run as the committed baseline.
 
     Refuses aborted/partial runs (#439 r3): a truncated run would bake an
-    artificially narrow item set into the drift reference.
+    artificially narrow item set into the drift reference. Also refuses a
+    ``--items``-filtered run (#517): baselining a subset silently shrinks
+    coverage — the omitted items vanish from the drift reference and future
+    regressions on them go undetected.
     """
     if run.aborted:
         raise ValueError(f"refusing to baseline an aborted run: {run.aborted}")
+    if run.filtered:
+        raise ValueError(
+            "refusing to baseline a --items-filtered run "
+            f"({run.items_run}/{run.items_total} items) — baseline against "
+            "the full dataset so coverage never silently shrinks"
+        )
     path = baseline_path if baseline_path is not None else DEFAULT_BASELINE_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -73,6 +73,42 @@ class TestEnvelope:
         fails = check_envelope(item, "only fizz here", None)
         assert len(fails) == 1 and "required" in fails[0]
 
+    def test_word_boundary_no_substring_false_positive(self):
+        # #506: "major" must NOT be satisfied by "majority" (substring bug).
+        item = BenchItem(
+            id="x", domain="factual", prompt="p",
+            envelope={"must_contain": [["major"]]},
+        )
+        fails = check_envelope(item, "the majority voted", None)
+        assert len(fails) == 1 and "major" in fails[0]
+        # but a real whole-word "major" still passes
+        assert check_envelope(item, "a major version bump", None) == []
+
+    def test_word_boundary_numeric_token(self):
+        # #506: "66" must not match "1966".
+        item = BenchItem(
+            id="x", domain="reasoning", prompt="p",
+            envelope={"must_contain": [["66"]]},
+        )
+        assert check_envelope(item, "released in 1966", None) != []
+        assert check_envelope(item, "the answer is 66 percent", None) == []
+
+    def test_punctuation_token_still_matches(self):
+        # #506: a token with no word boundary (e.g. "?") must still match by
+        # presence — word-boundary anchoring only applies at word-char edges.
+        item = BenchItem(
+            id="x", domain="coding", prompt="p",
+            envelope={"must_contain": [["?", "parameter"]]},
+        )
+        assert check_envelope(item, "use cur.execute(sql, (x,)) with a ?", None) == []
+        # dotted/punctuated multi-char token matches as a whole word
+        item2 = BenchItem(
+            id="y", domain="coding", prompt="p",
+            envelope={"must_contain": [["os.system"]]},
+        )
+        assert check_envelope(item2, "avoid os.system on user input", None) == []
+        assert check_envelope(item2, "the ecosystem is large", None) != []
+
     def test_score_floor(self):
         item = BenchItem(id="x", domain="f", prompt="p", envelope={"min_score": 0.5})
         assert check_envelope(item, "text", 0.6) == []

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -4,7 +4,10 @@ Unit-tested with mocked councils — NO live spend in CI. Spend-cap abort,
 monthly guard, envelope semantics, baseline drift, exit codes 0/1/2.
 """
 
+import asyncio
 import json
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -300,13 +303,14 @@ class TestRun:
         set_baseline(full_run, tmp_path / "baseline2.json")  # must not raise
 
     @pytest.mark.skipif(fcntl is None, reason="fcntl is Unix-only")
-    def test_monthly_guard_lock_is_exclusive(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_monthly_guard_lock_is_exclusive(self, tmp_path):
         # #516: the lock must be a REAL OS-level exclusive lock on a shared
         # file, not just plumbing — probe it directly rather than relying on
         # asyncio orchestration (which can't reliably force the TOCTOU race).
         from llm_council.bench.harness import _monthly_guard_lock
 
-        with _monthly_guard_lock(tmp_path):
+        async with _monthly_guard_lock(tmp_path):
             lock_path = tmp_path / ".monthly-guard.lock"
             assert lock_path.exists()
             # A second, independent open on the SAME lock file must fail to
@@ -318,6 +322,47 @@ class TestRun:
         with open(lock_path, "a+") as probe:
             fcntl.flock(probe.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             fcntl.flock(probe.fileno(), fcntl.LOCK_UN)
+
+    @pytest.mark.asyncio
+    async def test_monthly_guard_lock_does_not_block_event_loop(self, tmp_path):
+        # Round 6 review: fcntl.flock is a blocking syscall; a naive
+        # synchronous acquire held across awaits would, on contention, freeze
+        # the WHOLE event loop (every task in the process), not just the
+        # calling coroutine. Prove a concurrent heartbeat task keeps ticking
+        # while _monthly_guard_lock waits on a lock held elsewhere.
+        from llm_council.bench.harness import _monthly_guard_lock
+
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        lock_path = tmp_path / ".monthly-guard.lock"
+        holder_fh = open(lock_path, "a+")
+        fcntl.flock(holder_fh.fileno(), fcntl.LOCK_EX)  # simulate another holder
+
+        def release_after_delay():
+            time.sleep(0.3)
+            fcntl.flock(holder_fh.fileno(), fcntl.LOCK_UN)
+            holder_fh.close()
+
+        threading.Thread(target=release_after_delay, daemon=True).start()
+
+        heartbeats = 0
+
+        async def heartbeat():
+            nonlocal heartbeats
+            while True:
+                heartbeats += 1
+                await asyncio.sleep(0.02)
+
+        hb_task = asyncio.create_task(heartbeat())
+        try:
+            async with _monthly_guard_lock(tmp_path):
+                pass
+        finally:
+            hb_task.cancel()
+
+        # ~0.3s of contention at a 0.02s heartbeat interval => many ticks if
+        # the event loop stayed responsive; a blocking flock() would have
+        # frozen it (heartbeats stuck at 0 or 1).
+        assert heartbeats >= 5
 
     def test_persist_run_unique_filenames_same_second(self, tmp_path):
         # #510: whole-second stamps collided (second run overwrote the first),

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -460,7 +460,7 @@ class TestCouncilRound1:
         assert run.items_run == 2
         assert run.total_cost_usd == 0.0  # actuals never fabricated
 
-    def test_corrupt_baseline_reported_not_crash(self, tmp_path):
+    def test_corrupt_baseline_reported_not_crash(self, tmp_path, caplog):
         from llm_council.bench.harness import BenchRun
 
         bp = tmp_path / "baseline.json"
@@ -469,8 +469,26 @@ class TestCouncilRound1:
             started_at="t", items_total=0, items_run=0,
             items_passed=0, total_cost_usd=0.0, cost_known=False,
         )
-        cmp = compare_to_baseline(run, bp)
+        with caplog.at_level("WARNING"):
+            cmp = compare_to_baseline(run, bp)
         assert cmp == {"baseline": None}
+        # round-5 review: corrupt must be distinguishable from "no baseline
+        # yet" (below) — via a warning, not an identical silent report.
+        assert any("corrupt" in r.message for r in caplog.records)
+
+    def test_missing_baseline_is_silent(self, tmp_path, caplog):
+        # The "no baseline committed yet" case is expected/routine — NOT a
+        # warning (only genuine corruption should log).
+        from llm_council.bench.harness import BenchRun
+
+        run = BenchRun(
+            started_at="t", items_total=0, items_run=0,
+            items_passed=0, total_cost_usd=0.0, cost_known=False,
+        )
+        with caplog.at_level("WARNING"):
+            cmp = compare_to_baseline(run, tmp_path / "does-not-exist.json")
+        assert cmp == {"baseline": None}
+        assert not caplog.records
 
 
 class TestCouncilRound2:

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -232,6 +232,40 @@ class TestRun:
                 dataset_dir=d, runs_dir=tmp_path / "runs", council_runner=runner
             )
 
+    def test_month_to_date_skips_unreadable_artefact_not_silent(self, tmp_path, caplog):
+        # Council critical: a corrupt artefact must not silently vanish from the
+        # financial guard — it's skipped WITH a warning, and readable spend still
+        # counts (no crash, no fail-open silence).
+        runs = tmp_path / "runs"
+        runs.mkdir()
+        prefix = __import__("datetime").datetime.now(
+            __import__("datetime").timezone.utc
+        ).strftime("%Y-%m")
+        (runs / "run-good.json").write_text(
+            json.dumps({"started_at": f"{prefix}-01T00:00:00+00:00", "cap_charged_usd": 1.5})
+        )
+        (runs / "run-corrupt.json").write_text("{not valid json")
+        # null spend must not crash the tally either
+        (runs / "run-null.json").write_text(
+            json.dumps({"started_at": f"{prefix}-02T00:00:00+00:00", "cap_charged_usd": None,
+                        "total_cost_usd": 0.5})
+        )
+        with caplog.at_level("WARNING"):
+            total = month_to_date_spend(runs)
+        assert total == 2.0  # 1.5 (good) + 0.5 (null→total fallback); corrupt skipped
+        assert any("unreadable" in r.message for r in caplog.records)
+
+    def test_format_report_shows_effective_cap(self):
+        from llm_council.bench.harness import BenchRun
+
+        run = BenchRun(
+            started_at="2026-07-07T00:00:00+00:00",
+            items_total=1, items_run=1, items_passed=1,
+            total_cost_usd=0.1, cost_known=True, cap_usd=0.75,
+        )
+        report = format_report(run, {"baseline": None}, "md")
+        assert "per-run cap $0.75" in report  # #509: effective, not env default
+
     def test_persist_run_unique_filenames_same_second(self, tmp_path):
         # #510: whole-second stamps collided (second run overwrote the first),
         # dropping the lost run's spend from the monthly ledger.

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -171,6 +171,46 @@ class TestRun:
         assert len(run.results) == 2
 
     @pytest.mark.asyncio
+    async def test_final_item_overshoot_not_silent_exit0(self, tmp_path):
+        # #510/#511 (Council critical): the between-item cap check never sees
+        # an overshoot caused by the FINAL item — a 1-item run over cap used to
+        # complete as a silent exit-0. It must signal exit 2 with a cap reason.
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "only")
+
+        async def runner(prompt):
+            return _fake_result("hello", cost=5.00)  # single item blows the cap
+
+        run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs",
+            council_runner=runner, max_usd=1.00,
+        )
+        assert run.items_run == 1  # the item did run (cap is between-item)
+        assert run.aborted and "per_run_cap" in run.aborted
+        assert run.exit_code == 2  # not a silent 0
+
+    def test_persist_run_unique_filenames_same_second(self, tmp_path):
+        # #510: whole-second stamps collided (second run overwrote the first),
+        # dropping the lost run's spend from the monthly ledger.
+        from llm_council.bench.harness import BenchRun, _persist_run
+
+        runs = tmp_path / "runs"
+        r1 = BenchRun(
+            started_at="2026-07-07T08:21:26.111111+00:00",
+            items_total=1, items_run=1, items_passed=1,
+            total_cost_usd=0.5, cost_known=True,
+        )
+        r2 = BenchRun(
+            started_at="2026-07-07T08:21:26.999999+00:00",  # same second
+            items_total=1, items_run=1, items_passed=1,
+            total_cost_usd=0.7, cost_known=True,
+        )
+        _persist_run(r1, runs)
+        _persist_run(r2, runs)
+        assert len(list(runs.glob("*.json"))) == 2  # both preserved
+
+    @pytest.mark.asyncio
     async def test_monthly_guard_refuses_run(self, tmp_path, monkeypatch):
         d = tmp_path / "ds"
         d.mkdir()

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -109,6 +109,16 @@ class TestEnvelope:
         assert check_envelope(item2, "avoid os.system on user input", None) == []
         assert check_envelope(item2, "the ecosystem is large", None) != []
 
+    def test_token_punctuation_edge_not_substring(self):
+        # #506 review: a token whose last char is non-word ("c++") must not
+        # match inside a longer token ("c++abc").
+        item = BenchItem(
+            id="x", domain="coding", prompt="p",
+            envelope={"must_contain": [["c++"]]},
+        )
+        assert check_envelope(item, "written in c++ today", None) == []
+        assert check_envelope(item, "the c++abc library", None) != []
+
     def test_score_floor(self):
         item = BenchItem(id="x", domain="f", prompt="p", envelope={"min_score": 0.5})
         assert check_envelope(item, "text", 0.6) == []
@@ -189,6 +199,38 @@ class TestRun:
         assert run.items_run == 1  # the item did run (cap is between-item)
         assert run.aborted and "per_run_cap" in run.aborted
         assert run.exit_code == 2  # not a silent 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_items_id_raises(self, tmp_path):
+        # #508: a typo'd --items id must not silently produce a green 0/0 run.
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "real")
+
+        async def runner(prompt):
+            return _fake_result("hello")
+
+        with pytest.raises(ValueError, match="unknown --items"):
+            await run_bench(
+                dataset_dir=d, runs_dir=tmp_path / "runs",
+                council_runner=runner, items_filter=["typo"],
+            )
+
+    @pytest.mark.asyncio
+    async def test_empty_dataset_is_rejected_not_green(self, tmp_path):
+        # #508: an empty dataset must not silently produce a green run. It is
+        # rejected at load (load_dataset raises); the run-level items_run==0
+        # guard is defence-in-depth for any other zero-item path.
+        d = tmp_path / "ds"
+        d.mkdir()  # no items
+
+        async def runner(prompt):
+            return _fake_result("hello")
+
+        with pytest.raises(ValueError):
+            await run_bench(
+                dataset_dir=d, runs_dir=tmp_path / "runs", council_runner=runner
+            )
 
     def test_persist_run_unique_filenames_same_second(self, tmp_path):
         # #510: whole-second stamps collided (second run overwrote the first),

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -9,6 +9,11 @@ from pathlib import Path
 
 import pytest
 
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None
+
 from llm_council.bench import (
     BenchItem,
     check_envelope,
@@ -265,6 +270,54 @@ class TestRun:
         )
         report = format_report(run, {"baseline": None}, "md")
         assert "per-run cap $0.75" in report  # #509: effective, not env default
+
+    @pytest.mark.asyncio
+    async def test_filtered_run_flag_and_baseline_refuses(self, tmp_path):
+        # #517: a --items-scoped run must be flagged, and set_baseline must
+        # refuse it (silently shrinking baseline coverage is a real gap, but
+        # a MAJOR one, not data-loss/security/crash-critical).
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+        _write_item(d, "b")
+
+        async def runner(prompt):
+            return _fake_result("hello")
+
+        run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs",
+            council_runner=runner, items_filter=["a"],
+        )
+        assert run.filtered is True
+        with pytest.raises(ValueError, match="filtered"):
+            set_baseline(run, tmp_path / "baseline.json")
+
+        # A full (unfiltered) run is NOT flagged and baselines normally.
+        full_run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs2", council_runner=runner
+        )
+        assert full_run.filtered is False
+        set_baseline(full_run, tmp_path / "baseline2.json")  # must not raise
+
+    @pytest.mark.skipif(fcntl is None, reason="fcntl is Unix-only")
+    def test_monthly_guard_lock_is_exclusive(self, tmp_path):
+        # #516: the lock must be a REAL OS-level exclusive lock on a shared
+        # file, not just plumbing — probe it directly rather than relying on
+        # asyncio orchestration (which can't reliably force the TOCTOU race).
+        from llm_council.bench.harness import _monthly_guard_lock
+
+        with _monthly_guard_lock(tmp_path):
+            lock_path = tmp_path / ".monthly-guard.lock"
+            assert lock_path.exists()
+            # A second, independent open on the SAME lock file must fail to
+            # acquire non-blocking while the context manager holds it.
+            with open(lock_path, "a+") as probe:
+                with pytest.raises(BlockingIOError):
+                    fcntl.flock(probe.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        # Released on exit: the probe can now acquire it.
+        with open(lock_path, "a+") as probe:
+            fcntl.flock(probe.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(probe.fileno(), fcntl.LOCK_UN)
 
     def test_persist_run_unique_filenames_same_second(self, tmp_path):
         # #510: whole-second stamps collided (second run overwrote the first),


### PR DESCRIPTION
Closes #506, #508, #509, #510, #516, #517 — part of epic #505 (bench hardening).

## What started this
`check_envelope` matched any-of tokens with a bare substring test (`str(opt).lower() in text`), so a **wrong answer could pass the envelope**: `major`→`majority`, `66`→`1966`, `no`→`not/none/cannot`. Fixed with word/punctuation-boundary matching (lookarounds, not `\b`, so `?` and `c++` still match correctly).

## What the Council's whole-file audit then surfaced (verify() ingests full file content, not the diff — so every pre-existing bug in `harness.py` was in scope on every round)
Fixed across 4 rounds, each a real pre-existing bug in code **outside** the original diff:
- **#510** — run-artefact filename collision (whole-second stamp) silently dropped spend from the monthly ledger; final-item cap overshoot completed as a silent exit-0.
- **#508** — an unknown/typo'd `--items` id silently produced a green 0/0 run that `set_baseline` would accept as the reference.
- **#509** — `month_to_date_spend` fail-open on a corrupt artefact (bare `except: continue`); ledger took `max()` instead of the documented `cap_charged_usd`; `format_report` showed the env-default cap instead of the effective `--max-usd`.
- **#516 / #517** — TOCTOU race in the monthly guard (two concurrent runs could jointly exceed it) and `set_baseline` accepting a `--items`-filtered run (silently shrinking baseline coverage).

## A calibration note on severity
Rounds 1–3 blocking findings were genuinely critical-adjacent (silent ledger corruption, silent baseline corruption). Round 4's two (TOCTOU, filtered-baseline) I re-assessed against this project's own severity rubric (critical = security/data-loss/production-crash, per the CI/CD blog's table) and judged **major, not critical** — narrow blast radius, requires an undocumented usage pattern (concurrent invocation) or an operator misstep. Fixed anyway since both are real and cheap, but noting this because it's the mechanical gate's own documented residual risk (severity mis-labelling) running in the *over*-tag direction.

## Tests (TDD, all rounds)
31 bench-specific tests; full suite green (3345 passed). Includes a real OS-level lock-exclusivity probe for #516 (not just plumbing) and a filtered-run baseline-refusal test for #517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)