### PR TITLE
feat(bench): distinguish council/infra errors from quality drift

### DIFF
--- a/src/llm_council/bench/__init__.py
+++ b/src/llm_council/bench/__init__.py
@@ -10,5 +10,6 @@ from .harness import (  # noqa: F401
     load_dataset,
     month_to_date_spend,
     run_bench,
+    run_from_dict,
     set_baseline,
 )

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -565,10 +565,18 @@ def compare_to_baseline(
         return {"baseline": None}
     regressions = []
     for r in run.results:
+        if r.is_infra:
+            # A council/infra error is NOT a quality regression (#507) — an
+            # `ok=False` infra item would otherwise show up as a false
+            # "regression vs baseline" here, exactly the drift-vs-infra
+            # conflation #507 exists to prevent.
+            continue
         base = baseline.get("items", {}).get(r.item_id)
         if base and base.get("ok") and not r.ok:
             regressions.append(r.item_id)
-    pass_rate = round(run.items_passed / run.items_run, 3) if run.items_run else None
+    # Consistent with exit_code (#507): pass rate excludes infra-errored
+    # items, which never had a chance to score.
+    pass_rate = round(run.items_passed / run.items_scored, 3) if run.items_scored else None
     return {
         "baseline": baseline.get("created_at"),
         "baseline_pass_rate": baseline.get("pass_rate"),

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -219,21 +219,30 @@ def _token_in_text(token: str, text: str) -> bool:
 
     A bare substring test (the old behaviour) false-positives: ``"major"``
     matched ``"majority"``, ``"66"`` matched ``"1966"`` — a wrong answer could
-    pass the envelope, silently weakening the drift guard. We anchor with ``\\b``
-    only at edges adjacent to a word character, so punctuation-only tokens
-    (``"?"``) and dotted tokens (``"os.system"``) still match by presence
-    without an impossible boundary. ``text`` is expected pre-lowercased.
+    pass the envelope, silently weakening the drift guard. ``text`` is
+    expected pre-lowercased.
+
+    The boundary check is applied PER SIDE, conditional on whether that side's
+    edge character of the TOKEN itself is a word character (alnum/``_``) — not
+    unconditionally. A round-4 attempt at unconditional lookarounds
+    (``(?<!\\w)…(?!\\w)`` on both sides always) "fixed" a synthetic edge case
+    (``"c++"`` matching inside ``"c++abc"`` — not an actual dataset token) at
+    the cost of a real regression: ``"?"`` (a REAL v1 token,
+    ``code-sql-injection.json``) stopped matching its overwhelmingly common
+    real-world position — immediately after a word, as in "...use a
+    parameter?" — because requiring no word char *before* a trailing "?" is
+    wrong; punctuation routinely glues to the preceding word. Conditioning the
+    boundary on the token's own edge character restores that: ``"major"``/
+    ``"66"`` (word-char edges) get boundaries on both sides; ``"?"``
+    (punctuation edge) gets none and matches anywhere, exactly as real usage
+    needs.
     """
     t = token.lower()
     if not t:
         return False
-    # Lookarounds instead of \b so tokens whose edge char is non-word
-    # (``"?"``, ``"c++"``) are still bounded correctly: require no word char
-    # immediately adjacent on either side. \b would silently drop the boundary
-    # on a punctuation edge, letting ``"c++"`` match inside ``"c++abc"``.
-    return (
-        re.search(r"(?<!\w)" + re.escape(t) + r"(?!\w)", text) is not None
-    )
+    left = r"(?<!\w)" if (t[0].isalnum() or t[0] == "_") else ""
+    right = r"(?!\w)" if (t[-1].isalnum() or t[-1] == "_") else ""
+    return re.search(left + re.escape(t) + right, text) is not None
 
 
 def check_envelope(
@@ -541,7 +550,11 @@ def set_baseline(run: BenchRun, baseline_path: Optional[Path] = None) -> Path:
             r.item_id: {"ok": r.ok, "score": r.score, "cost_usd": r.cost_usd}
             for r in run.results
         },
-        "pass_rate": round(run.items_passed / run.items_run, 3) if run.items_run else None,
+        # Same denominator as compare_to_baseline (#507): a mixed run (not
+        # aborted, but with SOME infra-errored items — set_baseline only
+        # refuses fully-aborted/filtered runs) must not bake an
+        # infra-deflated pass_rate into the committed baseline.
+        "pass_rate": round(run.items_passed / run.items_scored, 3) if run.items_scored else None,
         "total_cost_usd": run.total_cost_usd,
     }
     path.write_text(json.dumps(payload, indent=2) + "\n")

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -25,7 +25,7 @@ import logging
 import os
 import re
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -536,6 +536,34 @@ def _persist_run(run: BenchRun, runs_dir: Optional[Path] = None) -> None:
         )
     except Exception as exc:
         logger.warning("bench run artefact not persisted (%s)", exc)
+
+
+def run_from_dict(data: Dict[str, Any]) -> BenchRun:
+    """Rebuild a BenchRun from a persisted run artefact (round 12 review).
+
+    The CLI (``report`` / ``baseline --set``) used to hand-list a fixed
+    subset of fields when reconstructing a ``BenchRun`` from a loaded
+    ``run-*.json``. Every field added since that whitelist was last updated —
+    ``cap_usd``, ``filtered``, ``infra_errors`` — was silently dropped on
+    reload, even though the persisted JSON (written by ``_persist_run`` via
+    ``asdict``) actually contains them. ``filtered`` defaulting back to
+    ``False`` was the worst case: it meant ``bench baseline --set`` could
+    NEVER actually refuse a filtered run once round-tripped through a
+    persisted artefact — a live bypass of #517's fix through the one code
+    path (the CLI) that exercises it. Building the kwargs from
+    ``dataclasses.fields()`` instead of a hand-maintained list means a future
+    new field is included automatically; ``exit_code`` (present in the JSON
+    payload as a computed convenience, never a constructor arg) is dropped
+    explicitly rather than by accident.
+    """
+    valid = {f.name for f in fields(BenchRun)} - {"results"}
+    kwargs: Dict[str, Any] = {k: v for k, v in data.items() if k in valid}
+    item_valid = {f.name for f in fields(ItemResult)}
+    kwargs["results"] = [
+        ItemResult(**{k: v for k, v in r.items() if k in item_valid})
+        for r in data.get("results", [])
+    ]
+    return BenchRun(**kwargs)
 
 
 def set_baseline(run: BenchRun, baseline_path: Optional[Path] = None) -> Path:

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -546,9 +546,17 @@ def set_baseline(run: BenchRun, baseline_path: Optional[Path] = None) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "created_at": run.started_at,
+        # Infra-errored items are excluded (round 10 review): r.ok is always
+        # False for an infra item (it has failures but no genuine envelope
+        # verdict), so baking it in as "ok: False" would permanently
+        # blindspot compare_to_baseline's regression check for that item —
+        # `if base.get("ok") and not r.ok` can never fire once base.get("ok")
+        # is frozen False, even after a REAL later regression. An absent
+        # baseline entry (None) is correctly ignored by that check instead.
         "items": {
             r.item_id: {"ok": r.ok, "score": r.score, "cost_usd": r.cost_usd}
             for r in run.results
+            if not r.is_infra
         },
         # Same denominator as compare_to_baseline (#507): a mixed run (not
         # aborted, but with SOME infra-errored items — set_baseline only

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -136,6 +136,11 @@ class ItemResult:
     cost_usd: float = 0.0
     cost_known: bool = False
     latency_ms: int = 0
+    # True when this item's failure is a council/infra error (runner raised, or
+    # the council itself reported status="failed" — no responses/no synthesis),
+    # not a genuine envelope/quality miss (#507). Keeps a rate-limit/billing
+    # lapse from reading as "quality collapsed".
+    is_infra: bool = False
 
 
 @dataclass
@@ -156,13 +161,32 @@ class BenchRun:
     # set_baseline must refuse a filtered run so the baseline never silently
     # loses coverage of the omitted items.
     filtered: bool = False
+    # Count of items whose failure was a council/infra error, not a genuine
+    # envelope miss (#507) — runner raised, or council reported status="failed"
+    # (no responses / no synthesis). Kept separate so a rate-limit/billing
+    # lapse can never read as "quality collapsed".
+    infra_errors: int = 0
     results: List[ItemResult] = field(default_factory=list)
+
+    @property
+    def items_scored(self) -> int:
+        """Items that actually ran through envelope scoring — excludes
+        infra-errored items, which never produced a scoreable result."""
+        return self.items_run - self.infra_errors
 
     @property
     def exit_code(self) -> int:
         if self.aborted:
             return EXIT_ABORTED
-        if self.items_passed < self.items_run:
+        # items_scored == 0 with items_run > 0 means EVERY attempted item was
+        # an infra error — an infra/abort outcome, never a green pass (0 < 0
+        # is False) and never drift (#507). _run_items already sets `aborted`
+        # for this case, so `self.aborted` above should already catch it; this
+        # is a defensive second layer in case a caller constructs a BenchRun
+        # directly without going through _run_items.
+        if self.items_run > 0 and self.items_scored == 0:
+            return EXIT_ABORTED
+        if self.items_passed < self.items_scored:
             return EXIT_DRIFT
         return EXIT_OK
 
@@ -377,15 +401,20 @@ async def _run_items(
         try:
             result = await council_runner(item.prompt)
         except Exception as exc:
+            # An exception from the runner is unambiguously a council/infra
+            # error (gateway down, transport failure), never a quality
+            # signal (#507).
             run.results.append(
                 ItemResult(
                     item_id=item.id,
                     domain=item.domain,
                     ok=False,
                     failures=[f"council_error:{exc}"],
+                    is_infra=True,
                 )
             )
             run.items_run += 1
+            run.infra_errors += 1
             # An erroring item may already have spent (#439 r2): charge the
             # conservative default so failures cannot bypass the cap.
             cap_charged = round(cap_charged + bench_unknown_item_usd(), 6)
@@ -395,16 +424,28 @@ async def _run_items(
         synthesis = result.get("synthesis", "")
         score = _extract_score(result)
         cost, cost_known = _extract_cost(result)
-        # Solo matrix configs (ADR-048 P2) have no council consensus signal;
-        # min_score floors are skipped for them by explicit opt-in.
-        failures = check_envelope(
-            item, synthesis, score, apply_score_floor=not ignore_score_floor
-        )
+        # The council itself may report total failure without raising (all
+        # models errored/timed out — CLAUDE.md's graceful-degradation policy
+        # returns a result with no responses rather than an exception). That
+        # is ALSO a council/infra error, not a genuine envelope/quality miss
+        # (#507's empirically-observed rate-limit case: score_unavailable at
+        # $0.00 spend, every item failing — not a real quality regression).
+        is_infra = result.get("metadata", {}).get("status") == "failed"
+        if is_infra:
+            failures = ["council_status_failed"]
+        else:
+            # Solo matrix configs (ADR-048 P2) have no council consensus
+            # signal; min_score floors are skipped for them by explicit opt-in.
+            failures = check_envelope(
+                item, synthesis, score, apply_score_floor=not ignore_score_floor
+            )
         run.total_cost_usd = round(run.total_cost_usd + cost, 6)
         cap_charged = round(cap_charged + (cost if cost_known else bench_unknown_item_usd()), 6)
         if not cost_known:
             any_unknown = True
         run.items_run += 1
+        if is_infra:
+            run.infra_errors += 1
         if not failures:
             run.items_passed += 1
         run.results.append(
@@ -417,6 +458,7 @@ async def _run_items(
                 cost_usd=cost,
                 cost_known=cost_known,
                 latency_ms=latency_ms,
+                is_infra=is_infra,
             )
         )
 
@@ -425,6 +467,17 @@ async def _run_items(
     # reference — mark it aborted so exit is 2 and baselining refuses it (#508).
     if run.items_run == 0 and run.aborted is None:
         run.aborted = "no_items: 0 items ran (empty dataset or filter)"
+    # Every attempted item was a council/infra error (rate-limit, billing
+    # lapse, gateway down) — an infra/abort outcome, never a green pass
+    # (items_scored==0 items_passed==0 would otherwise read as OK) or a
+    # quality-drift signal (#507). A MIXED run (some infra, some genuinely
+    # scored) is NOT aborted here — its exit reflects only the
+    # genuinely-scored items via items_scored in exit_code.
+    elif run.items_run > 0 and run.items_scored == 0 and run.aborted is None:
+        run.aborted = (
+            f"infra_failure: {run.infra_errors}/{run.items_run} items errored "
+            "(council runner exception or status=failed) — not a quality signal"
+        )
     # The between-item cap check never sees an overshoot caused by the FINAL
     # item (the loop just ends), so a run pushed over cap on its last item used
     # to complete as a silent exit-0. A run that reached its spend ceiling is an
@@ -532,9 +585,16 @@ def format_report(run: BenchRun, comparison: Dict[str, Any], fmt: str = "md") ->
         return json.dumps(payload, indent=2)
     lines = ["# Bench Report (ADR-048)"]
     lines.append(
-        f"Items: {run.items_passed}/{run.items_run} within envelope "
+        f"Items: {run.items_passed}/{run.items_scored} within envelope "
         f"(of {run.items_total} selected) — exit code {run.exit_code}"
     )
+    if run.infra_errors:
+        # Surfaced separately from envelope drift (#507) — routes nightly
+        # alerts to "check the gateway/billing" vs "quality regressed".
+        lines.append(
+            f"Council/infra errors: {run.infra_errors}/{run.items_run} "
+            "(NOT a quality signal — see items marked [INFRA] below)"
+        )
     cost = f"${run.total_cost_usd:.4f}" if run.cost_known else f"~${run.total_cost_usd:.4f} (cost not fully known)"
     # Show the EFFECTIVE cap (a --max-usd override), not the env default (#509).
     effective_cap = run.cap_usd if run.cap_usd is not None else bench_max_usd()
@@ -551,7 +611,7 @@ def format_report(run: BenchRun, comparison: Dict[str, Any], fmt: str = "md") ->
     else:
         lines.append("No committed baseline (run `llm-council bench baseline --set`).")
     for r in run.results:
-        marker = "PASS" if r.ok else "FAIL"
+        marker = "PASS" if r.ok else ("INFRA" if r.is_infra else "FAIL")
         detail = "" if r.ok else f" — {'; '.join(r.failures)}"
         lines.append(f"- [{marker}] {r.item_id} ({r.domain}){detail}")
     return "\n".join(lines)

--- a/src/llm_council/bench/harness.py
+++ b/src/llm_council/bench/harness.py
@@ -358,6 +358,10 @@ async def run_bench(
         total_cost_usd=0.0,
         cost_known=False,
         filtered=bool(items_filter),
+        # Round 11 review: set immediately, not only at the end of
+        # _run_items — a monthly-guard abort below returns before items ever
+        # run, and the effective cap should still be visible in the report.
+        cap_usd=cap,
     )
 
     if council_runner is None:
@@ -366,20 +370,27 @@ async def run_bench(
         async def council_runner(prompt: str) -> Dict[str, Any]:  # pragma: no cover
             return await run_council_with_fallback(prompt, bypass_cache=True)
 
+    # Resolve ONCE and reuse everywhere below (round 11 review: passing the
+    # raw, possibly-None `runs_dir` to month_to_date_spend/_run_items relied
+    # on each callee re-deriving the same default independently — harmless
+    # today since they use the identical fallback, but a maintainability trap
+    # if that ever drifts).
     resolved_runs_dir = runs_dir if runs_dir is not None else DEFAULT_RUNS_DIR
     # Hold the monthly-guard lock across check-through-persist (#516): without
     # this, two concurrent invocations can both read the same month-to-date
     # spend, both pass the guard, then both write — jointly exceeding the cap.
     async with _monthly_guard_lock(resolved_runs_dir):
-        mtd = month_to_date_spend(runs_dir)
+        mtd = month_to_date_spend(resolved_runs_dir)
         if mtd >= monthly_cap:
             run.aborted = (
                 f"monthly_guard: month-to-date bench spend ${mtd:.2f} >= "
                 f"${monthly_cap:.2f} (LLM_COUNCIL_BENCH_MONTHLY_USD)"
             )
-            _persist_run(run, runs_dir)
+            _persist_run(run, resolved_runs_dir)
             return run
-        return await _run_items(run, items, council_runner, cap, runs_dir, ignore_score_floor)
+        return await _run_items(
+            run, items, council_runner, cap, resolved_runs_dir, ignore_score_floor
+        )
 
 
 async def _run_items(
@@ -501,7 +512,9 @@ async def _run_items(
     # 'fully known' means EVERY executed item reported a cost (#439 r2).
     run.cost_known = run.items_run > 0 and not any_unknown
     run.cap_charged_usd = cap_charged
-    run.cap_usd = cap
+    # run.cap_usd is set once, in run_bench, immediately after construction
+    # (round 11 review) — visible even on a monthly-guard abort that returns
+    # before this function runs.
     _persist_run(run, runs_dir)
     return run
 

--- a/src/llm_council/bench/matrix.py
+++ b/src/llm_council/bench/matrix.py
@@ -129,7 +129,13 @@ async def run_matrix(
             council_runner=runner,
             ignore_score_floor=(config.kind == "solo"),
         )
-        pass_rate = round(run.items_passed / run.items_run, 3) if run.items_run else 0.0
+        # Consistent with BenchRun.exit_code (#507): pass rate excludes
+        # council/infra-errored items, which never had a chance to score — an
+        # infra-heavy config must not look artificially worse in the
+        # quality-per-dollar comparison than one that simply ran cleanly.
+        pass_rate = (
+            round(run.items_passed / run.items_scored, 3) if run.items_scored else 0.0
+        )
         rows.append(
             {
                 "config": config.name,

--- a/src/llm_council/cli.py
+++ b/src/llm_council/cli.py
@@ -119,16 +119,11 @@ def bench_command(
         if not set_flag:
             sys.stdout.write("Pass --set to snapshot the latest run as baseline.\n")
             return 0
-        run = harness.BenchRun(
-            started_at=data["started_at"],
-            items_total=data["items_total"],
-            items_run=data["items_run"],
-            items_passed=data["items_passed"],
-            total_cost_usd=data["total_cost_usd"],
-            cost_known=data["cost_known"],
-            aborted=data.get("aborted"),
-            results=[harness.ItemResult(**r) for r in data.get("results", [])],
-        )
+        # run_from_dict (not a hand-listed field subset — round 12 review):
+        # the old whitelist silently dropped filtered/cap_usd/infra_errors on
+        # reload, so `bench baseline --set` could never actually refuse a
+        # filtered run once round-tripped through a persisted artefact.
+        run = harness.run_from_dict(data)
         path = harness.set_baseline(run)
         sys.stdout.write(f"Baseline written to {path}\n")
         return 0
@@ -137,16 +132,7 @@ def bench_command(
     data = _latest_run()
     if data is None:
         return 2
-    run = harness.BenchRun(
-        started_at=data["started_at"],
-        items_total=data["items_total"],
-        items_run=data["items_run"],
-        items_passed=data["items_passed"],
-        total_cost_usd=data["total_cost_usd"],
-        cost_known=data["cost_known"],
-        aborted=data.get("aborted"),
-        results=[harness.ItemResult(**r) for r in data.get("results", [])],
-    )
+    run = harness.run_from_dict(data)
     comparison = harness.compare_to_baseline(run)
     sys.stdout.write(harness.format_report(run, comparison, output_format) + "\n")
     if publish:

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -411,10 +411,16 @@ class TestRun:
             called.append(prompt)
             return _fake_result("hello")
 
-        run = await run_bench(dataset_dir=d, runs_dir=runs, council_runner=runner)
+        run = await run_bench(
+            dataset_dir=d, runs_dir=runs, council_runner=runner, max_usd=0.55
+        )
         assert run.exit_code == 2
         assert "monthly_guard" in run.aborted
         assert called == []  # zero spend
+        # Round 11 review: cap_usd must be populated even though the run
+        # aborted before any items ran (previously only set at the end of
+        # _run_items, which this path never reaches).
+        assert run.cap_usd == 0.55
 
     @pytest.mark.asyncio
     async def test_council_error_marks_item_failed_not_crash(self, tmp_path):

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -557,6 +557,47 @@ class TestBaseline:
         assert "No committed baseline" in format_report(run, cmp)
 
     @pytest.mark.asyncio
+    async def test_infra_error_excluded_from_baseline_items(self, tmp_path):
+        # Round 10 review: set_baseline must NOT bake ok=False for an
+        # infra-errored item — base.get("ok") frozen False can never satisfy
+        # compare_to_baseline's "base.get('ok') and not r.ok" check, so a
+        # REAL future regression on that item would be permanently
+        # invisible. Excluding it (absent entry) is correctly ignored by
+        # that check instead — no false record either way.
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+        _write_item(d, "b")
+
+        calls = {"n": 0}
+
+        async def mixed(prompt):
+            calls["n"] += 1
+            if calls["n"] == 2:  # "b" loads second (sorted glob) — infra-errors
+                raise RuntimeError("gateway down")
+            return _fake_result("hello")
+
+        run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs", council_runner=mixed
+        )
+        bp = set_baseline(run, tmp_path / "baseline.json")
+        baseline = json.loads(bp.read_text())
+        assert "b" not in baseline["items"]  # excluded, not baked in as False
+        assert "a" in baseline["items"]
+
+        # A later GENUINE regression on "a" (which WAS properly baselined)
+        # must still be detected — the fix doesn't affect non-infra items.
+        async def later(prompt):
+            return _fake_result("wrong answer")
+
+        later_run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs2", council_runner=later
+        )
+        cmp = compare_to_baseline(later_run, bp)
+        assert "a" in cmp["regressions"]
+        assert "b" not in cmp["regressions"]  # no false record either way
+
+    @pytest.mark.asyncio
     async def test_infra_error_not_reported_as_regression(self, tmp_path):
         # Council round-8 finding (in-diff, #507 follow-through): an item
         # that previously passed but now infra-errors must NOT show up as a

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -421,8 +421,80 @@ class TestRun:
         run = await run_bench(
             dataset_dir=d, runs_dir=tmp_path / "runs", council_runner=runner
         )
-        assert run.exit_code == 1
+        # #507: a run where EVERY item errored is an infra/abort outcome
+        # (exit 2), never envelope drift (exit 1) — a rate-limit/billing
+        # lapse must not read as "quality collapsed".
+        assert run.exit_code == 2
+        assert run.infra_errors == 1
+        assert run.items_scored == 0
+        assert run.aborted and "infra_failure" in run.aborted
+        assert run.results[0].is_infra is True
         assert "council_error" in run.results[0].failures[0]
+
+    @pytest.mark.asyncio
+    async def test_council_status_failed_counts_as_infra_not_drift(self, tmp_path):
+        # #507 empirically-observed case: the runner does NOT raise (graceful
+        # degradation — CLAUDE.md's "continue with whatever responses
+        # succeed" policy) but reports total failure via metadata.status.
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+
+        async def runner(prompt):
+            return {
+                "synthesis": "Error: All models failed to respond.",
+                "metadata": {"status": "failed"},
+            }
+
+        run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs", council_runner=runner
+        )
+        assert run.exit_code == 2  # infra/abort, not drift
+        assert run.infra_errors == 1
+        assert run.results[0].is_infra is True
+
+    @pytest.mark.asyncio
+    async def test_mixed_infra_and_drift_reports_both_separately(self, tmp_path):
+        # #507 acceptance: "mixed run reports both counts; drift exit
+        # reflects only genuinely-scored misses."
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")  # will infra-error
+        _write_item(d, "b")  # will genuinely fail its envelope
+
+        calls = {"n": 0}
+
+        async def runner(prompt):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("gateway down")
+            return _fake_result("wrong answer entirely")
+
+        run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs", council_runner=runner
+        )
+        assert run.infra_errors == 1
+        assert run.items_run == 2
+        assert run.items_scored == 1  # only the genuinely-run item
+        assert run.items_passed == 0  # that one item failed its envelope
+        assert run.exit_code == 1  # DRIFT — a real miss, not infra-masked
+        assert not run.aborted  # a mixed run is not itself "aborted"
+
+    def test_format_report_surfaces_infra_errors(self):
+        from llm_council.bench.harness import BenchRun, ItemResult
+
+        run = BenchRun(
+            started_at="t", items_total=1, items_run=1, items_passed=0,
+            total_cost_usd=0.0, cost_known=False, infra_errors=1,
+            aborted="infra_failure: 1/1 items errored",
+            results=[ItemResult(
+                item_id="a", domain="f", ok=False,
+                failures=["council_error:boom"], is_infra=True,
+            )],
+        )
+        report = format_report(run, {"baseline": None}, "md")
+        assert "Council/infra errors: 1/1" in report
+        assert "[INFRA] a" in report
 
     @pytest.mark.asyncio
     async def test_run_artefact_persisted(self, tmp_path):

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -549,6 +549,33 @@ class TestBaseline:
         assert cmp == {"baseline": None}
         assert "No committed baseline" in format_report(run, cmp)
 
+    @pytest.mark.asyncio
+    async def test_infra_error_not_reported_as_regression(self, tmp_path):
+        # Council round-8 finding (in-diff, #507 follow-through): an item
+        # that previously passed but now infra-errors must NOT show up as a
+        # "regression" — that would re-conflate infra with quality drift,
+        # exactly what #507 exists to prevent.
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+
+        async def good(prompt):
+            return _fake_result("hello")
+
+        async def erroring(prompt):
+            raise RuntimeError("gateway down")
+
+        base_run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs", council_runner=good
+        )
+        bp = set_baseline(base_run, tmp_path / "baseline.json")
+        infra_run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs2", council_runner=erroring
+        )
+        cmp = compare_to_baseline(infra_run, bp)
+        assert cmp["regressions"] == []  # NOT ["a"]
+        assert cmp["pass_rate"] is None  # items_scored == 0
+
 
 class TestCouncilRound1:
     @pytest.mark.asyncio

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -117,15 +117,22 @@ class TestEnvelope:
         assert check_envelope(item2, "avoid os.system on user input", None) == []
         assert check_envelope(item2, "the ecosystem is large", None) != []
 
-    def test_token_punctuation_edge_not_substring(self):
-        # #506 review: a token whose last char is non-word ("c++") must not
-        # match inside a longer token ("c++abc").
+    def test_punctuation_token_matches_after_a_word(self):
+        # Round 9 review: "?" (a REAL v1 token, code-sql-injection.json) is a
+        # LIVE regression from round 4's "fix" for a synthetic "c++abc" edge
+        # case — requiring no word char immediately BEFORE a trailing "?"
+        # broke the overwhelmingly common real position of "?": right after a
+        # word ("...use a parameter?"). Punctuation-edge tokens get no
+        # boundary requirement at all; a false-positive risk on a purely
+        # hypothetical token ("c++" is not in the dataset) is accepted in
+        # exchange for correct matching of the real one.
         item = BenchItem(
             id="x", domain="coding", prompt="p",
-            envelope={"must_contain": [["c++"]]},
+            envelope={"must_contain": [["?"]]},
         )
-        assert check_envelope(item, "written in c++ today", None) == []
-        assert check_envelope(item, "the c++abc library", None) != []
+        assert check_envelope(item, "should you use a parameter?", None) == []
+        assert check_envelope(item, "use a ? placeholder", None) == []
+        assert check_envelope(item, "no punctuation here at all", None) != []
 
     def test_score_floor(self):
         item = BenchItem(id="x", domain="f", prompt="p", envelope={"min_score": 0.5})

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -25,6 +25,7 @@ from llm_council.bench import (
     load_dataset,
     month_to_date_spend,
     run_bench,
+    run_from_dict,
     set_baseline,
 )
 
@@ -770,3 +771,68 @@ class TestCouncilRound3:
         assert run.aborted
         with pytest.raises(ValueError, match="aborted"):
             set_baseline(run, tmp_path / "baseline.json")
+
+
+class TestRunFromDict:
+    """Round 12 review: the CLI's report/baseline --set handlers used to
+    hand-list a fixed BenchRun field subset when reconstructing from a
+    persisted run-*.json, silently dropping every field added since —
+    cap_usd, filtered, infra_errors. `filtered` defaulting back to False was
+    the worst case: bench baseline --set could never actually refuse a
+    filtered run once round-tripped through a persisted artefact, a live
+    bypass of #517's fix through the one path (the CLI) that exercises it.
+    run_from_dict fixes this by deriving the accepted kwargs from
+    dataclasses.fields(), not a hand-maintained list.
+    """
+
+    @pytest.mark.asyncio
+    async def test_round_trip_preserves_new_fields(self, tmp_path):
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+        _write_item(d, "b")
+
+        async def mixed(prompt):
+            return _fake_result("hello")
+
+        runs = tmp_path / "runs"
+        run = await run_bench(
+            dataset_dir=d, runs_dir=runs, council_runner=mixed,
+            items_filter=["a"], max_usd=0.42,
+        )
+        assert run.filtered is True  # sanity: the live run is correctly flagged
+
+        persisted = json.loads(next(runs.glob("*.json")).read_text())
+        reloaded = run_from_dict(persisted)
+        assert reloaded.filtered is True  # NOT silently dropped back to False
+        assert reloaded.cap_usd == 0.42
+        assert reloaded.infra_errors == 0
+
+    def test_filtered_run_still_refused_after_cli_style_round_trip(self, tmp_path):
+        # The concrete #517 regression this closes: a filtered run, persisted
+        # then reloaded exactly as the CLI does, must still be refused by
+        # set_baseline — not silently accepted because `filtered` defaulted
+        # back to False.
+        from llm_council.bench.harness import BenchRun
+
+        run = BenchRun(
+            started_at="t", items_total=2, items_run=1, items_passed=1,
+            total_cost_usd=0.01, cost_known=True, filtered=True,
+        )
+        persisted = json.loads(json.dumps({**run.__dict__, "exit_code": run.exit_code}))
+        reloaded = run_from_dict(persisted)
+        assert reloaded.filtered is True
+        with pytest.raises(ValueError, match="filtered"):
+            set_baseline(reloaded, tmp_path / "baseline.json")
+
+    def test_tolerates_unknown_future_keys(self, tmp_path):
+        # Forward-compat: a key not in the current BenchRun/ItemResult schema
+        # (e.g. read by an older install after a downgrade) is ignored rather
+        # than raising a TypeError.
+        data = {
+            "started_at": "t", "items_total": 0, "items_run": 0,
+            "items_passed": 0, "total_cost_usd": 0.0, "cost_known": False,
+            "results": [], "exit_code": 0, "some_future_field": "unused",
+        }
+        run = run_from_dict(data)
+        assert run.items_total == 0

--- a/tests/test_bench_matrix.py
+++ b/tests/test_bench_matrix.py
@@ -101,6 +101,34 @@ class TestMatrix:
         assert by_name["bad"]["pass_rate"] == 0.0
         assert by_name["council"]["pass_rate"] == 1.0
 
+    @pytest.mark.asyncio
+    async def test_pass_rate_excludes_infra_errors_from_denominator(self, tmp_path):
+        # #507 follow-through (Council round-8 finding, in-diff): an
+        # infra-errored item must not deflate pass_rate — items_scored
+        # excludes it from the denominator, same as BenchRun.exit_code.
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+        _write_item(d, "b")
+
+        calls = {"n": 0}
+
+        async def mixed(prompt):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("gateway down")
+            return _result("hello")
+
+        rows = await run_matrix(
+            [MatrixConfig(name="mixed", kind="solo", runner=mixed)],
+            dataset_dir=d,
+            runs_dir=tmp_path / "runs",
+            max_usd=2.0,
+        )
+        # 1 genuine pass, 1 infra error: NOT 50% (items_run) — 100% of what
+        # actually got scored.
+        assert rows[0]["pass_rate"] == 1.0
+
 
 class TestCouncilRound1:
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #507 — part of epic #505 (bench hardening).

## Problem (empirically demonstrated 2026-07-06)
A rate-limit/billing lapse during a 6-item run reported `0/6 within envelope — exit 1`, `$0.00` spend, every item `score_unavailable` — indistinguishable from a genuine quality regression. A nightly CI run in this state fires a false 'quality collapsed' alarm.

## Fix
- `ItemResult.is_infra` + `BenchRun.infra_errors` track council/infra errors (runner raised, OR the council itself reports `metadata.status == "failed"` — the graceful-degradation no-responses case) separately from genuine envelope misses.
- `BenchRun.items_scored = items_run - infra_errors`; `exit_code` compares `items_passed` against `items_scored`, so infra errors never masquerade as drift.
- All-items-infra-errored ⇒ `aborted` (exit 2), never a green pass or false drift. A **mixed** run (some infra, some genuinely scored) is not itself aborted — its exit reflects only the genuinely-scored items.
- `format_report` surfaces `infra_errors` and marks infra items `[INFRA]` (not `[FAIL]`).

## Tests (TDD)
Updated the pre-existing council-error test (single infra-errored item now correctly exits 2, not 1 — that was exactly this bug) + 3 new tests (status=='failed' path, mixed infra+drift, report surfacing). Full suite green (3350 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)