### PR TITLE
fix(bench): matrix-wide spend budget shared across configs

### DIFF
--- a/src/llm_council/bench/matrix.py
+++ b/src/llm_council/bench/matrix.py
@@ -229,7 +229,12 @@ def format_matrix_table(rows: List[Dict[str, Any]]) -> str:
         cost = f"{r['cost_usd']:.4f}" if r["cost_known"] else f"~{r['cost_usd']:.4f} (unknown)"
         qpd = r["quality_per_dollar"]
         qpd_str = f"{qpd:.3f}" if qpd is not None else "n/a"
-        note = " (aborted)" if r.get("aborted") else ""
+        # Show the ACTUAL reason (config_error / matrix_budget_exhausted /
+        # per_run_cap / ...), not a generic "(aborted)" — the round-2 review
+        # correctly noted this silently discarded exactly the observability
+        # this session's own fixes (config_error, matrix_budget_exhausted)
+        # depend on to be useful in the table, not just the JSON.
+        note = f" ({r['aborted']})" if r.get("aborted") else ""
         lines.append(
             f"| {r['config']}{note} | {r['kind']} | {r['items_run']} "
             f"| {r['pass_rate']:.0%} | {cost} | {qpd_str} |"

--- a/src/llm_council/bench/matrix.py
+++ b/src/llm_council/bench/matrix.py
@@ -205,7 +205,10 @@ async def run_matrix(
                     "items_run": 0,
                     "pass_rate": 0.0,
                     "cost_usd": 0.0,
-                    "cost_known": False,
+                    # Round 6 review: $0 is KNOWN with certainty here (the
+                    # config never ran), not "unknown" — cost_known means "do
+                    # we have a reliable figure", and we do.
+                    "cost_known": True,
                     "cap_charged_usd": 0.0,  # nothing was spent — this is known, not assumed
                     "quality_per_dollar": None,
                     "aborted": f"config_error: {exc}",
@@ -235,7 +238,13 @@ async def run_matrix(
             # _default_runner branch above, run_bench WAS actually invoked
             # here, so "unknown, possibly real" is the honest state, not "zero".
             exhausted = remaining
-            spent = total_budget
+            # += exhausted, not "= total_budget" (round 6 review) — same
+            # accumulator pattern as the success path below, even though the
+            # arithmetic is equivalent here (spent + remaining == total_budget
+            # by construction): a future edit that adds another accumulation
+            # site is less likely to reintroduce a divergent "hardcode the
+            # total" pattern if there's only ever one style to follow.
+            spent = round(spent + exhausted, 6)
             rows.append(
                 {
                     "config": config.name,

--- a/src/llm_council/bench/matrix.py
+++ b/src/llm_council/bench/matrix.py
@@ -58,6 +58,15 @@ def _default_runner(config: MatrixConfig) -> Callable[..., Any]:
     if config.kind not in ("solo", "council", "graduated"):
         raise ValueError(f"unknown matrix kind: {config.kind!r}")
     if config.kind == "solo":
+        # Explicit ValueError instead of a bare IndexError (round 3 review):
+        # safely caught by run_matrix's try/except either way, but a generic
+        # "list index out of range" is uninformative in the table's abort
+        # reason (which round 2's fix made visible specifically so this kind
+        # of message would be useful).
+        if ":" not in config.name:
+            raise ValueError(
+                f"solo config name {config.name!r} must be 'solo:<model>'"
+            )
         model = config.name.split(":", 1)[1]
 
         async def solo_runner(prompt: str) -> Dict[str, Any]:
@@ -173,6 +182,17 @@ async def run_matrix(
                 ignore_score_floor=(config.kind == "solo"),
             )
         except Exception as exc:
+            # Round 3 review, against MY OWN round-1 fix: before that fix, ANY
+            # exception here crashed the whole matrix (loud). Now it's caught
+            # silently — but run_bench may have already made real, costly API
+            # calls before failing partway through (e.g. mid-_run_items), and
+            # there is no reliable way to recover a partial cap_charged_usd
+            # from a call that raised. Assume the WORST CASE (this attempt may
+            # have consumed the entire remaining budget) rather than zero —
+            # same conservative-charge philosophy as bench_unknown_item_usd
+            # elsewhere in this epic — so a genuinely-unknown spend can never
+            # let a LATER config overspend on top of it.
+            spent = total_budget
             rows.append(
                 {
                     "config": config.name,

--- a/src/llm_council/bench/matrix.py
+++ b/src/llm_council/bench/matrix.py
@@ -75,9 +75,20 @@ def _default_runner(config: MatrixConfig) -> Callable[..., Any]:
             response = await query_model_with_status(
                 model, [{"role": "user", "content": prompt}], timeout=120.0
             )
-            usage = (response or {}).get("usage") or {}
+            if response is None:
+                # query_model_with_status returns None on failure (timeout,
+                # API error — graceful degradation per CLAUDE.md's Error
+                # handling policy). Round 5 review: silently defaulting to an
+                # empty-but-"successful"-looking synthesis/cost here would
+                # mask an infra failure as a genuine (if poor) quality result
+                # — harness's check_envelope would score it as a real miss.
+                # Use the SAME metadata.status=="failed" convention #507
+                # established for the council path, so it's correctly
+                # classified as an infra error (is_infra=True), not drift.
+                return {"synthesis": "", "metadata": {"status": "failed"}}
+            usage = response.get("usage") or {}
             return {
-                "synthesis": (response or {}).get("content") or "",
+                "synthesis": response.get("content") or "",
                 "metadata": {
                     "aggregate_rankings": [],
                     "usage": {
@@ -170,13 +181,38 @@ async def run_matrix(
         try:
             # _default_runner validates config.kind and parses config.name
             # (e.g. "solo:<model>") EAGERLY, before any item runs — a
-            # malformed name (no colon) or an unknown kind raises here, not
-            # inside harness's own per-item try/except. Uncaught, that would
-            # crash the WHOLE matrix mid-run and discard already-PAID-FOR
-            # results from every earlier config (round 1 review) — exactly
-            # the failure mode the docstring promises never happens ("one
-            # broken configuration never aborts the rest of the matrix").
+            # malformed name (no colon) or an unknown kind raises HERE,
+            # before run_bench is ever invoked. Uncaught, that would crash
+            # the WHOLE matrix mid-run and discard already-PAID-FOR results
+            # from every earlier config (round 1 review) — exactly the
+            # failure mode the docstring promises never happens ("one broken
+            # configuration never aborts the rest of the matrix").
             runner = config.runner or _default_runner(config)
+        except Exception as exc:
+            # Round 5 review, against MY OWN round-3 fix: this branch is
+            # UNREACHED run_bench — genuinely ZERO spend occurred (a config
+            # NAME TYPO never gets the chance to spend anything). Treating it
+            # the same as a mid-run_bench failure (round 3's conservative
+            # spent=total_budget) was itself a bug: one config's typo would
+            # silently skip every OTHER config over $0 actually spent — not
+            # much better than the pre-round-1 crash from the user's point of
+            # view. Only a genuine run_bench failure (below) needs the
+            # conservative worst-case charge.
+            rows.append(
+                {
+                    "config": config.name,
+                    "kind": config.kind,
+                    "items_run": 0,
+                    "pass_rate": 0.0,
+                    "cost_usd": 0.0,
+                    "cost_known": False,
+                    "cap_charged_usd": 0.0,  # nothing was spent — this is known, not assumed
+                    "quality_per_dollar": None,
+                    "aborted": f"config_error: {exc}",
+                }
+            )
+            continue
+        try:
             run = await run_bench(
                 dataset_dir=dataset_dir,
                 runs_dir=runs_dir,
@@ -195,9 +231,9 @@ async def run_matrix(
             # have consumed the entire remaining budget) rather than zero —
             # same conservative-charge philosophy as bench_unknown_item_usd
             # elsewhere in this epic — so a genuinely-unknown spend can never
-            # let a LATER config overspend on top of it.
-            # The amount conservatively treated as consumed by this failing
-            # config is whatever budget remained when it started.
+            # let a LATER config overspend on top of it. Unlike the
+            # _default_runner branch above, run_bench WAS actually invoked
+            # here, so "unknown, possibly real" is the honest state, not "zero".
             exhausted = remaining
             spent = total_budget
             rows.append(

--- a/src/llm_council/bench/matrix.py
+++ b/src/llm_council/bench/matrix.py
@@ -113,22 +113,61 @@ async def run_matrix(
     max_usd: Optional[float] = None,
     items_filter: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
-    """Run every configuration; each gets its own capped bench run.
+    """Run every configuration against a SHARED matrix-wide budget (#511).
+
+    ``max_usd`` is the TOTAL ceiling across every config, not a per-config
+    cap: passing the same cap to each of N configs (the old behaviour) could
+    spend up to N times the intended budget in one invocation, with only the
+    monthly guard bounding the total, and only between separate invocations.
+    Each config's own cap is now the REMAINING budget when it starts, so the
+    matrix as a whole can never exceed ``max_usd`` (bench_max_usd() when
+    unset). A config starting with zero (or negative, from float rounding)
+    remaining budget is skipped entirely rather than run — it would abort on
+    its own first item anyway (harness's own cap<=0 short-circuit), but
+    skipping makes the reason explicit in that config's row instead of a
+    bare zero-item aborted result.
 
     A config whose runner errors on every item simply scores 0 — one broken
     configuration never aborts the rest of the matrix.
     """
+    from .harness import bench_max_usd
+
+    total_budget = max_usd if max_usd is not None else bench_max_usd()
+    spent = 0.0
     rows: List[Dict[str, Any]] = []
     for config in configs:
+        remaining = round(total_budget - spent, 6)
+        if remaining <= 0:
+            rows.append(
+                {
+                    "config": config.name,
+                    "kind": config.kind,
+                    "items_run": 0,
+                    "pass_rate": 0.0,
+                    "cost_usd": 0.0,
+                    "cost_known": False,
+                    "quality_per_dollar": None,
+                    "aborted": (
+                        f"matrix_budget_exhausted: ${spent:.2f} of ${total_budget:.2f} "
+                        "total already spent by earlier configs — skipped, not run"
+                    ),
+                }
+            )
+            continue
         runner = config.runner or _default_runner(config)
         run = await run_bench(
             dataset_dir=dataset_dir,
             runs_dir=runs_dir,
-            max_usd=max_usd,
+            max_usd=remaining,
             items_filter=items_filter,
             council_runner=runner,
             ignore_score_floor=(config.kind == "solo"),
         )
+        # cap_charged_usd (actuals + conservative unknown-cost charges), not
+        # total_cost_usd — same convention as the monthly ledger (#439 r2/r3):
+        # an unknown-cost config must still count against the shared budget,
+        # not silently look free to the configs that follow it.
+        spent = round(spent + run.cap_charged_usd, 6)
         # Consistent with BenchRun.exit_code (#507): pass rate excludes
         # council/infra-errored items, which never had a chance to score — an
         # infra-heavy config must not look artificially worse in the

--- a/src/llm_council/bench/matrix.py
+++ b/src/llm_council/bench/matrix.py
@@ -154,15 +154,38 @@ async def run_matrix(
                 }
             )
             continue
-        runner = config.runner or _default_runner(config)
-        run = await run_bench(
-            dataset_dir=dataset_dir,
-            runs_dir=runs_dir,
-            max_usd=remaining,
-            items_filter=items_filter,
-            council_runner=runner,
-            ignore_score_floor=(config.kind == "solo"),
-        )
+        try:
+            # _default_runner validates config.kind and parses config.name
+            # (e.g. "solo:<model>") EAGERLY, before any item runs — a
+            # malformed name (no colon) or an unknown kind raises here, not
+            # inside harness's own per-item try/except. Uncaught, that would
+            # crash the WHOLE matrix mid-run and discard already-PAID-FOR
+            # results from every earlier config (round 1 review) — exactly
+            # the failure mode the docstring promises never happens ("one
+            # broken configuration never aborts the rest of the matrix").
+            runner = config.runner or _default_runner(config)
+            run = await run_bench(
+                dataset_dir=dataset_dir,
+                runs_dir=runs_dir,
+                max_usd=remaining,
+                items_filter=items_filter,
+                council_runner=runner,
+                ignore_score_floor=(config.kind == "solo"),
+            )
+        except Exception as exc:
+            rows.append(
+                {
+                    "config": config.name,
+                    "kind": config.kind,
+                    "items_run": 0,
+                    "pass_rate": 0.0,
+                    "cost_usd": 0.0,
+                    "cost_known": False,
+                    "quality_per_dollar": None,
+                    "aborted": f"config_error: {exc}",
+                }
+            )
+            continue
         # cap_charged_usd (actuals + conservative unknown-cost charges), not
         # total_cost_usd — same convention as the monthly ledger (#439 r2/r3):
         # an unknown-cost config must still count against the shared budget,

--- a/src/llm_council/bench/matrix.py
+++ b/src/llm_council/bench/matrix.py
@@ -155,6 +155,10 @@ async def run_matrix(
                     "pass_rate": 0.0,
                     "cost_usd": 0.0,
                     "cost_known": False,
+                    # Nothing NEW consumed — this config never started at all
+                    # (distinct from the exception path, which conservatively
+                    # charges its whole remaining allotment).
+                    "cap_charged_usd": 0.0,
                     "quality_per_dollar": None,
                     "aborted": (
                         f"matrix_budget_exhausted: ${spent:.2f} of ${total_budget:.2f} "
@@ -192,6 +196,9 @@ async def run_matrix(
             # same conservative-charge philosophy as bench_unknown_item_usd
             # elsewhere in this epic — so a genuinely-unknown spend can never
             # let a LATER config overspend on top of it.
+            # The amount conservatively treated as consumed by this failing
+            # config is whatever budget remained when it started.
+            exhausted = remaining
             spent = total_budget
             rows.append(
                 {
@@ -201,6 +208,11 @@ async def run_matrix(
                     "pass_rate": 0.0,
                     "cost_usd": 0.0,
                     "cost_known": False,
+                    # Round 4 review: the row must not show cost_usd=0.0 while
+                    # the ledger silently charges the whole remaining budget
+                    # against this config elsewhere — surface the conservative
+                    # assumption explicitly instead of hiding it.
+                    "cap_charged_usd": exhausted,
                     "quality_per_dollar": None,
                     "aborted": f"config_error: {exc}",
                 }
@@ -226,6 +238,15 @@ async def run_matrix(
                 "pass_rate": pass_rate,
                 "cost_usd": run.total_cost_usd,
                 "cost_known": run.cost_known,
+                # Round 4 review: expose the guard's OWN conservative figure
+                # (actuals + unknown-cost charges) alongside the honest
+                # actual-cost figure above — they can legitimately differ
+                # (unknown-cost items charge a safety margin for the budget
+                # that isn't necessarily real spend), and that's by design
+                # (same distinction as month_to_date_spend's ledger), not a
+                # bug; showing both answers "why doesn't this add up?"
+                # instead of hiding one side of it.
+                "cap_charged_usd": run.cap_charged_usd,
                 "quality_per_dollar": quality_per_dollar(
                     pass_rate=pass_rate,
                     cost_usd=run.total_cost_usd,
@@ -235,6 +256,17 @@ async def run_matrix(
             }
         )
     return rows
+
+
+def _md_table_cell(value: str) -> str:
+    """Escape a value for embedding in a markdown table cell (round 4 review).
+
+    A `|` in an exception message (config_error's `str(exc)`) or a
+    user-supplied config name would otherwise split into extra columns and
+    corrupt the row; a newline would break it across lines. Both are
+    realistic here — `config_error` embeds an arbitrary exception message.
+    """
+    return str(value).replace("|", "\\|").replace("\n", " ").replace("\r", " ")
 
 
 def format_matrix_table(rows: List[Dict[str, Any]]) -> str:
@@ -254,10 +286,10 @@ def format_matrix_table(rows: List[Dict[str, Any]]) -> str:
         # correctly noted this silently discarded exactly the observability
         # this session's own fixes (config_error, matrix_budget_exhausted)
         # depend on to be useful in the table, not just the JSON.
-        note = f" ({r['aborted']})" if r.get("aborted") else ""
+        note = f" ({_md_table_cell(r['aborted'])})" if r.get("aborted") else ""
         lines.append(
-            f"| {r['config']}{note} | {r['kind']} | {r['items_run']} "
-            f"| {r['pass_rate']:.0%} | {cost} | {qpd_str} |"
+            f"| {_md_table_cell(r['config'])}{note} | {_md_table_cell(r['kind'])} "
+            f"| {r['items_run']} | {r['pass_rate']:.0%} | {cost} | {qpd_str} |"
         )
     lines.append("")
     lines.append(

--- a/src/llm_council/cli.py
+++ b/src/llm_council/cli.py
@@ -85,6 +85,17 @@ def bench_command(
                 sys.stdout.write(f"Unknown matrix config: {name}\n")
                 return 2
         items_filter = [i.strip() for i in items.split(",")] if items else None
+        # Shown BEFORE spending (#511 acceptance): max_usd is now the TOTAL
+        # ceiling shared across every config, not a per-config cap — make
+        # that bound visible up front rather than only discoverable by
+        # reading each row's cost after the fact.
+        from .bench.harness import bench_max_usd
+
+        effective_budget = max_usd if max_usd is not None else bench_max_usd()
+        sys.stdout.write(
+            f"Matrix budget: ${effective_budget:.2f} total across "
+            f"{len(matrix_configs)} config(s)\n"
+        )
         rows = asyncio.run(
             run_matrix(
                 matrix_configs,
@@ -322,7 +333,7 @@ def main():
     )
     bench_parser.add_argument("--dataset", type=str, default="bench/dataset/v1", help="Dataset directory (default: bench/dataset/v1)")
     bench_parser.add_argument("--items", type=str, default=None, help="Comma-separated item ids to run (default: all)")
-    bench_parser.add_argument("--max-usd", type=float, default=None, dest="max_usd", help="Per-run spend cap in USD (default: LLM_COUNCIL_BENCH_MAX_USD, $2.00; monthly guard LLM_COUNCIL_BENCH_MONTHLY_USD, $30)")
+    bench_parser.add_argument("--max-usd", type=float, default=None, dest="max_usd", help="Spend cap in USD (default: LLM_COUNCIL_BENCH_MAX_USD, $2.00; monthly guard LLM_COUNCIL_BENCH_MONTHLY_USD, $30). For `run`: per-run cap. For `matrix` (#511): TOTAL shared across every config, not per-config — a config starting with zero budget remaining is skipped.")
     bench_parser.add_argument("--set", action="store_true", dest="set_baseline_flag",
                               help="(baseline) write the snapshot")
     bench_parser.add_argument("--format", choices=["md", "json"], default="md", dest="bench_format", help="Report format (default: md)")

--- a/tests/test_bench_harness.py
+++ b/tests/test_bench_harness.py
@@ -197,6 +197,31 @@ class TestRun:
         assert len(run.results) == 2
 
     @pytest.mark.asyncio
+    async def test_max_usd_zero_short_circuits_before_any_item(self, tmp_path):
+        # #511 acceptance: --max-usd 0 (or negative) must spend $0 and abort
+        # immediately — the top-of-loop check (cap_charged=0.0 >= cap<=0) was
+        # already correct by the time this ticket was picked up; this locks
+        # it in as a regression test rather than "fixing" a non-defect.
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+
+        called = []
+
+        async def runner(prompt):
+            called.append(prompt)
+            return _fake_result("hello")
+
+        run = await run_bench(
+            dataset_dir=d, runs_dir=tmp_path / "runs",
+            council_runner=runner, max_usd=0.0,
+        )
+        assert called == []  # zero spend — the runner is never invoked
+        assert run.items_run == 0
+        assert run.exit_code == 2
+        assert run.aborted and "per_run_cap" in run.aborted
+
+    @pytest.mark.asyncio
     async def test_final_item_overshoot_not_silent_exit0(self, tmp_path):
         # #510/#511 (Council critical): the between-item cap check never sees
         # an overshoot caused by the FINAL item — a 1-item run over cap used to

--- a/tests/test_bench_matrix.py
+++ b/tests/test_bench_matrix.py
@@ -102,6 +102,53 @@ class TestMatrix:
         assert by_name["council"]["pass_rate"] == 1.0
 
     @pytest.mark.asyncio
+    async def test_malformed_config_name_does_not_crash_matrix(self, tmp_path):
+        # Round-1 review (#511): _default_runner eagerly parses config.name
+        # ("solo:<model>") and validates config.kind BEFORE any item runs —
+        # unguarded, a colon-less name raised an uncaught IndexError that
+        # crashed the WHOLE matrix mid-loop, discarding already-PAID-FOR
+        # results from every earlier config. A later config's typo must not
+        # destroy prior configs' results.
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+
+        async def good(prompt):
+            return _result("hello", cost=0.05)
+
+        configs = [
+            MatrixConfig(name="council", kind="council", runner=good),
+            MatrixConfig(name="solo-missing-colon", kind="solo"),  # no runner override
+        ]
+        rows = await run_matrix(
+            configs, dataset_dir=d, runs_dir=tmp_path / "runs", max_usd=2.0
+        )
+        by_name = {r["config"]: r for r in rows}
+        assert by_name["council"]["cost_usd"] == 0.05  # prior result PRESERVED
+        assert by_name["solo-missing-colon"]["items_run"] == 0
+        assert "config_error" in by_name["solo-missing-colon"]["aborted"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_kind_does_not_crash_matrix(self, tmp_path):
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+
+        async def good(prompt):
+            return _result("hello", cost=0.05)
+
+        configs = [
+            MatrixConfig(name="council", kind="council", runner=good),
+            MatrixConfig(name="bogus", kind="not-a-real-kind"),
+        ]
+        rows = await run_matrix(
+            configs, dataset_dir=d, runs_dir=tmp_path / "runs", max_usd=2.0
+        )
+        by_name = {r["config"]: r for r in rows}
+        assert by_name["council"]["cost_usd"] == 0.05
+        assert "config_error" in by_name["bogus"]["aborted"]
+
+    @pytest.mark.asyncio
     async def test_matrix_wide_budget_shared_across_configs(self, tmp_path):
         # #511: max_usd is the TOTAL across every config, not per-config — the
         # old behaviour passed the SAME cap to each config, so N configs

--- a/tests/test_bench_matrix.py
+++ b/tests/test_bench_matrix.py
@@ -148,6 +148,18 @@ class TestMatrix:
         assert by_name["council"]["cost_usd"] == 0.05
         assert "config_error" in by_name["bogus"]["aborted"]
 
+    def test_table_shows_actual_abort_reason_not_generic(self):
+        # Round 2 review: the table used to show a bare "(aborted)" suffix,
+        # discarding exactly the config_error/matrix_budget_exhausted reason
+        # this session's own fixes depend on being visible.
+        rows = [{
+            "config": "bad", "kind": "solo", "items_run": 0, "pass_rate": 0.0,
+            "cost_usd": 0.0, "cost_known": False, "quality_per_dollar": None,
+            "aborted": "config_error: bad config",
+        }]
+        table = format_matrix_table(rows)
+        assert "config_error: bad config" in table
+
     @pytest.mark.asyncio
     async def test_matrix_wide_budget_shared_across_configs(self, tmp_path):
         # #511: max_usd is the TOTAL across every config, not per-config — the

--- a/tests/test_bench_matrix.py
+++ b/tests/test_bench_matrix.py
@@ -156,6 +156,10 @@ class TestMatrix:
         )
         by_name = {r["config"]: r for r in rows}
         assert "config_error" in by_name["broken"]["aborted"]
+        # Round 4 review: the row must not silently show cost_usd=0.0 while
+        # the ledger conservatively charges the whole remaining budget
+        # elsewhere — cap_charged_usd surfaces exactly what was assumed.
+        assert by_name["broken"]["cap_charged_usd"] == 2.0
         # "good" never actually ran — the failing config conservatively
         # consumed the whole budget, exactly like a real overspend would.
         assert by_name["good"]["items_run"] == 0
@@ -208,6 +212,23 @@ class TestMatrix:
         by_name = {r["config"]: r for r in rows}
         assert by_name["council"]["cost_usd"] == 0.05
         assert "config_error" in by_name["bogus"]["aborted"]
+
+    def test_table_escapes_pipe_in_abort_reason(self):
+        # Round 4 review: a `|` in an exception message (config_error embeds
+        # str(exc) verbatim) would otherwise split into extra columns and
+        # corrupt the table's structure.
+        rows = [{
+            "config": "bad", "kind": "solo", "items_run": 0, "pass_rate": 0.0,
+            "cost_usd": 0.0, "cost_known": False, "quality_per_dollar": None,
+            "aborted": "config_error: boom | evil | injection",
+        }]
+        table = format_matrix_table(rows)
+        # Escaped (\|), not a raw column-splitting pipe: a markdown renderer
+        # treats \| as a literal character, not a cell boundary, so the row
+        # still renders as ONE config cell instead of splitting into extra
+        # columns.
+        assert "boom \\| evil \\| injection" in table
+        assert "boom | evil | injection" not in table  # the unescaped form is gone
 
     def test_table_shows_actual_abort_reason_not_generic(self):
         # Round 2 review: the table used to show a bare "(aborted)" suffix,

--- a/tests/test_bench_matrix.py
+++ b/tests/test_bench_matrix.py
@@ -101,6 +101,58 @@ class TestMatrix:
         assert by_name["bad"]["pass_rate"] == 0.0
         assert by_name["council"]["pass_rate"] == 1.0
 
+    @pytest.mark.asyncio
+    async def test_config_validation_error_does_not_exhaust_budget(self, tmp_path):
+        # Round 5 review, against MY OWN round-3 fix: a config NAME TYPO is
+        # caught by _default_runner BEFORE run_bench is ever invoked — ZERO
+        # spend occurred, known for certain (not just assumed). Treating it
+        # like a genuine mid-run_bench failure (round 3's conservative
+        # spent=total_budget) was itself a bug: one config's typo would
+        # silently skip every OTHER config over $0 actually spent.
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+
+        async def good(prompt):
+            return _result("hello", cost=0.05)
+
+        configs = [
+            MatrixConfig(name="typo-no-colon", kind="solo"),  # no runner override
+            MatrixConfig(name="good", kind="solo", runner=good),
+        ]
+        rows = await run_matrix(
+            configs, dataset_dir=d, runs_dir=tmp_path / "runs", max_usd=2.0
+        )
+        by_name = {r["config"]: r for r in rows}
+        assert "config_error" in by_name["typo-no-colon"]["aborted"]
+        assert by_name["typo-no-colon"]["cap_charged_usd"] == 0.0
+        # The SUBSEQUENT config must run normally — not skipped as
+        # "budget exhausted" over a typo that spent nothing.
+        assert by_name["good"]["items_run"] == 1
+        assert by_name["good"]["cost_usd"] == 0.05
+        assert by_name["good"].get("aborted") in (None, "")
+
+    @pytest.mark.asyncio
+    async def test_solo_runner_none_response_marks_infra_not_empty_pass(
+        self, tmp_path, monkeypatch
+    ):
+        # Round 5 review: query_model_with_status returns None on failure
+        # (timeout/API error, graceful degradation). Silently defaulting to
+        # an empty-but-"successful"-looking result would mask an infra
+        # failure as a genuine quality miss. Must use the SAME
+        # metadata.status=="failed" convention #507 established.
+        import llm_council.gateway_adapter as gw
+        from llm_council.bench.matrix import _default_runner
+
+        async def failing(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(gw, "query_model_with_status", failing)
+
+        runner = _default_runner(MatrixConfig(name="solo:some-model", kind="solo"))
+        result = await runner("q")
+        assert result["metadata"]["status"] == "failed"
+
     def test_solo_missing_colon_raises_explicit_value_error(self):
         # Round 3 review: an explicit, clear message instead of a bare
         # "list index out of range" IndexError.

--- a/tests/test_bench_matrix.py
+++ b/tests/test_bench_matrix.py
@@ -102,6 +102,43 @@ class TestMatrix:
         assert by_name["council"]["pass_rate"] == 1.0
 
     @pytest.mark.asyncio
+    async def test_matrix_wide_budget_shared_across_configs(self, tmp_path):
+        # #511: max_usd is the TOTAL across every config, not per-config — the
+        # old behaviour passed the SAME cap to each config, so N configs
+        # could spend up to N x cap in one invocation. 3 configs at $1/item,
+        # budget $2 total: only the first 2 may spend; the 3rd must be
+        # skipped BEFORE it runs (its runner never called), not run-then-
+        # capped.
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+
+        call_log = []
+
+        def make_runner(name):
+            async def runner(prompt):
+                call_log.append(name)
+                return _result("hello", cost=1.0)
+            return runner
+
+        configs = [
+            MatrixConfig(name="one", kind="solo", runner=make_runner("one")),
+            MatrixConfig(name="two", kind="solo", runner=make_runner("two")),
+            MatrixConfig(name="three", kind="solo", runner=make_runner("three")),
+        ]
+        rows = await run_matrix(
+            configs, dataset_dir=d, runs_dir=tmp_path / "runs", max_usd=2.0
+        )
+        assert call_log == ["one", "two"]  # "three"'s runner never invoked
+        by_name = {r["config"]: r for r in rows}
+        assert by_name["one"]["cost_usd"] == 1.0
+        assert by_name["two"]["cost_usd"] == 1.0
+        assert by_name["three"]["items_run"] == 0
+        assert "matrix_budget_exhausted" in by_name["three"]["aborted"]
+        total_spent = sum(r["cost_usd"] for r in rows)
+        assert total_spent <= 2.0  # the whole point: bounded, not N x cap
+
+    @pytest.mark.asyncio
     async def test_pass_rate_excludes_infra_errors_from_denominator(self, tmp_path):
         # #507 follow-through (Council round-8 finding, in-diff): an
         # infra-errored item must not deflate pass_rate — items_scored

--- a/tests/test_bench_matrix.py
+++ b/tests/test_bench_matrix.py
@@ -101,6 +101,67 @@ class TestMatrix:
         assert by_name["bad"]["pass_rate"] == 0.0
         assert by_name["council"]["pass_rate"] == 1.0
 
+    def test_solo_missing_colon_raises_explicit_value_error(self):
+        # Round 3 review: an explicit, clear message instead of a bare
+        # "list index out of range" IndexError.
+        from llm_council.bench.matrix import _default_runner
+
+        with pytest.raises(ValueError, match="must be 'solo:<model>'"):
+            _default_runner(MatrixConfig(name="no-colon-here", kind="solo"))
+
+    @pytest.mark.asyncio
+    async def test_config_exception_conservatively_exhausts_budget(
+        self, tmp_path, monkeypatch
+    ):
+        # Round 3 review, against my OWN round-1 fix: before it, ANY
+        # exception from run_bench crashed the whole matrix (loud). Catching
+        # it silently assumed zero spend — but run_bench may have already
+        # made real, costly API calls before failing partway through (e.g. in
+        # the monthly-guard-lock exit path, after _run_items already spent),
+        # with no reliable way to recover a partial cost figure. A failing
+        # config must conservatively consume the WHOLE remaining budget so a
+        # later config can never overspend on top of an unknown cost.
+        #
+        # A plain runner exception does NOT reach this path — harness's own
+        # per-item loop (#507) already absorbs it as an infra_failure without
+        # run_bench raising. To exercise run_bench raising directly (the
+        # actual scenario the finding describes), patch it at the point
+        # matrix.py calls it.
+        import llm_council.bench.matrix as matrix_mod
+
+        d = tmp_path / "ds"
+        d.mkdir()
+        _write_item(d, "a")
+
+        call_count = {"n": 0}
+        real_run_bench = matrix_mod.run_bench
+
+        async def flaky_run_bench(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("boom mid-run_bench")
+            return await real_run_bench(*args, **kwargs)
+
+        monkeypatch.setattr(matrix_mod, "run_bench", flaky_run_bench)
+
+        async def good(prompt):
+            return _result("hello", cost=0.05)
+
+        configs = [
+            MatrixConfig(name="broken", kind="solo", runner=good),
+            MatrixConfig(name="good", kind="solo", runner=good),
+        ]
+        rows = await run_matrix(
+            configs, dataset_dir=d, runs_dir=tmp_path / "runs", max_usd=2.0
+        )
+        by_name = {r["config"]: r for r in rows}
+        assert "config_error" in by_name["broken"]["aborted"]
+        # "good" never actually ran — the failing config conservatively
+        # consumed the whole budget, exactly like a real overspend would.
+        assert by_name["good"]["items_run"] == 0
+        assert "matrix_budget_exhausted" in by_name["good"]["aborted"]
+        assert call_count["n"] == 1  # good's run_bench call was never reached
+
     @pytest.mark.asyncio
     async def test_malformed_config_name_does_not_crash_matrix(self, tmp_path):
         # Round-1 review (#511): _default_runner eagerly parses config.name


### PR DESCRIPTION
Closes #511 — part of epic #505 (bench hardening).

## Problem
`bench matrix` passed the SAME `max_usd` to every config, so N configs could spend up to N x the intended cap in one invocation — bounded only by the monthly guard, and only between separate invocations.

## Fix
- `max_usd` is now the TOTAL ceiling shared across every config, not per-config. Each subsequent config gets whatever remains; a config starting at zero (or negative) remaining budget is skipped entirely (clear `matrix_budget_exhausted` reason in its row), not run-then-capped.
- Spend tracked via `cap_charged_usd` (actuals + conservative unknown-cost charges) — same convention as the monthly ledger, so an unknown-cost config still counts against the shared budget.
- CLI prints the effective total budget before running the matrix (acceptance: bounded + shown before spending); `--max-usd` help text documents the per-run-vs-matrix-total distinction.

## Second half of the ticket
`--max-usd 0` spending $0 and aborting immediately was **already correct** by the time this was picked up — the top-of-loop `cap_charged=0.0 >= cap` check already short-circuits before any item runs for `cap<=0`. Added a regression test locking it in rather than "fixing" a non-defect.

## Tests (TDD)
3 configs at $1/item, budget $2 total: only the first 2 configs run (their spend sums to exactly $2); the 3rd is skipped BEFORE its runner is ever invoked. Full suite green (3358 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)