### PR TITLE
fix(verify): .lock missing from TEXT_EXTENSIONS excludes uv.lock

### DIFF
--- a/src/llm_council/verification/constants.py
+++ b/src/llm_council/verification/constants.py
@@ -119,6 +119,11 @@ TEXT_EXTENSIONS: Set[str] = frozenset(
         ".yaml",
         ".yml",
         ".toml",
+        # #533: .lock is TOML for uv (uv.lock) and plain text for several
+        # other ecosystems; deny-listed lockfiles (yarn.lock, poetry.lock,
+        # etc.) are excluded separately via GARBAGE_FILENAMES, checked
+        # before _is_text_file, so this only affects non-deny-listed ones.
+        ".lock",
         ".xml",
         ".xsd",
         ".xsl",

--- a/tests/test_directory_expansion.py
+++ b/tests/test_directory_expansion.py
@@ -576,6 +576,21 @@ class TestConstants:
         assert "yarn.lock" in GARBAGE_FILENAMES
         assert "poetry.lock" in GARBAGE_FILENAMES
 
+    def test_lock_extension_is_text(self):
+        """#533: .lock was missing from TEXT_EXTENSIONS, so uv.lock (not in
+        GARBAGE_FILENAMES -- unlike yarn.lock/poetry.lock/etc., which are
+        deliberately excluded as noise) was silently dropped as "non-text"
+        by _is_text_file, causing target_paths=["uv.lock"] to resolve to
+        zero files and raise SnapshotResolutionError."""
+        from llm_council.verification.api import _is_garbage_file, _is_text_file
+
+        assert _is_text_file("uv.lock") is True
+        # Deny-listed lock files must still be excluded -- via
+        # _is_garbage_file, checked before _is_text_file in
+        # _expand_target_paths -- not by this change.
+        assert _is_garbage_file("yarn.lock") is True
+        assert _is_garbage_file("poetry.lock") is True
+
     def test_max_files_expansion_defined(self):
         """MAX_FILES_EXPANSION should be 100."""
         from llm_council.verification.api import MAX_FILES_EXPANSION


### PR DESCRIPTION
Closes #533

## Summary
`.lock` was missing from `TEXT_EXTENSIONS`, so `_is_text_file("uv.lock")` returned `False` and `_expand_target_paths()` silently excluded it as "non-text" — `council-verify`/`council-gate` with `target_paths=["uv.lock"]` raised `SnapshotResolutionError` even though `uv.lock` is plain TOML and a normal blob at every commit.

`uv.lock` was never in `GARBAGE_FILENAMES` (unlike `yarn.lock`/`poetry.lock`/etc., which are deliberately deny-listed as noise), so this was an accidental gap, not intentional exclusion.

Discovered and worked around during epic #526 (Dependabot remediation) — every `uv.lock`-only PR in that epic had to fall back to the D10 Tier-3 manual-coverage path since `--file-paths uv.lock` couldn't resolve.

## Test plan
- New regression test in `tests/test_directory_expansion.py` (TDD: confirmed red before the fix, green after)
- `_expand_target_paths("HEAD", ["uv.lock"])` now resolves the file directly instead of returning empty
- Full suite: 3388 passed, 1 skipped
- `ruff check src/ tests/`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
