### PR TITLE
fix(verify): surface binary-verdict parse failures in diagnostics (#544)

### DIFF
--- a/docs/guides/verify.md
+++ b/docs/guides/verify.md
@@ -153,6 +153,8 @@ A `Finding` has: `severity` (`critical` \| `major` \| `minor` \| `info`),
 | `findings_source` | string | `structured` (clean parse), `fallback` (missing/malformed → legacy path), or `skipped` (`chairman_disabled=true` — no synthesis to parse). |
 | `fallback_reason` | string? | Why the fallback fired, when it did. |
 | `verdict_source` | string | `mechanical` = `policy(findings)`; `legacy` = prose parse; `chairman_disabled` = synthesis skipped, no verdict computed. |
+| `verdict_parse` | string | How the chairman's BINARY verdict block parsed: `ok`, `error` (malformed — see `verdict_parse_error`), or `absent` (no structured verdict expected). Reported **regardless** of `LLM_COUNCIL_STRUCTURED_FINDINGS`. Distinct from `fallback_reason`, which describes the *findings* parser. |
+| `verdict_parse_error` | string? | Exception type and message when `verdict_parse == "error"`. Never contains the offending payload. |
 | `findings_by_severity` | object | Count per severity — surfaces severity mis-labelling over time. |
 | `verdict_evidence_mismatch` | string? | Defensive invariant marker; `None` in normal operation (should never fire under the mechanical gate). |
 | `inner_verdict` | string? | Structured verdict **before** UNCLEAR softening (nested so consumers can't parse it to bypass the low-confidence gate). |

--- a/src/llm_council/council_stages.py
+++ b/src/llm_council/council_stages.py
@@ -826,6 +826,23 @@ Now provide your evaluation and ranking:"""
     return stage2_results, label_to_model, total_usage
 
 
+def _record_verdict_parse_error(response: Dict[str, Any], exc: BaseException) -> None:
+    """Persist why the chairman's structured verdict failed to parse (#544).
+
+    The parse failure was previously only a WARNING log line, so nothing in the
+    response distinguished "the chairman emitted a clean verdict" from "the
+    verdict JSON was malformed and the verdict was scraped out of prose".
+
+    Records the exception TYPE and message only — never the offending payload,
+    which is model output and may embed reviewed file content (cf. ADR-050 D3
+    `scrub_exception`). Diagnostics must never raise.
+    """
+    try:
+        response["verdict_parse_error"] = f"{type(exc).__name__}: {exc}"
+    except Exception:  # pragma: no cover - defensive; telemetry never raises
+        pass
+
+
 async def stage3_synthesize_final(
     user_query: str,
     stage1_results: List[Dict[str, Any]],
@@ -1071,6 +1088,11 @@ STAGE 2 - Peer Rankings:
             import logging
 
             logging.getLogger(__name__).warning(f"Failed to parse binary verdict: {e}")
+            # #544: a log line is not a signal. Record the reason on the result so
+            # build_verification_result can surface it in `diagnostics`; otherwise
+            # `verdict_source="legacy"` is indistinguishable from "structured
+            # findings are simply disabled", and a degrading chairman is invisible.
+            _record_verdict_parse_error(response, e)
     elif verdict_type == VerdictType.TIE_BREAKER:
         try:
             verdict_result = parse_tie_breaker_verdict(response_content)
@@ -1085,6 +1107,7 @@ STAGE 2 - Peer Rankings:
             import logging
 
             logging.getLogger(__name__).warning(f"Failed to parse tie-breaker verdict: {e}")
+            _record_verdict_parse_error(response, e)
 
     return (
         {"model": _get_chairman_model(), "response": response_content},

--- a/src/llm_council/verification/schemas.py
+++ b/src/llm_council/verification/schemas.py
@@ -331,6 +331,24 @@ class VerifyDiagnostics(BaseModel):
             "chairman_disabled = chairman synthesis skipped (PR #519), no verdict computed"
         ),
     )
+    verdict_parse: Literal["ok", "error", "absent"] = Field(
+        default="absent",
+        description=(
+            "#544: how the chairman's ADR-025b BINARY verdict block parsed. "
+            "ok = parsed; error = malformed (see verdict_parse_error); "
+            "absent = no structured verdict expected (non-BINARY mode, chairman "
+            "error, or chairman disabled). Set independently of "
+            "LLM_COUNCIL_STRUCTURED_FINDINGS, and distinct from fallback_reason, "
+            "which describes the FINDINGS parser."
+        ),
+    )
+    verdict_parse_error: Optional[str] = Field(
+        default=None,
+        description=(
+            "#544: exception type and message when verdict_parse == 'error'. "
+            "Never contains the offending payload (cf. ADR-050 D3 scrub_exception)."
+        ),
+    )
     # ADR-051 C4 (#488): severity distribution — surfaces severity mis-labelling
     # (the mechanical gate's residual failure mode) over time.
     findings_by_severity: Dict[str, int] = Field(default_factory=dict)

--- a/src/llm_council/verification/verdict_extractor.py
+++ b/src/llm_council/verification/verdict_extractor.py
@@ -470,6 +470,22 @@ def build_verification_result(
 
     findings_dicts: List[Dict[str, Any]] = []
     diagnostics: Dict[str, Any] = {"findings_source": "fallback", "verdict_source": "legacy"}
+
+    # #544: record how the chairman's ADR-025b BINARY verdict block fared. This is
+    # set UNCONDITIONALLY — outside the structured-findings flag — because a
+    # malformed verdict is exactly as informative when the flag is off, and
+    # `verdict_source="legacy"` cannot otherwise be told apart from "flag off".
+    # `fallback_reason` describes the FINDINGS parser and is a different signal.
+    _verdict_parse_error = (stage3_result or {}).get("verdict_parse_error")
+    if _verdict_parse_error:
+        diagnostics["verdict_parse"] = "error"
+        diagnostics["verdict_parse_error"] = _verdict_parse_error
+    elif verdict_result is not None:
+        diagnostics["verdict_parse"] = "ok"
+    else:
+        # No structured verdict and no parse error: a non-BINARY run, a chairman
+        # error, or a disabled chairman. Not a degradation signal.
+        diagnostics["verdict_parse"] = "absent"
     if structured_findings_enabled():
         try:
             parsed, source, reason = parse_findings((stage3_result or {}).get("response") or "")

--- a/tests/test_issue544_verdict_parse_visibility.py
+++ b/tests/test_issue544_verdict_parse_visibility.py
@@ -1,0 +1,120 @@
+"""Regression tests for #544 — a binary-verdict parse failure must leave a trace.
+
+`council_stages.stage3_synthesize_final` parses the chairman's ADR-025b BINARY
+`VerdictResult`. When that JSON is malformed — most commonly a missing `verdict`
+key — the `except ValueError` logs a warning and leaves `verdict_result = None`.
+Nothing about that reaches the response.
+
+`build_verification_result` then takes the legacy prose-regex branch.
+`diagnostics.fallback_reason` is set only by the *findings* parser (behind
+`LLM_COUNCIL_STRUCTURED_FINDINGS`), never by the *verdict* parser, so:
+
+- With the flag OFF (the default), `verdict_source` reads `"legacy"` — which is
+  indistinguishable from "structured findings are simply disabled". A caller
+  cannot tell a clean legacy run from one where the chairman's verdict JSON was
+  malformed and the verdict was scraped out of prose.
+- With the flag ON, the mechanical gate overrides the verdict anyway, so the
+  parse failure has no effect on the verdict — but it is still the only signal
+  that the chairman's structured output is degrading, and it is discarded.
+
+Observed on two real runs (`bff6de55`, `dc7acb57`), chairman
+`google/gemini-3.1-pro-preview`, stderr `Failed to parse binary verdict: Missing
+required field: verdict`, while `diagnostics` carried no `fallback_reason` at all.
+
+NOTE on scope: these runs also reported confidence ~0.27. That is **not** caused
+by the parse failure — on the mechanical path confidence is always recomputed by
+`calculate_confidence_from_agreement(stage2_results, mechanical)`. See the
+separate issue on the mechanical path inheriting the legacy agreement heuristic.
+"""
+
+from typing import Any, Dict, List
+
+import pytest
+
+from llm_council.verification.verdict_extractor import build_verification_result
+
+
+def _stage2(scores: List[float]) -> List[Dict[str, Any]]:
+    return [
+        {"parsed_ranking": {"ranking": ["Response A", "Response B"], "scores": {"overall": s}}}
+        for s in scores
+    ]
+
+
+class _StructuredVerdict:
+    """Minimal stand-in for a parsed ADR-025b BINARY VerdictResult."""
+
+    def __init__(self, verdict: str = "pass", confidence: float = 0.9):
+        self.verdict = verdict
+        self.confidence = confidence
+        self.approved = verdict == "pass"
+
+
+class TestVerdictParseIsVisible:
+    def test_parse_error_is_surfaced_in_diagnostics(self):
+        """A malformed verdict block must be recorded, not merely logged."""
+        stage3 = {
+            "model": "chairman",
+            "response": "The work looks acceptable overall.",
+            # what stage3_synthesize_final records when parse_binary_verdict raises
+            "verdict_parse_error": "ValueError: Missing required field: verdict",
+        }
+
+        result = build_verification_result(
+            stage1_results=[],
+            stage2_results=_stage2([8, 8, 8]),
+            stage3_result=stage3,
+            verdict_result=None,  # parse failed
+        )
+
+        diagnostics = result.get("diagnostics") or {}
+        assert diagnostics.get("verdict_parse") == "error", (
+            "a binary-verdict parse failure leaves no trace in the response; "
+            "verdict_source='legacy' is indistinguishable from 'flag is off'"
+        )
+        assert "Missing required field" in (diagnostics.get("verdict_parse_error") or "")
+
+    def test_successful_parse_is_recorded_as_ok(self):
+        result = build_verification_result(
+            stage1_results=[],
+            stage2_results=_stage2([9, 9, 9]),
+            stage3_result={"model": "chairman", "response": "Approved."},
+            verdict_result=_StructuredVerdict("pass", 0.9),
+        )
+        diagnostics = result.get("diagnostics") or {}
+        assert diagnostics.get("verdict_parse") == "ok"
+        assert "verdict_parse_error" not in diagnostics
+
+    def test_absent_verdict_without_error_is_distinguishable(self):
+        """No verdict_result and no parse error (e.g. non-BINARY mode) != a parse failure."""
+        result = build_verification_result(
+            stage1_results=[],
+            stage2_results=_stage2([8, 8, 8]),
+            stage3_result={"model": "chairman", "response": "Approved."},
+            verdict_result=None,
+        )
+        diagnostics = result.get("diagnostics") or {}
+        assert diagnostics.get("verdict_parse") == "absent"
+        assert "verdict_parse_error" not in diagnostics
+
+
+class TestStage3RecordsTheParseError:
+    def test_stage3_stores_parse_error_on_the_result_dict(self):
+        """The `except ValueError` in stage3 must persist the reason, not just log it."""
+        import llm_council.council_stages as cs
+
+        # Exercise the narrow contract: a malformed BINARY payload must leave
+        # `verdict_parse_error` on the returned stage-3 dict.
+        response: Dict[str, Any] = {"content": "no json here", "usage": {}}
+        cs._record_verdict_parse_error(response, ValueError("Missing required field: verdict"))
+
+        assert response["verdict_parse_error"] == "ValueError: Missing required field: verdict"
+
+    def test_helper_is_idempotent_and_never_raises(self):
+        import llm_council.council_stages as cs
+
+        response: Dict[str, Any] = {}
+        cs._record_verdict_parse_error(response, ValueError("x"))
+        cs._record_verdict_parse_error(response, ValueError("y"))
+        # last writer wins; telemetry must never raise
+        assert response["verdict_parse_error"].endswith("y")


### PR DESCRIPTION
Closes #544. Part of #546 (P2). Stacked conceptually alongside #558; the two are independent.

## What actually broke

`stage3_synthesize_final` parses the chairman’s ADR-025b BINARY `VerdictResult`. When that JSON is malformed — in practice, a missing `verdict` key — the `except ValueError` logged a warning and left `verdict_result = None`. **Nothing reached the response.**

`build_verification_result` then took the legacy prose-regex branch. `diagnostics.fallback_reason` is set only by the **findings** parser, and only behind `LLM_COUNCIL_STRUCTURED_FINDINGS`. It is never set by the **verdict** parser. So with the flag off — the default — `verdict_source: "legacy"` was indistinguishable from “structured findings are simply disabled”, and a chairman whose structured output is degrading was invisible.

Observed on two runs, chairman `google/gemini-3.1-pro-preview`:

```
stderr: Failed to parse binary verdict: Missing required field: verdict
diagnostics: {"findings_source":"structured","verdict_source":"mechanical","findings_by_severity":{...}}
                                                     ^ no marker anywhere
```

## Fix

- `_record_verdict_parse_error` persists the exception **type and message** onto the stage-3 result (BINARY and TIE_BREAKER). It never records the offending payload — that is model output and may embed reviewed file content (cf. ADR-050 D3 `scrub_exception`). Diagnostics never raise.
- `diagnostics.verdict_parse ∈ {ok, error, absent}`, set **unconditionally**, outside the structured-findings flag — a malformed verdict is exactly as informative when the flag is off. Plus `verdict_parse_error` when it is `error`. `absent` distinguishes “no structured verdict expected” (non-BINARY mode, chairman error, chairman disabled) from a real parse failure.
- Added both to `VerifyDiagnostics`. **Pydantic drops unknown keys**, so without this the fields would never have reached a caller.
- Documented in `verify.md`. ADR-051 C6’s `TestVerifyResponseFieldDrift` went red on the new fields, exactly as designed.

## Correction to the issue as originally filed

I wrote #544 claiming the parse failure *caused* confidence to collapse to ~0.27. **That is wrong**, and I have corrected the issue.

On the mechanical path confidence is *always* recomputed as `calculate_confidence_from_agreement(stage2_results, mechanical)` — deliberately, per ADR-051 C5 round 1 (“confidence must correspond to the mechanical verdict it accompanies”). It would have been ~0.27 whether or not the verdict block parsed. The parse failure and the low confidence are independent.

Chasing that down surfaced a **separate, real** defect: that agreement heuristic is calibrated for legacy prose verdicts and systematically under-confidences `pass`. Five unanimous reviewers scoring a solid 7/10 yield `conf(pass) = 0.65`, below the 0.7 gate, so a clean artifact is softened to `unclear(low_confidence)`. Filed separately rather than scope-creeping this PR.

## Verification

- 5 new tests, all red before the change
- `3251 passed, 1 skipped` — full suite, no regressions
- `ruff check src/ tests/` clean
- `VerifyDiagnostics` round-trip asserted, so the fields genuinely survive to the caller

🤖 Generated with [Claude Code](https://claude.com/claude-code)