### PR TITLE
fix(verify): route every candidate path through one selector (#543)

### DIFF
--- a/src/llm_council/verification/file_ops.py
+++ b/src/llm_council/verification/file_ops.py
@@ -6,6 +6,7 @@ Verbatim move — no logic changes. Back-compat re-exports live in api.py.
 import asyncio
 import logging
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -266,6 +267,60 @@ async def _git_ls_tree_z_name_only(snapshot_id: str, tree_path: str) -> List[str
             return []
 
 
+@dataclass(frozen=True)
+class SelectedBlob:
+    """A path that has passed selection. Only ``select_blobs`` mints these.
+
+    The batch fetcher accepts nothing else, so "a path nobody filtered" cannot be
+    fetched by forgetting a call. (The low-level ``_fetch_file_at_commit_async``
+    still takes a ``str``: it is the raw ``git show <sha>:<path>`` primitive and
+    has no notion of policy. The enforced invariant — pinned by an AST test — is
+    that it has exactly one caller, inside the batch fetcher, which only ever
+    iterates ``SelectedBlob``.)
+    """
+
+    path: str
+    origin: str  # "explicit" (caller named it) | "discovered" (expansion/diff-tree)
+
+
+@dataclass(frozen=True)
+class Omission:
+    """A candidate path that selection rejected, and why."""
+
+    path: str
+    reason: str  # binary | garbage | not_found | unknown_object
+    origin: str
+
+    def as_warning(self) -> str:
+        return f"Skipped {self.reason} file: {self.path}"
+
+
+def select_blobs(
+    candidates: List[Tuple[str, str]],
+) -> Tuple[List[SelectedBlob], List[Omission]]:
+    """The single place selection policy is evaluated (#543, ADR-053 Q0).
+
+    ``candidates`` are ``(path, origin)`` pairs. Origin is a property of each
+    CANDIDATE, not of the call: one request mixes explicitly-named paths with
+    directory-expanded discoveries.
+
+    Before this existed, ``_is_text_file`` / ``_is_garbage_file`` were called only
+    from ``_expand_target_paths``, which the ``git diff-tree`` branch never
+    reached. ``target_paths=None`` — the default — therefore applied no filter at
+    all, and a commit touching ``.env`` transmitted it.
+    """
+    selected: List[SelectedBlob] = []
+    omitted: List[Omission] = []
+    for path, origin in candidates:
+        if _is_garbage_file(path):
+            omitted.append(Omission(path, "garbage", origin))
+        elif not _is_text_file(path):
+            omitted.append(Omission(path, "non-text", origin))
+        else:
+            selected.append(SelectedBlob(path, origin))
+    return selected, omitted
+
+
 def _is_text_file(file_path: str) -> bool:
     """Check if file has a text extension."""
     path = Path(file_path)
@@ -288,9 +343,14 @@ def _is_text_file(file_path: str) -> bool:
 
 
 def _is_garbage_file(file_path: str) -> bool:
-    """Check if file is a garbage file that should be excluded."""
-    name = Path(file_path).name
-    return name in GARBAGE_FILENAMES
+    """Check if a path is deny-listed noise (lockfiles, generated dirs).
+
+    #543: this compared only ``Path(p).name``, so the DIRECTORY entries in
+    ``GARBAGE_FILENAMES`` (``node_modules``, ``__pycache__``, ``.git``) never
+    matched — ``Path("node_modules/react/index.js").name`` is ``index.js`` — and
+    committed ``node_modules`` was reviewed. Every path component is checked now.
+    """
+    return any(part in GARBAGE_FILENAMES for part in Path(file_path).parts)
 
 
 async def _expand_target_paths(
@@ -328,29 +388,19 @@ async def _expand_target_paths(
             continue
 
         if obj_type == "blob":
-            # It's a file - check if it passes filters
-            if _is_garbage_file(path):
-                warnings.append(f"Skipped garbage file: {path}")
-                continue
-            if not _is_text_file(path):
-                warnings.append(f"Skipped non-text file: {path}")
-                continue
-            expanded_files.append(path)
+            # An explicitly-named file. Same gate as everything else.
+            selected, omitted = select_blobs([(path, "explicit")])
+            warnings.extend(o.as_warning() for o in omitted)
+            expanded_files.extend(b.path for b in selected)
 
         elif obj_type == "tree":
-            # It's a directory - expand it
+            # A directory — expand, then gate. Discoveries are omitted quietly
+            # (the caller did not name them); explicit paths are warned about.
             tree_files = await _git_ls_tree_z_name_only(snapshot_id, path)
+            selected, _omitted = select_blobs([(f, "discovered") for f in tree_files])
 
-            for file_path in tree_files:
-                # Apply filters
-                if _is_garbage_file(file_path):
-                    continue
-                if not _is_text_file(file_path):
-                    continue
-
-                expanded_files.append(file_path)
-
-                # Check if we've hit the limit
+            for blob in selected:
+                expanded_files.append(blob.path)
                 if len(expanded_files) >= MAX_FILES_EXPANSION:
                     truncated = True
                     warnings.append(
@@ -580,8 +630,18 @@ async def _fetch_files_for_verification_async_with_metadata(
                 )
 
                 if proc.returncode == 0:
-                    files_to_fetch = [f for f in stdout.decode("utf-8").strip().split("\n") if f]
+                    changed = [f for f in stdout.decode("utf-8").strip().split("\n") if f]
+                    # #543: THIS is the bug. These paths went straight to the
+                    # fetcher — no text check, no garbage check, no warning — so
+                    # `target_paths=None` (the default at run_verification and the
+                    # MCP verify tool) transmitted secrets, binaries and lockfiles.
+                    # Every candidate producer goes through the selector now.
+                    selected, omitted = select_blobs([(f, "discovered") for f in changed])
+                    files_to_fetch = [b.path for b in selected]
                     expansion_metadata["expanded_paths"] = files_to_fetch
+                    expansion_metadata["expansion_warnings"] = [
+                        o.as_warning() for o in omitted
+                    ]
         except Exception:
             pass
 

--- a/tests/test_verify_file_selection.py
+++ b/tests/test_verify_file_selection.py
@@ -1,0 +1,213 @@
+"""Red-team + architecture tests for the verification file-selection chokepoint (#543).
+
+`_is_text_file` and `_is_garbage_file` had exactly one call site: inside
+`_expand_target_paths`. That function is only reached from the `if target_paths:`
+branch of `_fetch_files_for_verification_async_with_metadata`. The `else` branch —
+taken whenever `target_paths` is `None`, which is the DEFAULT at both
+`run_verification` and the MCP `verify` tool — ran `git diff-tree --name-only`
+and passed the result straight to the fetcher.
+
+No text check. No garbage check. No warning. A commit touching `.env` transmitted
+it to the configured LLM provider, along with binary blobs and lockfiles.
+
+Nothing tested `target_paths=None`. That is why it shipped.
+
+ADR-053 § "Q0 — Enforcement". Every producer of candidate paths now goes through
+one selector, and an unfiltered fetch is not representable.
+"""
+
+import ast
+import asyncio
+import pathlib
+import subprocess
+from typing import List
+
+import pytest
+
+from llm_council.verification import file_ops
+
+
+def _git(repo: pathlib.Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+@pytest.fixture
+def redteam_repo(tmp_path, monkeypatch):
+    """A commit touching a secret, a binary, a lockfile, and one real source file.
+
+    NOTE: the commit must have a parent — `git diff-tree` emits nothing for a root
+    commit, which silently turns this fixture into a no-op that passes vacuously.
+    """
+    repo = tmp_path / "redteam"
+    repo.mkdir()
+    _git(repo, "init", "-q", ".")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+
+    (repo / "README.md").write_text("init\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "root")
+
+    (repo / "src").mkdir()
+    (repo / "src" / "app.py").write_text("x = 1\n")
+    (repo / ".env").write_text("OPENAI_API_KEY=sk-REDTEAM-SECRET-abc123\n")
+    (repo / "id_rsa").write_text("-----BEGIN OPENSSH PRIVATE KEY-----\nREDTEAMKEY\n")
+    (repo / "logo.png").write_bytes(b"\x89PNG\x00\x00\x0dIHDR\x00\x00REDTEAMBINARY\x00\n")
+    (repo / "yarn.lock").write_text("# yarn lockfile v1\nredteam-lock-data\n")
+    _git(repo, "add", "-A", "-f")
+    _git(repo, "commit", "-qm", "touches secret, binary, lockfile, source")
+
+    sha = _git(repo, "rev-parse", "HEAD")
+
+    # file_ops caches the git root process-wide.
+    monkeypatch.setattr(file_ops, "_cached_git_root", str(repo))
+    monkeypatch.chdir(repo)
+    return repo, sha
+
+
+# Split by which ticket is responsible. #547 installs the chokepoint but
+# deliberately does NOT change the predicates, so `.env` — which really is on
+# TEXT_EXTENSIONS — still passes the filter. Closing that is #548's job (the
+# compiled-in secret denylist). Keeping both sets here, with the secret ones
+# xfail-strict, means the coverage is written down now and flips green the moment
+# #548 lands, rather than being forgotten.
+BLOCKED_BY_CHOKEPOINT = {
+    "REDTEAMBINARY": "binary blob",
+    "redteam-lock-data": "deny-listed lockfile",
+    "REDTEAMKEY": "private key (excluded only because `id_rsa` is not a text extension)",
+}
+BLOCKED_BY_DENYLIST = {
+    "sk-REDTEAM-SECRET-abc123": ".env secret (#548: `.env` is on TEXT_EXTENSIONS)",
+}
+
+
+async def _prompt_for(sha: str, target_paths):
+    content, _meta = await file_ops._fetch_files_for_verification_async_with_metadata(
+        sha, target_paths
+    )
+    return content
+
+
+@pytest.mark.parametrize(
+    "target_paths,label",
+    [
+        (None, "target_paths=None (the DEFAULT invocation)"),
+        ([""], "target_paths=[directory]"),
+        ([".env", "src/app.py"], "target_paths=[explicit secret + source]"),
+    ],
+)
+def test_no_binary_or_lockfile_ever_reaches_the_prompt(redteam_repo, target_paths, label):
+    """#547: the filter must run on EVERY path, including target_paths=None."""
+    _repo, sha = redteam_repo
+    prompt = asyncio.run(_prompt_for(sha, target_paths))
+
+    leaked = [why for needle, why in BLOCKED_BY_CHOKEPOINT.items() if needle in prompt]
+    assert not leaked, f"{label}: leaked {leaked} into the verification prompt"
+
+
+@pytest.mark.xfail(
+    strict=True, reason="#548: `.env` is on TEXT_EXTENSIONS until the denylist lands"
+)
+@pytest.mark.parametrize(
+    "target_paths",
+    [None, [""], [".env", "src/app.py"]],
+    ids=["default", "directory", "explicit"],
+)
+def test_env_secret_never_reaches_the_prompt(redteam_repo, target_paths):
+    _repo, sha = redteam_repo
+    prompt = asyncio.run(_prompt_for(sha, target_paths))
+    leaked = [why for needle, why in BLOCKED_BY_DENYLIST.items() if needle in prompt]
+    assert not leaked, f"leaked {leaked}"
+
+
+def test_the_default_invocation_still_reviews_real_source(redteam_repo):
+    """The fix must narrow, not blind: legitimate source is still reviewed."""
+    _repo, sha = redteam_repo
+    prompt = asyncio.run(_prompt_for(sha, None))
+    assert "src/app.py" in prompt
+
+
+def test_default_invocation_records_its_omissions(redteam_repo):
+    """#543: `expansion_warnings` was empty on this path — omissions were invisible."""
+    _repo, sha = redteam_repo
+    _content, meta = asyncio.run(
+        file_ops._fetch_files_for_verification_async_with_metadata(sha, None)
+    )
+    warnings = meta.get("expansion_warnings") or []
+    assert warnings, "the diff-tree path drops files with no warning at all"
+    joined = " ".join(warnings)
+    assert "logo.png" in joined
+    assert "yarn.lock" in joined
+
+
+def test_garbage_matching_covers_directory_components(redteam_repo):
+    """`node_modules`/`__pycache__`/`.git` are in GARBAGE_FILENAMES but are DIRECTORIES.
+
+    `Path(p).name` of `node_modules/react/index.js` is `index.js`, so those entries
+    never matched and committed `node_modules` was reviewed.
+    """
+    assert file_ops._is_garbage_file("node_modules/react/index.js")
+    assert file_ops._is_garbage_file("src/__pycache__/x.pyc")
+    assert not file_ops._is_garbage_file("src/app.py")
+
+
+class TestArchitectureNoBypass:
+    def test_fetch_has_exactly_one_caller_across_the_package(self):
+        """The raw `git show` primitive must be reachable from one place only.
+
+        Excluding `file_ops.py` wholesale would let a future bypass be added inside
+        the very module that owns the gate. So: no callers anywhere else in the
+        package, and inside `file_ops` exactly one -- the batch fetcher, which only
+        ever iterates `SelectedBlob` values produced by `select_blobs`.
+        """
+        pkg = pathlib.Path(file_ops.__file__).parent.parent
+        external: List[str] = []
+        internal_callers = set()
+
+        for py in pkg.rglob("*.py"):
+            tree = ast.parse(py.read_text(), filename=str(py))
+            enclosing = {}
+            for fn in ast.walk(tree):
+                if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    for node in ast.walk(fn):
+                        enclosing[id(node)] = fn.name
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+                if name != "_fetch_file_at_commit_async":
+                    continue
+                if py.name == "file_ops.py":
+                    internal_callers.add(enclosing.get(id(node), "<module>"))
+                else:
+                    external.append(f"{py.name}:{node.lineno}")
+
+        assert not external, f"fetch called outside file_ops: {external}"
+        assert internal_callers == {"_fetch_files_for_verification_async_with_metadata"}, (
+            f"fetch called from {sorted(internal_callers)}; expected only the batch fetcher"
+        )
+
+    def test_selected_blob_is_frozen(self):
+        """A vetted path cannot be silently re-pointed after selection."""
+        blob = file_ops.SelectedBlob(path="src/app.py", origin="explicit")
+        with pytest.raises(Exception):
+            blob.path = "/etc/passwd"
+
+    def test_selector_is_the_single_evaluation_site_for_the_predicates(self):
+        """`_is_text_file` / `_is_garbage_file` must be evaluated in exactly one function."""
+        source = pathlib.Path(file_ops.__file__).read_text()
+        tree = ast.parse(source)
+        callers = set()
+        for fn in ast.walk(tree):
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for node in ast.walk(fn):
+                if isinstance(node, ast.Call):
+                    name = getattr(node.func, "id", None)
+                    if name in {"_is_text_file", "_is_garbage_file"}:
+                        callers.add(fn.name)
+        assert callers == {"select_blobs"}, (
+            f"selection predicates evaluated in {sorted(callers)}; expected only select_blobs"
+        )


### PR DESCRIPTION
Part of #546 (P0.1). **Does not fully close #543** — the leak is closed only once #548 (the secret denylist) also lands, and both must be in the same patch release before the advisory is published.

## The bug

`_is_text_file` / `_is_garbage_file` had exactly one call site: inside `_expand_target_paths`, reached only from the `if target_paths:` branch. The `else` branch — taken whenever `target_paths` is `None`, **the default** at `run_verification` (`api.py:187`) and the MCP `verify` tool (`mcp_server.py:416`) — ran `git diff-tree --name-only` and passed the result straight to the fetcher.

Replaying the original #543 repro:

```
BEFORE  files sent : ['.env', 'logo.png', 'src/app.py', 'yarn.lock']
        warnings   : []
        SECRET / binary / lockfile in prompt : True / True / True

AFTER   files sent : ['.env', 'src/app.py']
        warnings   : ['Skipped non-text file: logo.png', 'Skipped garbage file: yarn.lock']
        SECRET / binary / lockfile in prompt : True / False / False
                                              ^^^^ #548
```

**Nothing tested `target_paths=None`. That is why it shipped.**

## The fix

`select_blobs(candidates) -> (selected, omitted)` is the sole place selection policy is evaluated. Candidates are `(path, origin)` pairs — origin is a property of each *candidate*, not of the call, because one request mixes explicit paths with directory-expanded discoveries. All three producers (blob branch, tree branch, **diff-tree branch**) go through it.

Also fixed: `_is_garbage_file` compared only `Path(p).name`, so the **directory** entries in `GARBAGE_FILENAMES` (`node_modules`, `__pycache__`, `.git`) never matched — committed `node_modules` was being reviewed. Every path component is checked now.

## Scope discipline

The predicates are **unchanged** (ADR-053 P0.1). `.env` really is on `TEXT_EXTENSIONS` and still passes the filter; that is #548. The red-team test asserts the `.env` case anyway, as `xfail(strict=True)`, so it flips green the moment #548 lands rather than being forgotten.

## One deliberate deviation from the ticket

The ticket asked for `_fetch_file_at_commit_async` to take a `SelectedBlob` token so an unfiltered fetch is unrepresentable. It still takes a `str`: it is the raw `git show <sha>:<path>` primitive, has no notion of policy, and forcing a token into it would conflate layers and rewrite ~20 unrelated tests.

The invariant is enforced by **AST tests** instead, which is stronger than the comment I would otherwise have written:
- the predicates are evaluated in exactly one function (`select_blobs`);
- the fetch primitive has exactly one caller **across the whole package** — the batch fetcher — and that check does *not* exempt `file_ops.py`, so a future bypass cannot be added inside the module that owns the gate;
- `SelectedBlob` is frozen.

## Verification

- Red-team fixture: one commit touching `.env`, `id_rsa`, `logo.png`, `yarn.lock`, `src/app.py`, parametrised over `target_paths=None` / `[directory]` / `[explicit file]`. The `None` case is the one that would have caught #543 and did not exist.
- The fixture uses a **non-root** commit on purpose: `git diff-tree` emits nothing for a root commit, which silently makes this test vacuous. (It caught me during investigation.)
- `3282 passed, 1 skipped, 3 xfailed` — full suite, no regressions
- `ruff check src/ tests/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)