### PR TITLE
fix(verify): validate snapshot_id at the run_verification boundary (#549)

### DIFF
--- a/src/llm_council/verification/api.py
+++ b/src/llm_council/verification/api.py
@@ -808,6 +808,17 @@ async def run_verification(
     Returns:
         Verification result dictionary
     """
+    # #549: validate the snapshot at THIS boundary. Defense in depth, NOT a live
+    # hole: production callers build a VerifyRequest (Pydantic rejects a malformed
+    # SHA), and the VerificationContextManager below re-validates before any git
+    # argv call. This makes the guarantee explicit and independent of the context
+    # manager keeping its position, and fails fast (before transcript setup) for a
+    # caller that bypassed construction (VerifyRequest.model_construct, a future
+    # caller). Shell injection is already precluded (argv arrays, no shell=True);
+    # the residual class is ARGUMENT injection, which matters once P3.1 adds
+    # pathspec-style `git ... -- <paths>` calls.
+    validate_snapshot_id(request.snapshot_id)
+
     verification_id = str(uuid.uuid4())[:8]
 
     # Create isolated context for this verification

--- a/tests/test_issue549_snapshot_validation.py
+++ b/tests/test_issue549_snapshot_validation.py
@@ -1,0 +1,53 @@
+"""#549: `run_verification` validates snapshot_id at its own boundary.
+
+Both production callers (CLI, MCP) build a `VerifyRequest`, whose Pydantic
+field-validator rejects a malformed `snapshot_id` at construction — so the
+HTTP/CLI/MCP paths are already covered. `run_verification` accepts the request object directly. It was NOT a live hole —
+`VerificationContextManager` already re-validates before the first git argv call —
+but that guarantee was implicit and positional. #549 makes `run_verification`
+validate at its own entry, so it fails fast and stays correct even if the context
+manager moves. These tests neuter that downstream check to prove the boundary
+guard stands on its own.
+
+Shell injection is already precluded (argv arrays; zero `shell=True`). The
+residual class is ARGUMENT injection, load-bearing once P3.1 adds pathspec-style
+`git ... -- <paths>` calls.
+"""
+
+import pytest
+
+from llm_council.verification.context import InvalidSnapshotError
+from llm_council.verification.schemas import VerifyRequest
+from llm_council.verification.transcript import create_transcript_store
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["--upload-pack=evil", "-x", "HEAD; rm -rf", "not a sha", "zzz$(whoami)"],
+)
+def test_run_verification_rejects_unvalidated_snapshot(bad, tmp_path, monkeypatch):
+    """A request that skipped Pydantic validation must still be rejected."""
+    import asyncio
+
+    # model_construct bypasses field validators — the defense-in-depth case.
+    req = VerifyRequest.model_construct(snapshot_id=bad, tier="balanced", target_paths=None)
+    store = create_transcript_store(base_path=tmp_path)
+
+    import llm_council.verification.context as ctx
+    import llm_council.verification.api as api_mod
+
+    # Neuter the DOWNSTREAM (context-manager) validation so this asserts the
+    # boundary guard in run_verification specifically, not the pre-existing one.
+    monkeypatch.setattr(ctx, "validate_snapshot_id", lambda s: True)
+
+    with pytest.raises(InvalidSnapshotError):
+        asyncio.run(api_mod.run_verification(req, store))
+
+
+def test_valid_snapshot_is_not_rejected(tmp_path, monkeypatch):
+    """A well-formed 40-hex SHA passes the boundary check (fails later, elsewhere)."""
+    from llm_council.verification.context import validate_snapshot_id
+
+    # The boundary check itself accepts a valid SHA. (Full run_verification needs
+    # network + a real commit; the unit under test here is only the guard.)
+    assert validate_snapshot_id("a" * 40) is True


### PR DESCRIPTION
Part of #546 (P0.3), the last code change before the release.

## Honest scoping: this is defense-in-depth, not a live hole

I set out to close an argument-injection gap and found it was **already closed**, just implicitly. `VerificationContextManager` validates `snapshot_id` before the first `git` argv call. Neutering my new guard and driving a `--upload-pack=…` snapshot through `run_verification` still gets blocked by the context manager.

So the PR does **not** claim to fix a live vulnerability. What it fixes: the safety of `run_verification` depended on the context manager *happening to run first*. It takes the request object directly and never re-checked. A caller that bypassed Pydantic construction (`VerifyRequest.model_construct`, or any future caller) relied on that ordering. This makes `run_verification` validate at its own entry — fail fast, before transcript setup, independent of the context manager’s position.

Shell injection is already precluded (every git call is `create_subprocess_exec` with argv arrays; zero `shell=True`). The residual class is **argument injection**, which becomes load-bearing when P3.1 adds pathspec-style `git ... -- <paths>` calls.

## The garbage-dir fix isn’t here

The ticket also scoped fixing `GARBAGE_FILENAMES` directory-component matching. That landed in #547 (the chokepoint PR — it was the natural home), so it is not repeated.

## Tests

The tests **neuter the downstream context-manager validation** so they assert *this* boundary guard specifically, not the pre-existing one. Parametrised over `-`-leading, non-hex, and shell-metachar snapshots.

- `3360 passed, 1 skipped` — full suite
- `ruff check src/ tests/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)