### PR TITLE
feat(verify): Q1 content sniffing behind LLM_COUNCIL_FILE_SELECTION (#552)

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -130,6 +130,7 @@
 | `LLM_COUNCIL_SCREEN_MAX_CHARS` | Screening eligibility: max content chars | 5000 |
 | `LLM_COUNCIL_SCREEN_MIN_SCORE` | Screening unanimity minimum per dimension | 9 |
 | `LLM_COUNCIL_STRUCTURED_FINDINGS` | ADR-051 structured findings channel: the chairman emits severity-tagged findings and the verdict is derived from them (`blocking_issues` = critical subset). Off by default — additive/opt-in until a later breaking default-ON flip | false |
+| `LLM_COUNCIL_FILE_SELECTION` | ADR-053 Q1 verify file classification: `allowlist` (extension `TEXT_EXTENSIONS` — byte-identical to pre-#552), `content` (git's NUL heuristic + snapshot `.gitattributes`, reviews any text file incl. unlisted languages), or `shadow` (acts on allowlist, logs what content would change). Invalid ⇒ allowlist. The secret denylist (#548) and garbage filter always run first regardless | allowlist |
 | `LLM_COUNCIL_TIMEOUT_MULTIPLIER` | Verification global-deadline multiplier (ADR-040) | 2.0 |
 | `LLM_COUNCIL_TRANSCRIPT_PATH` | Verification transcript root | .council/logs |
 

--- a/src/llm_council/verification/constants.py
+++ b/src/llm_council/verification/constants.py
@@ -21,6 +21,11 @@ MAX_TOTAL_CHARS = 50000
 # Maximum files to include after directory expansion (Issue #309)
 MAX_FILES_EXPANSION = 100
 
+# #552 (ADR-053 Q1): content-mode size cap. A blob larger than this is omitted
+# as `too_large` before any fetch, so a pathological blob is never streamed just
+# to sniff it. Generous: tier char budgets truncate anything reviewable anyway.
+MAX_BLOB_SIZE_BYTES = 5_000_000
+
 # Text file extensions to include (whitelist approach per council decision)
 # 80+ extensions covering common source code, config, and documentation files
 TEXT_EXTENSIONS: Set[str] = frozenset(

--- a/src/llm_council/verification/file_ops.py
+++ b/src/llm_council/verification/file_ops.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from .constants import (
     ASYNC_SUBPROCESS_TIMEOUT,
     GARBAGE_FILENAMES,
+    MAX_BLOB_SIZE_BYTES,
     MAX_FILE_CHARS,
     MAX_FILES_EXPANSION,
     MAX_TOTAL_CHARS,
@@ -400,32 +401,184 @@ def _is_secret_path(file_path: str) -> bool:
     return False
 
 
-def select_blobs(
+def file_selection_mode() -> str:
+    """ADR-053 Q1: `LLM_COUNCIL_FILE_SELECTION` in {allowlist,content,shadow}.
+
+    Invalid / unset ⇒ `allowlist` (the safe, byte-identical default).
+    """
+    val = os.getenv("LLM_COUNCIL_FILE_SELECTION", "allowlist").strip().lower()
+    return val if val in ("allowlist", "content", "shadow") else "allowlist"
+
+
+async def _blob_sizes(snapshot_id: str, paths: List[str]) -> Dict[str, int]:
+    """Byte size per path in the snapshot, via one `git ls-tree` call (#552).
+
+    Serves the size cap AND empty-file disambiguation (an empty blob is text but
+    `git grep` never lists it). Missing ⇒ absent from the returned map.
+    """
+    if not paths:
+        return {}
+    git_root = await _get_git_root_async()
+    semaphore = await _get_git_semaphore()
+    for fmt in ("--format=%(objectsize) %(path)", None):
+        args = ["git", "ls-tree", "-rz"]
+        if fmt:
+            args.append(fmt)
+        else:
+            args.insert(2, "-l")  # `-rl`: long listing, size in a fixed column
+        args += [snapshot_id, "--", *paths]
+        async with semaphore:
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+                    cwd=git_root,
+                )
+                stdout, _ = await asyncio.wait_for(
+                    proc.communicate(), timeout=ASYNC_SUBPROCESS_TIMEOUT
+                )
+            except Exception as e:
+                logger.warning("git ls-tree (sizes) raised: %s", e)
+                return {}
+        if proc.returncode != 0:
+            continue  # try the fallback format
+        out = stdout.decode("utf-8", errors="replace")
+        sizes: Dict[str, int] = {}
+        for entry in out.split("\0"):
+            if not entry.strip():
+                continue
+            if fmt:
+                size_str, _, path = entry.partition(" ")
+            else:
+                # "<mode> <type> <hash> <size>\t<path>"
+                meta, _, path = entry.partition("\t")
+                size_str = meta.split()[-1]
+            try:
+                sizes[path] = int(size_str)
+            except ValueError:
+                continue
+        return sizes
+    return {}
+
+
+async def _text_paths(snapshot_id: str, paths: List[str]) -> set:
+    """Subset of `paths` git classifies as text (NUL rule + `.gitattributes`).
+
+    `git --attr-source=<sha> grep -Iz --name-only -e '' <sha> -- <paths>`:
+    `-I` applies git's own binary heuristic (NUL in first 8000 bytes), and
+    `--attr-source=<sha>` honours `binary`/`-diff` from the SNAPSHOT's
+    `.gitattributes` (a top-level git option, not a grep flag — verified 2.50.1).
+    Exit 1 = "no text file matched", not an error. Empty blobs never appear here
+    (they are recovered via `_blob_sizes` size==0 by the caller).
+    """
+    if not paths:
+        return set()
+    git_root = await _get_git_root_async()
+    semaphore = await _get_git_semaphore()
+    async with semaphore:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "git", f"--attr-source={snapshot_id}", "grep", "-Iz", "--name-only",
+                "-e", "", snapshot_id, "--", *paths,
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=git_root,
+            )
+            stdout, _ = await asyncio.wait_for(
+                proc.communicate(), timeout=ASYNC_SUBPROCESS_TIMEOUT
+            )
+        except Exception as e:
+            logger.warning("git grep (text sniff) raised: %s", e)
+            return set()
+    # rc 0 = matches, 1 = no matches (not an error), >1 = real failure.
+    if proc.returncode not in (0, 1):
+        logger.warning("git grep (text sniff) rc=%s", proc.returncode)
+        return set()
+    out = stdout.decode("utf-8", errors="replace")
+    result = set()
+    for entry in out.split("\0"):
+        if not entry:
+            continue
+        # output is "<sha>:<path>"; strip the "<sha>:" prefix.
+        _, _, path = entry.partition(":")
+        result.add(path or entry)
+    return result
+
+
+async def _classify_decodable(
+    snapshot_id: str, candidates: List[Tuple[str, str]]
+) -> Tuple[List[SelectedBlob], List[Omission]]:
+    """Content-mode decodability (ADR-053 Q1): size cap → binary/text via git."""
+    paths = [p for p, _ in candidates]
+    sizes = await _blob_sizes(snapshot_id, paths)
+    text = await _text_paths(snapshot_id, paths)
+    selected: List[SelectedBlob] = []
+    omitted: List[Omission] = []
+    for path, origin in candidates:
+        size = sizes.get(path)
+        if size is not None and size > MAX_BLOB_SIZE_BYTES:
+            omitted.append(Omission(path, "too_large", origin))
+        elif path in text or size == 0:  # size==0 recovers empty blobs grep omits
+            selected.append(SelectedBlob(path, origin))
+        else:
+            omitted.append(Omission(path, "binary", origin))
+    return selected, omitted
+
+
+async def select_blobs(
+    snapshot_id: str,
     candidates: List[Tuple[str, str]],
 ) -> Tuple[List[SelectedBlob], List[Omission]]:
-    """The single place selection policy is evaluated (#543, ADR-053 Q0).
+    """The single place selection policy is evaluated (#543, ADR-053 Q0/Q1).
 
     ``candidates`` are ``(path, origin)`` pairs. Origin is a property of each
     CANDIDATE, not of the call: one request mixes explicitly-named paths with
     directory-expanded discoveries.
 
-    Before this existed, ``_is_text_file`` / ``_is_garbage_file`` were called only
-    from ``_expand_target_paths``, which the ``git diff-tree`` branch never
-    reached. ``target_paths=None`` — the default — therefore applied no filter at
-    all, and a commit touching ``.env`` transmitted it.
+    Order: Q3 secret boundary → Q2 garbage → Q1 decodability. Q3/Q2 are path-only
+    and always run. Q1 depends on ``LLM_COUNCIL_FILE_SELECTION`` (#552):
+    ``allowlist`` (default) uses the extension predicate and makes NO git call —
+    byte-identical to pre-#552; ``content`` sniffs blob bytes via git; ``shadow``
+    acts on the allowlist but logs what content would have changed.
     """
+    mode = file_selection_mode()
     selected: List[SelectedBlob] = []
     omitted: List[Omission] = []
+    # Q3 + Q2 first — a secret is denied even if it is text (#540/#548).
+    survivors: List[Tuple[str, str]] = []
     for path, origin in candidates:
-        # Trust boundary first: a secret is denied even if it is text (#540/#548).
         if _is_secret_path(path):
             omitted.append(Omission(path, "denied_secret", origin))
         elif _is_garbage_file(path):
             omitted.append(Omission(path, "garbage", origin))
-        elif not _is_text_file(path):
-            omitted.append(Omission(path, "non-text", origin))
         else:
+            survivors.append((path, origin))
+
+    if mode == "content":
+        sel, om = await _classify_decodable(snapshot_id, survivors)
+        selected += sel
+        omitted += om
+        return selected, omitted
+
+    # allowlist (and the acted-on half of shadow): sync extension predicate.
+    for path, origin in survivors:
+        if _is_text_file(path):
             selected.append(SelectedBlob(path, origin))
+        else:
+            omitted.append(Omission(path, "non-text", origin))
+
+    if mode == "shadow" and survivors:
+        try:
+            csel, _com = await _classify_decodable(snapshot_id, survivors)
+            allow_set = {b.path for b in selected}
+            content_set = {b.path for b in csel}
+            would_add = sorted(content_set - allow_set)
+            would_drop = sorted(allow_set - content_set)
+            if would_add or would_drop:
+                logger.info(
+                    "LLM_COUNCIL_FILE_SELECTION=shadow: content would add %s, drop %s",
+                    would_add, would_drop,
+                )
+        except Exception:  # shadow telemetry must never break selection
+            logger.debug("shadow content classification failed", exc_info=True)
+
     return selected, omitted
 
 
@@ -503,7 +656,7 @@ async def _expand_target_paths(
 
         if obj_type == "blob":
             # An explicitly-named file. Same gate as everything else.
-            selected, omitted = select_blobs([(path, "explicit")])
+            selected, omitted = await select_blobs(snapshot_id, [(path, "explicit")])
             warnings.extend(o.as_warning() for o in omitted)
             expanded_files.extend(b.path for b in selected)
 
@@ -511,7 +664,7 @@ async def _expand_target_paths(
             # A directory — expand, then gate. Discoveries are omitted quietly
             # (the caller did not name them); explicit paths are warned about.
             tree_files = await _git_ls_tree_z_name_only(snapshot_id, path)
-            selected, _omitted = select_blobs([(f, "discovered") for f in tree_files])
+            selected, _omitted = await select_blobs(snapshot_id, [(f, "discovered") for f in tree_files])
 
             for blob in selected:
                 expanded_files.append(blob.path)
@@ -750,7 +903,7 @@ async def _fetch_files_for_verification_async_with_metadata(
                     # `target_paths=None` (the default at run_verification and the
                     # MCP verify tool) transmitted secrets, binaries and lockfiles.
                     # Every candidate producer goes through the selector now.
-                    selected, omitted = select_blobs([(f, "discovered") for f in changed])
+                    selected, omitted = await select_blobs(snapshot_id, [(f, "discovered") for f in changed])
                     files_to_fetch = [b.path for b in selected]
                     expansion_metadata["expanded_paths"] = files_to_fetch
                     expansion_metadata["expansion_warnings"] = [

--- a/tests/test_issue552_content_sniffing.py
+++ b/tests/test_issue552_content_sniffing.py
@@ -1,0 +1,179 @@
+"""Q1 content sniffing behind LLM_COUNCIL_FILE_SELECTION (#552, ADR-053 Q1).
+
+`content` mode replaces the `TEXT_EXTENSIONS` allowlist with git's own rule —
+a blob is text iff its first 8000 bytes contain no NUL — read via
+`git --attr-source=<sha> grep -I`, which also honours `.gitattributes`
+`binary`/`-diff` from the snapshot. A one-call `git ls-tree` size pre-pass
+enforces a byte cap and disambiguates empty files (which `grep` omits).
+
+`allowlist` (default) stays byte-identical. `shadow` acts on the allowlist but
+logs what `content` would have changed.
+
+ADR erratum: the ADR's Q1 example list includes `.envrc` as "reviewed", but
+Q3a lists it as a secret and #548 shipped it denied. The secret boundary runs
+first and `.envrc` genuinely holds `export SECRET=…`, so it STAYS denied here.
+"""
+
+import asyncio
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from llm_council.verification import file_ops
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+@pytest.fixture
+def sniff_repo(tmp_path, monkeypatch):
+    repo = tmp_path / "sniff"
+    (repo / "src").mkdir(parents=True)
+    _git(repo, "init", "-q", ".")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+
+    # extensions NOT on TEXT_EXTENSIONS
+    (repo / "src" / "main.zig").write_text('const std = @import("std");\n')
+    (repo / "main.tf").write_text('resource "x" "y" {}\n')
+    (repo / "app.dart").write_text("void main() {}\n")
+    (repo / "Token.sol").write_text("contract T {}\n")
+    # extensionless, no special-case
+    (repo / "LICENSE").write_text("MIT License\n")
+    (repo / "CODEOWNERS").write_text("* @team\n")
+    (repo / "deploy").write_text("#!/usr/bin/env bash\necho hi\n")
+    (repo / "empty.py").write_text("")  # empty: text, but grep won't list it
+    # binary by content, and a lying extension
+    (repo / "logo.png").write_bytes(b"PNG\x00\x01binary\x00\n")
+    (repo / "weird.txt").write_bytes(b"utf16\x00text\x00\n")
+    # .gitattributes: mark a generated file -diff
+    (repo / "gen.js").write_text("var a = 1;\n")
+    (repo / ".gitattributes").write_text("gen.js -diff\n")
+
+    _git(repo, "add", "-A", "-f")
+    _git(repo, "commit", "-qm", "init")
+    sha = _git(repo, "rev-parse", "HEAD")
+
+    monkeypatch.setattr(file_ops, "_cached_git_root", str(repo))
+    monkeypatch.chdir(repo)
+    return repo, sha
+
+
+async def _select(sha, paths, origin="discovered"):
+    return await file_ops.select_blobs(sha, [(p, origin) for p in paths])
+
+
+class TestContentMode:
+    @pytest.fixture(autouse=True)
+    def _on(self, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_FILE_SELECTION", "content")
+
+    def test_unlisted_languages_are_reviewed_without_a_list_edit(self, sniff_repo):
+        _repo, sha = sniff_repo
+        paths = ["src/main.zig", "main.tf", "app.dart", "Token.sol"]
+        selected, omitted = asyncio.run(_select(sha, paths))
+        assert {b.path for b in selected} == set(paths), (
+            f"omitted: {[(o.path, o.reason) for o in omitted]}"
+        )
+
+    def test_extensionless_text_files_are_reviewed(self, sniff_repo):
+        _repo, sha = sniff_repo
+        paths = ["LICENSE", "CODEOWNERS", "deploy", "empty.py"]
+        selected, _omitted = asyncio.run(_select(sha, paths))
+        assert {b.path for b in selected} == set(paths)
+
+    def test_nul_bearing_blobs_excluded_as_binary(self, sniff_repo):
+        _repo, sha = sniff_repo
+        selected, omitted = asyncio.run(_select(sha, ["logo.png", "weird.txt"]))
+        assert selected == []
+        assert {o.reason for o in omitted} == {"binary"}
+
+    def test_gitattributes_minus_diff_honored_from_snapshot(self, sniff_repo):
+        _repo, sha = sniff_repo
+        selected, omitted = asyncio.run(_select(sha, ["gen.js"]))
+        assert selected == [], "gen.js is -diff in the snapshot's .gitattributes"
+        assert omitted[0].reason == "binary"
+
+    def test_oversize_blob_excluded_before_fetch(self, sniff_repo, monkeypatch):
+        repo, sha = sniff_repo
+        monkeypatch.setattr(file_ops, "MAX_BLOB_SIZE_BYTES", 4)  # tiny cap
+        selected, omitted = asyncio.run(_select(sha, ["LICENSE"]))  # 11 bytes > 4
+        assert selected == []
+        assert omitted[0].reason == "too_large"
+
+    def test_secret_still_denied_first_in_content_mode(self, sniff_repo):
+        """Q3 runs before Q1 — a committed .env is denied, not sniffed."""
+        repo, sha = sniff_repo
+        (repo / ".env").write_text("SECRET=x\n")
+        _git(repo, "add", "-A", "-f")
+        _git(repo, "commit", "-qm", "add env")
+        sha2 = _git(repo, "rev-parse", "HEAD")
+        selected, omitted = asyncio.run(_select(sha2, [".env"], origin="explicit"))
+        assert selected == []
+        assert omitted[0].reason == "denied_secret"
+
+    def test_envrc_stays_denied_adr_erratum(self, sniff_repo):
+        """ADR Q1 lists .envrc as reviewed; Q3a + #548 deny it. Security wins."""
+        repo, sha = sniff_repo
+        (repo / ".envrc").write_text("export AWS_SECRET_ACCESS_KEY=leak\n")
+        _git(repo, "add", "-A", "-f")
+        _git(repo, "commit", "-qm", "add envrc")
+        sha2 = _git(repo, "rev-parse", "HEAD")
+        selected, omitted = asyncio.run(_select(sha2, [".envrc"]))
+        assert selected == []
+        assert omitted[0].reason == "denied_secret"
+
+
+class TestAllowlistModeByteIdentical:
+    def test_default_is_allowlist_and_uses_the_extension_predicate(self, sniff_repo, monkeypatch):
+        monkeypatch.delenv("LLM_COUNCIL_FILE_SELECTION", raising=False)
+        _repo, sha = sniff_repo
+        # .zig is NOT on TEXT_EXTENSIONS ⇒ dropped in allowlist mode (the #542 gap)
+        selected, omitted = asyncio.run(_select(sha, ["src/main.zig", "LICENSE"]))
+        assert "src/main.zig" not in {b.path for b in selected}
+        # allowlist mode must make NO git subprocess call for content sniffing
+        # (byte-identical guarantee) — asserted indirectly: .zig omitted as non-text
+        assert any(o.path == "src/main.zig" and o.reason == "non-text" for o in omitted)
+
+    def test_allowlist_mode_is_synchronous_pathonly(self, monkeypatch):
+        """allowlist mode must not require a snapshot round-trip (no git calls)."""
+        monkeypatch.setenv("LLM_COUNCIL_FILE_SELECTION", "allowlist")
+        # a bogus snapshot must not matter in allowlist mode — no git call is made
+        selected, omitted = asyncio.run(
+            file_ops.select_blobs("0" * 40, [("a.py", "explicit"), ("b.zig", "explicit")])
+        )
+        assert {b.path for b in selected} == {"a.py"}
+        assert any(o.path == "b.zig" for o in omitted)
+
+
+class TestShadowMode:
+    def test_shadow_acts_on_allowlist_but_reports_the_delta(self, sniff_repo, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_FILE_SELECTION", "shadow")
+        _repo, sha = sniff_repo
+        # shadow ACTS on allowlist: .zig stays omitted
+        selected, omitted = asyncio.run(_select(sha, ["src/main.zig", "app.py"]))
+        assert "src/main.zig" not in {b.path for b in selected}
+
+
+class TestModeParsing:
+    @pytest.mark.parametrize(
+        "val,expected",
+        [
+            (None, "allowlist"),
+            ("allowlist", "allowlist"),
+            ("content", "content"),
+            ("shadow", "shadow"),
+            ("CONTENT", "content"),
+            ("garbage", "allowlist"),  # invalid ⇒ safe default
+        ],
+    )
+    def test_file_selection_mode(self, monkeypatch, val, expected):
+        if val is None:
+            monkeypatch.delenv("LLM_COUNCIL_FILE_SELECTION", raising=False)
+        else:
+            monkeypatch.setenv("LLM_COUNCIL_FILE_SELECTION", val)
+        assert file_ops.file_selection_mode() == expected

--- a/tests/test_verify_secret_denylist.py
+++ b/tests/test_verify_secret_denylist.py
@@ -12,6 +12,8 @@ the `*.example`/`*.sample` templates are preserved by NAME PATTERN, not by a
 fake extension entry.
 """
 
+import asyncio
+
 import pytest
 
 from llm_council.verification import file_ops
@@ -111,7 +113,7 @@ def test_allowed_paths_are_not_secrets(path):
 
 class TestSelectBlobsAppliesTheBoundary:
     def test_secret_is_omitted_with_denied_secret_reason(self):
-        selected, omitted = file_ops.select_blobs([(".env", "explicit")])
+        selected, omitted = asyncio.run(file_ops.select_blobs("0" * 40, [(".env", "explicit")]))
         assert selected == []
         assert len(omitted) == 1
         assert omitted[0].reason == "denied_secret"
@@ -119,13 +121,13 @@ class TestSelectBlobsAppliesTheBoundary:
 
     def test_boundary_runs_before_text_check(self):
         # `.env` is text; it must be denied as a SECRET, not admitted as text.
-        selected, omitted = file_ops.select_blobs([(".env", "discovered")])
+        selected, omitted = asyncio.run(file_ops.select_blobs("0" * 40, [(".env", "discovered")]))
         assert not selected
         assert omitted[0].reason == "denied_secret"
 
     def test_omission_records_path_only_never_a_value(self):
         # mirrors ADR-050 D3 scrub_exception — no content, just the path.
-        _sel, omitted = file_ops.select_blobs([("private.key", "explicit")])
+        _sel, omitted = asyncio.run(file_ops.select_blobs("0" * 40, [("private.key", "explicit")]))
         o = omitted[0]
         assert o.path == "private.key"
         assert o.reason == "denied_secret"
@@ -133,8 +135,10 @@ class TestSelectBlobsAppliesTheBoundary:
         assert set(vars(o)) == {"path", "reason", "origin"}
 
     def test_template_and_source_pass(self):
-        selected, omitted = file_ops.select_blobs(
-            [(".env.example", "explicit"), ("src/app.py", "explicit")]
+        selected, omitted = asyncio.run(
+            file_ops.select_blobs(
+                "0" * 40, [(".env.example", "explicit"), ("src/app.py", "explicit")]
+            )
         )
         assert {b.path for b in selected} == {".env.example", "src/app.py"}
         assert omitted == []


### PR DESCRIPTION
Part of #546 (P3.1), part of #542. **Default off — `allowlist` mode is byte-identical to master.**

## What it does

`content` mode replaces the ~140-entry `TEXT_EXTENSIONS` allowlist with git's own rule (a blob is text iff its first 8000 bytes contain no NUL). End-to-end proof:

```
[allowlist]  src/app.zig reviewed: False   <- the #542 gap (default, unchanged)
[content  ]  src/app.zig reviewed: True    <- reviewed, no list edit
```

`.zig`, `.tf`, `.dart`, `.sol`, `.gleam`, `LICENSE`, `CODEOWNERS`, shebang scripts — all reviewed with no per-language PR. The #533/#539 "add one extension per release" treadmill is over.

## How (one git call each, both empirically verified against git 2.50.1)

- **NUL + `.gitattributes` in one call:** `git --attr-source=<sha> grep -Iz --name-only -e '' <sha> -- <paths>`. `-I` is git's binary heuristic; `--attr-source=<sha>` honours `binary`/`-diff` from the **snapshot's** `.gitattributes` (top-level git option, not a grep flag).
- **Size cap + empty-file recovery:** `git ls-tree -rz --format='%(objectsize) %(path)'` (fallback `-rl` on git < 2.36) enforces `MAX_BLOB_SIZE_BYTES` before any fetch, and recovers empty blobs (text, but `grep` never lists them → `size == 0`).
- Every new git call passes `--` before pathspecs (the argument-injection hygiene #549 set up).

`select_blobs` is now `async` and takes `snapshot_id`. **`allowlist` makes no git call** — byte-identical, pinned by a bogus-snapshot test. `shadow` acts on the allowlist and logs the delta. The secret boundary (#548) and garbage filter still run **first**.

## ADR erratum (flagged, resolved for security)

The ADR's Q1 example list calls `.envrc` "reviewed", but Q3a lists it as a secret and #548 shipped it denied. The secret boundary runs first, and `.envrc` genuinely holds `export SECRET=…`, so **it stays denied**. Security wins over the illustrative list; test-pinned (`test_envrc_stays_denied_adr_erratum`).

## Verification

- 16 new tests (unlisted langs, extensionless, NUL→binary, `.gitattributes -diff` from snapshot, size cap, secret-first, mode parsing, byte-identical allowlist, shadow)
- `3376 passed, 1 skipped` full suite; the 4 #548 tests updated for the async signature
- env-reference drift test satisfied for the new flag
- `ruff check` clean

Deferred: Q2 (#553, next — shares the `--attr-source` plumbing), and the default flip to `content` (#557, after shadow telemetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)