### PR TITLE
feat(verify): Q2 reviewability — linguist-generated/vendored + .svg noise (#553)

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -131,6 +131,7 @@
 | `LLM_COUNCIL_SCREEN_MIN_SCORE` | Screening unanimity minimum per dimension | 9 |
 | `LLM_COUNCIL_STRUCTURED_FINDINGS` | ADR-051 structured findings channel: the chairman emits severity-tagged findings and the verdict is derived from them (`blocking_issues` = critical subset). Off by default — additive/opt-in until a later breaking default-ON flip | false |
 | `LLM_COUNCIL_FILE_SELECTION` | ADR-053 Q1 verify file classification: `allowlist` (extension `TEXT_EXTENSIONS` — byte-identical to pre-#552), `content` (git's NUL heuristic + snapshot `.gitattributes`, reviews any text file incl. unlisted languages), or `shadow` (acts on allowlist, logs what content would change). Invalid ⇒ allowlist. The secret denylist (#548) and garbage filter always run first regardless | allowlist |
+| `LLM_COUNCIL_REVIEW_SVG` | ADR-053 Q2: review `.svg` in `content` mode instead of omitting it as noise (SVG decodes as text but is usually a generated asset). Content-mode only — allowlist mode always reviews `.svg` via `TEXT_EXTENSIONS` | false |
 | `LLM_COUNCIL_TIMEOUT_MULTIPLIER` | Verification global-deadline multiplier (ADR-040) | 2.0 |
 | `LLM_COUNCIL_TRANSCRIPT_PATH` | Verification transcript root | .council/logs |
 

--- a/src/llm_council/verification/file_ops.py
+++ b/src/llm_council/verification/file_ops.py
@@ -502,6 +502,73 @@ async def _text_paths(snapshot_id: str, paths: List[str]) -> set:
     return result
 
 
+def review_svg_enabled() -> bool:
+    """ADR-053 Q2: `.svg` is noise-by-default in content mode; this opts back in."""
+    return os.getenv("LLM_COUNCIL_REVIEW_SVG", "").strip().lower() in ("true", "1", "yes")
+
+
+async def _reviewability_attrs(snapshot_id: str, paths: List[str]) -> Dict[str, str]:
+    """Map path → "generated"/"vendored" from the SNAPSHOT's linguist attributes.
+
+    One `git --attr-source=<sha> check-attr -z linguist-generated linguist-vendored`
+    call (#553, ADR-053 Q2). `-z` output is flat NUL triples `path\\0attr\\0value`;
+    a value of `set` means the attribute applies. `generated` wins if both are set.
+    """
+    if not paths:
+        return {}
+    git_root = await _get_git_root_async()
+    semaphore = await _get_git_semaphore()
+    async with semaphore:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "git", f"--attr-source={snapshot_id}", "check-attr", "-z",
+                "linguist-generated", "linguist-vendored", "--", *paths,
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=git_root,
+            )
+            stdout, _ = await asyncio.wait_for(
+                proc.communicate(), timeout=ASYNC_SUBPROCESS_TIMEOUT
+            )
+        except Exception as e:
+            logger.warning("git check-attr raised: %s", e)
+            return {}
+    if proc.returncode != 0:
+        return {}
+    fields = stdout.decode("utf-8", errors="replace").split("\0")
+    out: Dict[str, str] = {}
+    # consume flat triples; ignore a trailing empty field from the final NUL
+    for i in range(0, len(fields) - 2, 3):
+        path, attr, value = fields[i], fields[i + 1], fields[i + 2]
+        if value != "set":
+            continue
+        if attr == "linguist-generated":
+            out[path] = "generated"  # generated wins over vendored
+        elif attr == "linguist-vendored":
+            out.setdefault(path, "vendored")
+    return out
+
+
+async def _classify_reviewable(
+    snapshot_id: str, candidates: List[Tuple[str, str]]
+) -> Tuple[List[Tuple[str, str]], List[Omission]]:
+    """Content-mode reviewability (ADR-053 Q2): drop generated/vendored/.svg noise.
+
+    Returns (survivors, omitted); survivors then go to decodability (Q1).
+    """
+    attrs = await _reviewability_attrs(snapshot_id, [p for p, _ in candidates])
+    survivors: List[Tuple[str, str]] = []
+    omitted: List[Omission] = []
+    svg_reviewable = review_svg_enabled()
+    for path, origin in candidates:
+        reason = attrs.get(path)
+        if reason:
+            omitted.append(Omission(path, reason, origin))
+        elif Path(path).suffix.lower() == ".svg" and not svg_reviewable:
+            omitted.append(Omission(path, "noise", origin))
+        else:
+            survivors.append((path, origin))
+    return survivors, omitted
+
+
 async def _classify_decodable(
     snapshot_id: str, candidates: List[Tuple[str, str]]
 ) -> Tuple[List[SelectedBlob], List[Omission]]:
@@ -552,9 +619,11 @@ async def select_blobs(
             survivors.append((path, origin))
 
     if mode == "content":
-        sel, om = await _classify_decodable(snapshot_id, survivors)
+        # Q2 reviewability (generated/vendored/.svg noise) then Q1 decodability.
+        reviewable, om_review = await _classify_reviewable(snapshot_id, survivors)
+        sel, om = await _classify_decodable(snapshot_id, reviewable)
         selected += sel
-        omitted += om
+        omitted += om_review + om
         return selected, omitted
 
     # allowlist (and the acted-on half of shadow): sync extension predicate.
@@ -566,7 +635,8 @@ async def select_blobs(
 
     if mode == "shadow" and survivors:
         try:
-            csel, _com = await _classify_decodable(snapshot_id, survivors)
+            creviewable, _cr = await _classify_reviewable(snapshot_id, survivors)
+            csel, _com = await _classify_decodable(snapshot_id, creviewable)
             allow_set = {b.path for b in selected}
             content_set = {b.path for b in csel}
             would_add = sorted(content_set - allow_set)

--- a/tests/test_issue553_reviewability.py
+++ b/tests/test_issue553_reviewability.py
@@ -1,0 +1,117 @@
+"""Q2 reviewability: linguist-generated/vendored + .svg-as-noise (#553, ADR-053 Q2).
+
+Content mode gains a reviewability layer between the garbage filter (Q2 basenames)
+and decodability (Q1): a path marked `linguist-generated` / `linguist-vendored` in
+the SNAPSHOT's `.gitattributes` is omitted (`generated` / `vendored`), and `.svg`
+— which decodes as text but is usually a large generated asset — is omitted as
+`noise` unless the operator sets `LLM_COUNCIL_REVIEW_SVG=true`.
+
+All of this is content-mode only, so `allowlist` stays byte-identical: there,
+`.svg` is still on `TEXT_EXTENSIONS` and is reviewed, and no `check-attr` runs.
+"""
+
+import asyncio
+import subprocess
+
+import pytest
+
+from llm_council.verification import file_ops
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+@pytest.fixture
+def attr_repo(tmp_path, monkeypatch):
+    repo = tmp_path / "attr"
+    (repo / "vendor").mkdir(parents=True)
+    (repo / "gen").mkdir()
+    (repo / "src").mkdir()
+    _git(repo, "init", "-q", ".")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "vendor" / "lib.js").write_text("var a = 1;\n")
+    (repo / "gen" / "out.js").write_text("var b = 2;\n")
+    (repo / "src" / "app.py").write_text("print(1)\n")
+    (repo / "icon.svg").write_text("<svg><path d='M0 0'/></svg>\n")
+    (repo / ".gitattributes").write_text("vendor/** linguist-vendored\ngen/** linguist-generated\n")
+    _git(repo, "add", "-A", "-f")
+    _git(repo, "commit", "-qm", "init")
+    sha = _git(repo, "rev-parse", "HEAD")
+    monkeypatch.setattr(file_ops, "_cached_git_root", str(repo))
+    monkeypatch.chdir(repo)
+    return repo, sha
+
+
+async def _select(sha, paths):
+    return await file_ops.select_blobs(sha, [(p, "discovered") for p in paths])
+
+
+class TestContentModeReviewability:
+    @pytest.fixture(autouse=True)
+    def _on(self, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_FILE_SELECTION", "content")
+        monkeypatch.delenv("LLM_COUNCIL_REVIEW_SVG", raising=False)
+
+    def test_linguist_generated_is_omitted(self, attr_repo):
+        _repo, sha = attr_repo
+        selected, omitted = asyncio.run(_select(sha, ["gen/out.js", "src/app.py"]))
+        assert {b.path for b in selected} == {"src/app.py"}
+        assert any(o.path == "gen/out.js" and o.reason == "generated" for o in omitted)
+
+    def test_linguist_vendored_is_omitted(self, attr_repo):
+        _repo, sha = attr_repo
+        selected, omitted = asyncio.run(_select(sha, ["vendor/lib.js", "src/app.py"]))
+        assert {b.path for b in selected} == {"src/app.py"}
+        assert any(o.path == "vendor/lib.js" and o.reason == "vendored" for o in omitted)
+
+    def test_attrs_read_from_snapshot_not_worktree(self, attr_repo):
+        repo, sha = attr_repo
+        (repo / ".gitattributes").unlink()  # worktree no longer marks vendor/**
+        selected, omitted = asyncio.run(_select(sha, ["vendor/lib.js"]))
+        assert selected == [], "attrs must come from the snapshot, not the worktree"
+        assert omitted[0].reason == "vendored"
+
+    def test_svg_is_noise_by_default(self, attr_repo):
+        _repo, sha = attr_repo
+        selected, omitted = asyncio.run(_select(sha, ["icon.svg", "src/app.py"]))
+        assert {b.path for b in selected} == {"src/app.py"}
+        assert any(o.path == "icon.svg" and o.reason == "noise" for o in omitted)
+
+    def test_svg_reviewable_when_operator_opts_in(self, attr_repo, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_REVIEW_SVG", "true")
+        _repo, sha = attr_repo
+        selected, _omitted = asyncio.run(_select(sha, ["icon.svg"]))
+        assert {b.path for b in selected} == {"icon.svg"}
+
+
+class TestAllowlistByteIdentical:
+    def test_svg_still_reviewed_in_allowlist_mode(self, attr_repo, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_FILE_SELECTION", "allowlist")
+        _repo, sha = attr_repo
+        # .svg is on TEXT_EXTENSIONS; allowlist mode must review it, unchanged.
+        selected, _omitted = asyncio.run(_select(sha, ["icon.svg"]))
+        assert {b.path for b in selected} == {"icon.svg"}
+
+    def test_linguist_not_consulted_in_allowlist_mode(self, attr_repo, monkeypatch):
+        monkeypatch.setenv("LLM_COUNCIL_FILE_SELECTION", "allowlist")
+        _repo, sha = attr_repo
+        # vendor/lib.js is a .js on TEXT_EXTENSIONS ⇒ reviewed; no check-attr runs.
+        selected, _omitted = asyncio.run(_select(sha, ["vendor/lib.js"]))
+        assert {b.path for b in selected} == {"vendor/lib.js"}
+
+
+class TestReviewSvgFlag:
+    @pytest.mark.parametrize(
+        "val,reviewed",
+        [(None, False), ("true", True), ("1", True), ("false", False), ("", False)],
+    )
+    def test_review_svg_flag(self, monkeypatch, val, reviewed):
+        if val is None:
+            monkeypatch.delenv("LLM_COUNCIL_REVIEW_SVG", raising=False)
+        else:
+            monkeypatch.setenv("LLM_COUNCIL_REVIEW_SVG", val)
+        assert file_ops.review_svg_enabled() is reviewed


### PR DESCRIPTION
Part of #546 (P3.2), part of #542. Builds on #552 (content mode). **Content-mode only — `allowlist` byte-identical.**

## What it does

In `content` mode, a reviewability layer runs between the garbage filter and decodability:

- **`linguist-generated`** → omitted `generated`; **`linguist-vendored`** → omitted `vendored`. GitHub Linguist's de-facto standard for "not authored source," already in many repos.
- **`.svg`** → omitted `noise` by default (decodes as text, usually a generated asset); `LLM_COUNCIL_REVIEW_SVG=true` opts back in.

End-to-end:

```
content mode files sent: ['.gitattributes', 'app.py']
vendor/lib.min.js in prompt: False   (linguist-vendored)
warnings: ['Skipped vendored file: vendor/lib.min.js']
```

## How

One `git --attr-source=<sha> check-attr -z linguist-generated linguist-vendored -- <paths>` call, attrs read from the **snapshot** (verified: still applies after the worktree `.gitattributes` is deleted). `-z` output is flat NUL triples `path\0attr\0value`; `set` means it applies.

Content-mode only ⇒ `allowlist` stays byte-identical: `.svg` is on `TEXT_EXTENSIONS` and reviewed there, and no `check-attr` runs. Both pinned.

## Note

The `noise` omission reason is new; it should join the coverage-receipt reason enum in #555 (flagged in the commit).

## Verification

- 12 new tests (generated, vendored, snapshot-not-worktree, svg-noise, svg-opt-in, allowlist byte-identical ×2, flag parsing)
- `3388 passed, 1 skipped` full suite
- env-reference drift test satisfied; `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)