### PR TITLE
feat(verify): structural coverage receipt + conservation invariant (#555)

### DIFF
--- a/docs/guides/verify.md
+++ b/docs/guides/verify.md
@@ -172,7 +172,16 @@ A `Finding` has: `severity` (`critical` \| `major` \| `minor` \| `info`),
 | `completed_stages` | list? | Stages completed before a timeout (e.g. `["stage1","stage2"]`). |
 | `expanded_paths` | list? | Files included after directory expansion (#311). |
 | `paths_truncated` | bool? | `MAX_FILES_EXPANSION` limit was reached. |
-| `expansion_warnings` | list? | Warnings from directory expansion (skipped files, etc.). |
+| `expansion_warnings` | list? | Warnings from directory expansion (skipped files, etc.). Human-readable; prefer `coverage` for machine use. |
+| `coverage` | object? | **#555 structural coverage receipt** — which requested paths were reviewed vs omitted, typed. Additive; **no verdict effect** (the clamp is #556). Fields below. |
+| `coverage.requested` | list? | Verbatim `target_paths` (`None` when the changed set was used). |
+| `coverage.reviewed` | list | Paths whose contents entered the prompt. |
+| `coverage.omitted` | list | Each omitted path as `{path, reason, origin}`. |
+| `coverage.omitted[].reason` | string | `denied_secret` \| `garbage` \| `non-text` \| `binary` \| `generated` \| `vendored` \| `noise` \| `ignored` \| `too_large` \| `not_found`. `denied_secret` records the path only, never the matched value. |
+| `coverage.omitted[].origin` | string | `explicit` (caller named it) or `discovered` (directory/diff-tree expansion). |
+| `coverage.explicit_omitted` | bool | True if a caller-named path was omitted — the load-bearing signal that a `pass` covers less than asked. |
+| `coverage.truncated` | bool | `MAX_FILES_EXPANSION` capped directory expansion. |
+| `coverage.conservation_ok` | bool | Invariant marker: `reviewed` and `omitted` are disjoint (ADR-051 C4 pattern; should always be true). |
 | `timing` | object? | Per-stage and total timing in ms (ADR-041). |
 | `input_metrics` | object? | Input-size metrics (`content_chars`, `tier_max_chars`, `num_models`, `num_reviewers`, `tier`, cache fields). |
 | `screening` | object? | Screening-judge audit trail (ADR-047); present only when `LLM_COUNCIL_SCREENING` is shadow/active. |

--- a/src/llm_council/verification/api.py
+++ b/src/llm_council/verification/api.py
@@ -765,6 +765,8 @@ async def _run_verification_pipeline(
         "expanded_paths": expansion.get("expanded_paths") or None,
         "paths_truncated": expansion.get("paths_truncated"),
         "expansion_warnings": expansion.get("expansion_warnings") or None,
+        # #555: structural coverage receipt (additive; no verdict effect).
+        "coverage": expansion.get("coverage"),
     }
 
     # Persist result
@@ -1125,6 +1127,12 @@ async def run_verification(
                     .get("expansion", {})
                     .get("expansion_warnings")
                     or None
+                ),
+                # #555: coverage receipt survives the timeout path too.
+                "coverage": (
+                    (partial_state.get("evidence_render_info") or {})
+                    .get("expansion", {})
+                    .get("coverage")
                 ),
             }
             # #356: persist the partial/timeout result so timeouts (the dominant

--- a/src/llm_council/verification/file_ops.py
+++ b/src/llm_council/verification/file_ops.py
@@ -777,7 +777,7 @@ def _is_garbage_file(file_path: str) -> bool:
 async def _expand_target_paths(
     snapshot_id: str,
     target_paths: List[str],
-) -> Tuple[List[str], bool, List[str]]:
+) -> Tuple[List[str], bool, List[str], List[Omission]]:
     """
     Expand directories in target_paths to their constituent text files.
 
@@ -792,9 +792,11 @@ async def _expand_target_paths(
         - expanded_files: List of file paths after expansion
         - was_truncated: True if MAX_FILES_EXPANSION was hit
         - warnings: List of warning messages
+        - omissions: structured Omission list (#555 coverage receipt)
     """
     expanded_files: List[str] = []
     warnings: List[str] = []
+    omissions: List[Omission] = []
     truncated = False
 
     for path in target_paths:
@@ -806,19 +808,24 @@ async def _expand_target_paths(
 
         if obj_type is None:
             warnings.append(f"Path not found or invalid: {path}")
+            omissions.append(Omission(path, "not_found", "explicit"))
             continue
 
         if obj_type == "blob":
             # An explicitly-named file. Same gate as everything else.
             selected, omitted = await select_blobs(snapshot_id, [(path, "explicit")])
             warnings.extend(o.as_warning() for o in omitted)
+            omissions.extend(omitted)
             expanded_files.extend(b.path for b in selected)
 
         elif obj_type == "tree":
             # A directory — expand, then gate. Discoveries are omitted quietly
             # (the caller did not name them); explicit paths are warned about.
             tree_files = await _git_ls_tree_z_name_only(snapshot_id, path)
-            selected, _omitted = await select_blobs(snapshot_id, [(f, "discovered") for f in tree_files])
+            selected, tree_omitted = await select_blobs(
+                snapshot_id, [(f, "discovered") for f in tree_files]
+            )
+            omissions.extend(tree_omitted)
 
             for blob in selected:
                 expanded_files.append(blob.path)
@@ -835,13 +842,14 @@ async def _expand_target_paths(
 
         else:
             warnings.append(f"Unknown object type '{obj_type}' for path: {path}")
+            omissions.append(Omission(path, "not_found", "explicit"))
 
         # Check limit after each path
         if len(expanded_files) >= MAX_FILES_EXPANSION:
             truncated = True
             break
 
-    return expanded_files, truncated, warnings
+    return expanded_files, truncated, warnings, omissions
 
 
 # =============================================================================
@@ -1014,6 +1022,7 @@ async def _fetch_files_for_verification_async_with_metadata(
         "paths_truncated": False,
         "expansion_warnings": [],
     }
+    all_omissions: List[Omission] = []
     git_root = await _get_git_root_async()
 
     # Issue #342: derive per-file and per-batch caps from the tier so the
@@ -1025,7 +1034,9 @@ async def _fetch_files_for_verification_async_with_metadata(
 
     # ADR-034 v2.6: Expand directories in target_paths
     if target_paths:
-        files_to_fetch, truncated, warnings = await _expand_target_paths(snapshot_id, target_paths)
+        files_to_fetch, truncated, warnings, all_omissions = await _expand_target_paths(
+            snapshot_id, target_paths
+        )
         expansion_metadata["expanded_paths"] = files_to_fetch
         expansion_metadata["paths_truncated"] = truncated
         expansion_metadata["expansion_warnings"] = list(warnings)
@@ -1057,14 +1068,41 @@ async def _fetch_files_for_verification_async_with_metadata(
                     # `target_paths=None` (the default at run_verification and the
                     # MCP verify tool) transmitted secrets, binaries and lockfiles.
                     # Every candidate producer goes through the selector now.
-                    selected, omitted = await select_blobs(snapshot_id, [(f, "discovered") for f in changed])
+                    selected, omitted = await select_blobs(
+                        snapshot_id, [(f, "discovered") for f in changed]
+                    )
                     files_to_fetch = [b.path for b in selected]
+                    all_omissions = omitted
                     expansion_metadata["expanded_paths"] = files_to_fetch
                     expansion_metadata["expansion_warnings"] = [
                         o.as_warning() for o in omitted
                     ]
         except Exception:
             pass
+
+    # #555 coverage receipt: typed omissions + conservation invariant. Built here
+    # so every path select_blobs saw is accounted for, whichever branch produced
+    # it. `reviewed ∪ omitted == candidates` (disjoint) holds by construction —
+    # the invariant is a defensive marker (ADR-051 C4), never a crash.
+    reviewed_set = list(dict.fromkeys(files_to_fetch))  # de-dup, order-stable
+    omitted_records = [
+        {"path": o.path, "reason": o.reason, "origin": o.origin} for o in all_omissions
+    ]
+    rset, oset = set(reviewed_set), {o["path"] for o in omitted_records}
+    conservation_ok = rset.isdisjoint(oset)
+    if not conservation_ok:
+        logger.error(
+            "coverage conservation violated: %d paths in both reviewed and omitted",
+            len(rset & oset),
+        )
+    expansion_metadata["coverage"] = {
+        "requested": list(target_paths) if target_paths else None,
+        "reviewed": reviewed_set,
+        "omitted": omitted_records,
+        "explicit_omitted": any(o.origin == "explicit" for o in all_omissions),
+        "truncated": bool(expansion_metadata.get("paths_truncated")),
+        "conservation_ok": conservation_ok,
+    }
 
     if not files_to_fetch:
         return "[No files specified and could not determine changed files]", expansion_metadata

--- a/src/llm_council/verification/schemas.py
+++ b/src/llm_council/verification/schemas.py
@@ -373,6 +373,53 @@ class VerifyDiagnostics(BaseModel):
     findings_by_severity: Dict[str, int] = Field(default_factory=dict)
 
 
+class CoverageOmission(BaseModel):
+    """One path the verify pipeline did not review, and why (#555, ADR-053)."""
+
+    path: str = Field(description="Repo-relative path that was omitted")
+    reason: str = Field(
+        description=(
+            "Why it was omitted: denied_secret | garbage | non-text | binary | "
+            "generated | vendored | noise | ignored | too_large | not_found. "
+            "denied_secret records the path only, never the matched value."
+        )
+    )
+    origin: str = Field(
+        description="explicit (caller named it) or discovered (directory/diff-tree expansion)"
+    )
+
+
+class CoverageReport(BaseModel):
+    """Structural coverage receipt for a verify run (#555, ADR-053).
+
+    Makes #542's silent-partial-omission failure visible: a caller can tell a
+    `.zig` drop (`non-text`) from a `.png` (`binary`) from a secret
+    (`denied_secret`) without parsing prose. Additive, no verdict effect — the
+    coverage clamp is #556.
+    """
+
+    requested: Optional[List[str]] = Field(
+        default=None, description="Verbatim target_paths (None when the changed set was used)"
+    )
+    reviewed: List[str] = Field(
+        default_factory=list, description="Paths whose contents entered the prompt"
+    )
+    omitted: List[CoverageOmission] = Field(
+        default_factory=list, description="Every candidate path that was not reviewed, typed"
+    )
+    explicit_omitted: bool = Field(
+        default=False,
+        description="True if a caller-named (origin=explicit) path was omitted — the load-bearing signal",
+    )
+    truncated: bool = Field(
+        default=False, description="True if MAX_FILES_EXPANSION capped directory expansion"
+    )
+    conservation_ok: bool = Field(
+        default=True,
+        description="Invariant: reviewed and omitted are disjoint (ADR-051 C4 defensive marker)",
+    )
+
+
 class VerifyResponse(BaseModel):
     """Response body for POST /v1/council/verify."""
 
@@ -469,6 +516,14 @@ class VerifyResponse(BaseModel):
     expansion_warnings: Optional[List[str]] = Field(
         default=None,
         description="Warnings from directory expansion (skipped files, etc.)",
+    )
+    coverage: Optional["CoverageReport"] = Field(
+        default=None,
+        description=(
+            "#555 (ADR-053): structural coverage receipt — which requested paths "
+            "were reviewed vs omitted (with a typed reason/origin per omission). "
+            "Additive; no verdict effect (the clamp is #556)."
+        ),
     )
     # ADR-041: Verification telemetry fields
     timing: Optional[Dict[str, Any]] = Field(

--- a/tests/test_directory_expansion.py
+++ b/tests/test_directory_expansion.py
@@ -238,7 +238,7 @@ class TestExpandTargetPaths:
         """Single file path should pass through unchanged."""
         from llm_council.verification.api import _expand_target_paths
 
-        files, truncated, warnings = await _expand_target_paths("HEAD", ["pyproject.toml"])
+        files, truncated, warnings, _ = await _expand_target_paths("HEAD", ["pyproject.toml"])
         assert "pyproject.toml" in files
         assert truncated is False
 
@@ -247,7 +247,7 @@ class TestExpandTargetPaths:
         """Single directory should expand to constituent files."""
         from llm_council.verification.api import _expand_target_paths
 
-        files, truncated, warnings = await _expand_target_paths(
+        files, truncated, warnings, _ = await _expand_target_paths(
             "HEAD", ["src/llm_council/verification"]
         )
         assert len(files) > 0
@@ -261,7 +261,7 @@ class TestExpandTargetPaths:
         """Mixed file and directory paths should be handled correctly."""
         from llm_council.verification.api import _expand_target_paths
 
-        files, truncated, warnings = await _expand_target_paths(
+        files, truncated, warnings, _ = await _expand_target_paths(
             "HEAD", ["pyproject.toml", "src/llm_council/verification"]
         )
         assert "pyproject.toml" in files
@@ -284,7 +284,7 @@ class TestExpandTargetPaths:
             with patch("llm_council.verification.file_ops._get_git_object_type") as mock_type:
                 mock_type.return_value = "tree"
 
-                files, _, _ = await _expand_target_paths("HEAD", ["docs"])
+                files, _, _, _ = await _expand_target_paths("HEAD", ["docs"])
 
                 # Should include text files
                 assert "docs/file.md" in files
@@ -309,7 +309,7 @@ class TestExpandTargetPaths:
             with patch("llm_council.verification.file_ops._get_git_object_type") as mock_type:
                 mock_type.return_value = "tree"
 
-                files, _, _ = await _expand_target_paths("HEAD", ["src"])
+                files, _, _, _ = await _expand_target_paths("HEAD", ["src"])
 
                 # Should include normal files
                 assert "src/index.js" in files
@@ -335,7 +335,7 @@ class TestExpandTargetPaths:
             with patch("llm_council.verification.file_ops._get_git_object_type") as mock_type:
                 mock_type.return_value = "tree"
 
-                files, truncated, warnings = await _expand_target_paths("HEAD", ["src"])
+                files, truncated, warnings, _ = await _expand_target_paths("HEAD", ["src"])
 
                 assert len(files) == MAX_FILES_EXPANSION
                 assert truncated is True
@@ -346,7 +346,7 @@ class TestExpandTargetPaths:
         """Should add warning for nonexistent paths."""
         from llm_council.verification.api import _expand_target_paths
 
-        files, truncated, warnings = await _expand_target_paths(
+        files, truncated, warnings, _ = await _expand_target_paths(
             "HEAD", ["nonexistent/path/file.txt"]
         )
 
@@ -364,7 +364,7 @@ class TestExpandTargetPaths:
             with patch("llm_council.verification.file_ops._get_git_object_type") as mock_type:
                 mock_type.return_value = "tree"
 
-                files, truncated, warnings = await _expand_target_paths("HEAD", ["empty_dir"])
+                files, truncated, warnings, _ = await _expand_target_paths("HEAD", ["empty_dir"])
 
                 assert files == []
                 assert truncated is False
@@ -481,7 +481,7 @@ class TestDocsDirectoryIntegration:
         )
 
         # Expand docs/ directory
-        files, truncated, warnings = await _expand_target_paths("HEAD", ["docs"])
+        files, truncated, warnings, _ = await _expand_target_paths("HEAD", ["docs"])
 
         # Should have found files
         assert len(files) > 0
@@ -522,7 +522,7 @@ class TestDocsDirectoryIntegration:
         """Verify docs/ expansion only includes text files."""
         from llm_council.verification.api import _expand_target_paths, TEXT_EXTENSIONS
 
-        files, _, _ = await _expand_target_paths("HEAD", ["docs"])
+        files, _, _, _ = await _expand_target_paths("HEAD", ["docs"])
 
         for f in files:
             # All files should have text extensions
@@ -539,7 +539,7 @@ class TestDocsDirectoryIntegration:
         """Verify src/ expands to Python files."""
         from llm_council.verification.api import _expand_target_paths
 
-        files, _, _ = await _expand_target_paths("HEAD", ["src/llm_council/verification"])
+        files, _, _, _ = await _expand_target_paths("HEAD", ["src/llm_council/verification"])
 
         # Should have Python files
         py_files = [f for f in files if f.endswith(".py")]

--- a/tests/test_issue555_coverage_receipt.py
+++ b/tests/test_issue555_coverage_receipt.py
@@ -1,0 +1,169 @@
+"""Structural coverage receipt + conservation invariant (#555, ADR-053).
+
+#542's serious failure mode: some target_paths resolve, some don't, the call
+succeeds, and the drop appears only as a prose string in `expansion_warnings` —
+which no CI gate parses. The receipt makes every omission a typed
+`{path, reason, origin}` on the response, so a caller can tell a `.zig` drop
+(`non-text`) from a `.png` drop (`binary`) from a secret (`denied_secret`).
+
+Additive, default-ON, no clamp (that is #556). The conservation invariant —
+`reviewed ∪ omitted == candidates`, disjoint — is asserted defensively (marker on
+violation, never a crash), the ADR-051 C4 pattern.
+"""
+
+import asyncio
+import random
+import subprocess
+
+import pytest
+
+from llm_council.verification import file_ops
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _commit(tmp_path, monkeypatch, files):
+    repo = tmp_path / "cov"
+    repo.mkdir()
+    _git(repo, "init", "-q", ".")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "README.md").write_text("root\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "root")
+    for name, content in files.items():
+        p = repo / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            p.write_bytes(content)
+        else:
+            p.write_text(content)
+    _git(repo, "add", "-A", "-f")
+    _git(repo, "commit", "-qm", "work")
+    sha = _git(repo, "rev-parse", "HEAD")
+    monkeypatch.setattr(file_ops, "_cached_git_root", str(repo))
+    monkeypatch.chdir(repo)
+    return repo, sha
+
+
+async def _meta(sha, target_paths):
+    _content, meta = await file_ops._fetch_files_for_verification_async_with_metadata(
+        sha, target_paths
+    )
+    return meta
+
+
+class TestCoverageReceipt:
+    def test_coverage_present_with_typed_omissions(self, tmp_path, monkeypatch):
+        _repo, sha = _commit(
+            tmp_path,
+            monkeypatch,
+            {"src/app.py": "x\n", "logo.png": b"PNG\x00\x01\x00\n", "yarn.lock": "lock\n"},
+        )
+        meta = asyncio.run(_meta(sha, None))
+        cov = meta["coverage"]
+        assert "src/app.py" in cov["reviewed"]
+        by_path = {o["path"]: o["reason"] for o in cov["omitted"]}
+        assert by_path.get("logo.png") == "non-text"  # allowlist: .png not text
+        assert by_path.get("yarn.lock") == "garbage"
+        # every omission carries origin, and denied_secret never a value
+        assert all(set(o) == {"path", "reason", "origin"} for o in cov["omitted"])
+
+    def test_reason_distinguishes_secret_from_binary(self, tmp_path, monkeypatch):
+        _repo, sha = _commit(
+            tmp_path,
+            monkeypatch,
+            {".env": "SECRET=leak\n", "logo.png": b"\x00bin\n", "app.py": "x\n"},
+        )
+        meta = asyncio.run(_meta(sha, None))
+        by_path = {o["path"]: o["reason"] for o in meta["coverage"]["omitted"]}
+        assert by_path[".env"] == "denied_secret"
+        # the receipt never contains the secret value
+        assert "leak" not in str(meta["coverage"])
+
+    def test_explicit_omitted_flag_when_named_path_dropped(self, tmp_path, monkeypatch):
+        _repo, sha = _commit(tmp_path, monkeypatch, {"a.zig": "const x=1;\n", "b.py": "y\n"})
+        # allowlist mode: .zig is non-text; naming it explicitly ⇒ explicit_omitted
+        meta = asyncio.run(_meta(sha, ["a.zig", "b.py"]))
+        cov = meta["coverage"]
+        assert cov["explicit_omitted"] is True
+        assert any(o["path"] == "a.zig" and o["origin"] == "explicit" for o in cov["omitted"])
+
+    def test_not_found_path_is_recorded(self, tmp_path, monkeypatch):
+        _repo, sha = _commit(tmp_path, monkeypatch, {"real.py": "x\n"})
+        meta = asyncio.run(_meta(sha, ["real.py", "does/not/exist.py"]))
+        cov = meta["coverage"]
+        assert any(
+            o["path"] == "does/not/exist.py" and o["reason"] == "not_found" for o in cov["omitted"]
+        )
+        assert cov["explicit_omitted"] is True
+
+    def test_requested_is_verbatim_target_paths(self, tmp_path, monkeypatch):
+        _repo, sha = _commit(tmp_path, monkeypatch, {"a.py": "x\n"})
+        meta = asyncio.run(_meta(sha, ["a.py", "missing.py"]))
+        assert meta["coverage"]["requested"] == ["a.py", "missing.py"]
+
+
+class TestConservationInvariant:
+    def test_reviewed_and_omitted_partition_the_candidates(self, tmp_path, monkeypatch):
+        _repo, sha = _commit(
+            tmp_path,
+            monkeypatch,
+            {"src/app.py": "x\n", "logo.png": b"\x00\n", "yarn.lock": "l\n", "doc.md": "d\n"},
+        )
+        meta = asyncio.run(_meta(sha, None))
+        cov = meta["coverage"]
+        reviewed = set(cov["reviewed"])
+        omitted = {o["path"] for o in cov["omitted"]}
+        assert reviewed.isdisjoint(omitted)
+        assert cov["conservation_ok"] is True
+
+    def test_conservation_holds_over_random_trees(self, tmp_path, monkeypatch):
+        rng = random.Random(1234)  # seeded; Date/random-free determinism
+        files = {}
+        for i in range(40):
+            kind = rng.choice(["py", "zig", "png", "lock", "md", "env"])
+            if kind == "py":
+                files[f"d{i % 5}/f{i}.py"] = "x\n"
+            elif kind == "zig":
+                files[f"d{i % 5}/f{i}.zig"] = "const x=1;\n"
+            elif kind == "png":
+                files[f"d{i % 5}/f{i}.png"] = b"\x00bin\n"
+            elif kind == "lock":
+                files[f"d{i % 5}/yarn.lock"] = "l\n"
+            elif kind == "md":
+                files[f"d{i % 5}/f{i}.md"] = "d\n"
+            else:
+                files[f"d{i % 5}/.env"] = "S=x\n"
+        _repo, sha = _commit(tmp_path, monkeypatch, files)
+        meta = asyncio.run(_meta(sha, None))
+        cov = meta["coverage"]
+        reviewed = set(cov["reviewed"])
+        omitted = {o["path"] for o in cov["omitted"]}
+        assert reviewed.isdisjoint(omitted), "reviewed and omitted overlap"
+        assert cov["conservation_ok"] is True
+
+
+class TestSchema:
+    def test_verify_response_has_coverage_field(self):
+        from llm_council.verification.schemas import VerifyResponse
+
+        assert "coverage" in VerifyResponse.model_fields
+
+    def test_coverage_report_round_trips(self):
+        from llm_council.verification.schemas import CoverageReport
+
+        c = CoverageReport(
+            requested=["a.py"],
+            reviewed=["a.py"],
+            omitted=[{"path": ".env", "reason": "denied_secret", "origin": "explicit"}],
+            explicit_omitted=True,
+            truncated=False,
+            conservation_ok=True,
+        )
+        dumped = c.model_dump()
+        assert dumped["omitted"][0]["reason"] == "denied_secret"

--- a/tests/unit/verification/test_tier_aware_file_truncation.py
+++ b/tests/unit/verification/test_tier_aware_file_truncation.py
@@ -156,7 +156,7 @@ class TestFetchFilesUsesTierLimit:
             return "stub-content", False
 
         async def fake_expand(snapshot_id, target_paths):
-            return list(target_paths), False, []
+            return list(target_paths), False, [], []
 
         with (
             patch.object(api, "_fetch_file_at_commit_async", side_effect=fake_fetch),
@@ -188,7 +188,7 @@ class TestFetchFilesUsesTierLimit:
             return "stub", False
 
         async def fake_expand(snapshot_id, target_paths):
-            return list(target_paths), False, []
+            return list(target_paths), False, [], []
 
         with (
             patch.object(api, "_fetch_file_at_commit_async", side_effect=fake_fetch),
@@ -226,7 +226,7 @@ class TestPerFileTruncationSurfacesAsWarning:
             return ("content..." + "[truncated]"), True
 
         async def fake_expand(snapshot_id, target_paths):
-            return list(target_paths), False, []
+            return list(target_paths), False, [], []
 
         with (
             patch.object(api, "_fetch_file_at_commit_async", side_effect=fake_fetch),
@@ -259,7 +259,7 @@ class TestPerFileTruncationSurfacesAsWarning:
             return "small", False
 
         async def fake_expand(snapshot_id, target_paths):
-            return list(target_paths), False, []
+            return list(target_paths), False, [], []
 
         with (
             patch.object(api, "_fetch_file_at_commit_async", side_effect=fake_fetch),


### PR DESCRIPTION
Part of #546 (P3.4), the other half of #542. **Additive, default-ON, no verdict effect** (the clamp is #556).

## What it does

Every verify response gains a typed `coverage` receipt. Before, a dropped file appeared only as a prose string in `expansion_warnings` — which no CI gate parses — so a confident PASS could silently cover less than asked (#542 failure mode 2). Now:

```
reviewed: ['src/app.py']
omitted : [('.env', 'denied_secret'), ('yarn.lock', 'garbage'), ('logo.png', 'non-text')]
conservation_ok: True
secret value leaked into receipt: False
```

A caller can distinguish a `.zig` drop (`non-text`) from a `.png` (`binary`) from a secret (`denied_secret`) — the whole point.

## Shape

`coverage = {requested, reviewed, omitted:[{path,reason,origin}], explicit_omitted, truncated, conservation_ok}`

- `reason ∈ {denied_secret, garbage, non-text, binary, generated, vendored, noise, ignored, too_large, not_found}` — collects the reasons introduced across #547/#548/#552/#553/#554. **`denied_secret` records the path only, never the value** (verified end-to-end).
- `explicit_omitted` — the load-bearing signal that a **caller-named** path was dropped.
- **Conservation invariant** `reviewed ∩ omitted == ∅` as a defensive marker (`conservation_ok`), never a crash (ADR-051 C4 pattern). Property-tested over random trees.

## Plumbing

Structured `Omission`s (previously discarded in the tree branch, stringified in the diff-tree branch) are threaded through `_expand_target_paths` — now a 4-tuple, adding `not_found` for unresolved paths — into the receipt. Typed `CoverageReport`/`CoverageOmission` in `schemas.py`, documented field-by-field in `verify.md` (drift-guard enforced). Survives the timeout path. `expansion_warnings` retained, demoted to prose.

## Verification

- 9 new tests (typed omissions, secret≠binary, explicit_omitted, not_found, requested-verbatim, conservation ×2 incl. seeded random-tree property test, schema round-trip)
- `3411 passed, 1 skipped` full suite; the `_expand_target_paths` 4-tuple signature change updated its 11 directory-expansion tests + 4 tier-truncation fakes
- `ruff check` clean; field-drift guard satisfied

## Deferred

- **#556 coverage clamp** — turns `explicit_omitted` into an `unclear(incomplete_coverage)` verdict. **Blocked on ADR-053 Open Question 1** (`coverage_ack`): a uniform clamp makes any commit touching a `.png` return `unclear`, and a noisy gate gets switched off. The receipt ships first so omissions are visible without that risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)