### PR TITLE
docs(adr): resolve ADR-053 Open Question 1 — coverage_ack design (#556)

### DIFF
--- a/docs/adr/ADR-053-implementation-spec.md
+++ b/docs/adr/ADR-053-implementation-spec.md
@@ -211,21 +211,48 @@ default `allowlist`, byte-identical when off.
   `pathspec`. **No seeding** — the built-in denylist is the floor, not a
   template. `ignore --print-defaults` / `--init` / `--explain` as ergonomics.
 - **P3.4 — Coverage receipt.** Additive, default-ON, no type break. Conservation
-  invariant + `TestVerifyResponseFieldDrift` (ADR-051 C6 precedent).
-- **P3.5 — The clamp.** `pass` not representable over an unreviewed changed or
-  explicitly-named file → `unclear(incomplete_coverage)`.
-  `llm-council gate` hard-errors on `LLM_COUNCIL_COVERAGE_POLICY=warn`.
-  **Blocked on Open Question 1** — see below.
+  invariant + `TestVerifyResponseFieldDrift` (ADR-051 C6 precedent). **SHIPPED
+  (#555, PR #572).**
+- **P3.5 — The clamp + `coverage_ack`.** `pass` not representable over an
+  unreviewed changed or explicitly-named file → `unclear(incomplete_coverage)`,
+  UNLESS acknowledged. `llm-council gate` hard-errors on
+  `LLM_COUNCIL_COVERAGE_POLICY=warn`. **`coverage_ack` shape resolved** (ADR-053
+  Open Question 1); two sub-decisions await the maintainer — see below.
 - **P3.6 — Shadow-mode telemetry**, then flip `content` on in a later release.
 
-### P3.5 is blocked, and should stay blocked
+### P3.5 — the clamp, and its `coverage_ack` escape
 
-ADR-053 Open Question 1 (`coverage_ack`) is the highest-risk open item. Under the
-uniform clamp, *any commit touching a `.png` returns `unclear`*. That is
-literally true and completely unusable — and **a noisy gate gets switched off,
-which is worse than no gate**. Do not ship P3.5 until the acknowledgement
-mechanism is designed. P3.4 (the receipt) is independently valuable and can ship
-first: it makes the omission *visible* without making the gate noisy.
+The clamp is what turns the #555 receipt's `explicit_omitted` signal into a
+verdict. Without an acknowledgement mechanism it is unusable: under the uniform
+rule *any commit touching a `.png` returns `unclear`*, and a noisy gate gets
+switched off — worse than no gate. So P3.5 ships the clamp **and**
+`coverage_ack` together; the receipt (P3.4) already shipped the *visibility*
+without the verdict risk.
+
+**`coverage_ack` design (ADR-053 Open Question 1, resolved 2026-07-11).**
+Caller-owned and auditable — never a pipeline auto-carve-out, which would reopen
+the threat-model hole rev 3 closed. Three layers, in build order:
+
+1. `LLM_COUNCIL_COVERAGE_ACK_REASONS` — a reason-set the operator pre-accepts
+   (recommended default `binary,generated,vendored,too_large,ignored,noise`).
+   Ship first: one setting removes the ~90% "binary" noise. The clamp then fires
+   only on `non-text` (an unlisted language — the #542 bug), `not_found`,
+   `truncated`, and `denied_secret` of a changed file.
+2. `.council/coverage-ack` — a committed gitignore-syntax glob baseline, read
+   from the snapshot (reproducible, PR-reviewable, drift-visible). Add when the
+   long tail needs it. Reuses the `pathspec` matcher from P3.3.
+3. `coverage_ack=[...]` on `run_verification` — a per-call library primitive.
+
+Every ack is stamped on `coverage.acked`, so a would-have-clamped-but-acked run
+is still auditable.
+
+**Two sub-decisions block implementation — maintainer sign-off needed:**
+- **Default ack set** — does `non-text` clamp? Recommended **yes** (it is #542).
+- **`fail` vs `unclear`** — recommended **`unclear(incomplete_coverage)`**
+  (route/retry), consistent with ADR-047 P1.
+
+Do not implement P3.5 until those two are confirmed. Everything else about the
+mechanism is decided.
 
 ---
 

--- a/docs/adr/ADR-053-implementation-spec.md
+++ b/docs/adr/ADR-053-implementation-spec.md
@@ -246,13 +246,16 @@ the threat-model hole rev 3 closed. Three layers, in build order:
 Every ack is stamped on `coverage.acked`, so a would-have-clamped-but-acked run
 is still auditable.
 
-**Two sub-decisions block implementation — maintainer sign-off needed:**
-- **Default ack set** — does `non-text` clamp? Recommended **yes** (it is #542).
-- **`fail` vs `unclear`** — recommended **`unclear(incomplete_coverage)`**
-  (route/retry), consistent with ADR-047 P1.
+**Both sub-decisions settled 2026-07-11 — P3.5 is unblocked:**
+- **Default ack set = `binary,generated,vendored,too_large,ignored,noise`.**
+  `non-text` clamps (it is #542); so do `not_found`, `truncated`, and
+  `denied_secret` of a changed file.
+- **The clamp yields `unclear(incomplete_coverage)`** (not a hard error); the
+  `fail` policy stays available for callers who want the 422.
 
-Do not implement P3.5 until those two are confirmed. Everything else about the
-mechanism is decided.
+**Layer 1 (`LLM_COUNCIL_COVERAGE_ACK_REASONS`) ships with the clamp; layers 2/3
+(`.council/coverage-ack` baseline, per-call list) follow when the tail needs
+them** — the ADR's own build order.
 
 ---
 

--- a/docs/adr/ADR-053-verify-file-selection-trust-boundary.md
+++ b/docs/adr/ADR-053-verify-file-selection-trust-boundary.md
@@ -557,15 +557,14 @@ Every acknowledgement is **recorded on the receipt** (`coverage.acked: [...]`
 with the layer that acked each path), so an `unclear` that *would* have fired but
 was acknowledged is still auditable — the ack is visible, never silent.
 
-Two sub-decisions the maintainer confirms before P3.5 implements (both stated as
-recommendations, not settled):
-- **Default ack set.** Recommended: `binary,generated,vendored,too_large,ignored,noise`
-  — i.e. clamp only on `non-text` / `not_found` / `truncated` / `denied_secret`.
-  The crux is whether `non-text` (an unlisted language) is alarming enough to
-  clamp on; the recommendation says yes, because that *is* #542.
-- **`fail` vs `unclear`.** Recommended: `unclear(incomplete_coverage)` (route and
-  retry) over a hard `SnapshotResolutionError`, consistent with ADR-047 P1's
-  `unclear_reason` routing.
+Two sub-decisions, **both settled 2026-07-11**:
+- **Default ack set = `binary,generated,vendored,too_large,ignored,noise`.** So
+  `non-text` **does** clamp — an unlisted language the allowlist silently dropped
+  is exactly the #542 bug, and the gate should say so. Also clamping:
+  `not_found`, `truncated`, `denied_secret` of a changed file.
+- **The clamp yields `unclear(incomplete_coverage)`** (route and retry via the
+  ADR-047 P1 `unclear_reason`), not a hard `SnapshotResolutionError`. The `fail`
+  policy remains available for callers who want the hard error.
 
 ### How we guarantee the convention is actually applied
 
@@ -768,7 +767,8 @@ caller depends on a `pass` verdict over a partially-omitted explicit path (the
 
 ## Open questions for the decision makers
 
-1. **~~What shape is `coverage_ack`?~~** **Resolved (2026-07-11).** Three
+1. **~~What shape is `coverage_ack`? / default ack set / fail-vs-unclear~~**
+   **All resolved (2026-07-11).** Three
    composable layers, caller-owned and auditable so the uniform-clamp constraint
    holds: (1) `LLM_COUNCIL_COVERAGE_ACK_REASONS` reason-set (ship first, kills the
    ~90% "binary" noise); (2) a committed `.council/coverage-ack` glob baseline

--- a/docs/adr/ADR-053-verify-file-selection-trust-boundary.md
+++ b/docs/adr/ADR-053-verify-file-selection-trust-boundary.md
@@ -508,10 +508,64 @@ introducing a new error path.
 **Usability note.** Under the uniform rule, a commit that touches a `.png` will
 clamp to `unclear`. That is *literally true* — the council did not review the
 PNG — but it is noisy, and a noisy gate gets disabled, which is worse than no
-gate. The escape must be explicit and auditable rather than a global `warn`: a
-caller-supplied `coverage_ack` list naming paths accepted as unreviewed, stamped
-into the receipt. This is the baseline pattern from mypy, Semgrep, and
-`.gitleaksignore`. Its exact shape is Open Question 1.
+gate. The escape must be explicit and auditable rather than a global `warn`.
+That escape is `coverage_ack`, resolved below.
+
+#### `coverage_ack` — the acknowledgement mechanism (resolves Open Question 1)
+
+**Constraint that rules the design.** The clamp is *uniform, no reason-based
+carve-outs* ("The clamp", above), because any hardcoded carve-out is an attacker's
+hiding spot. So the escape cannot be "the pipeline auto-forgives binaries." It
+must be **caller-owned and auditable**: the operator explicitly accepts what goes
+unreviewed and takes responsibility for it. A caller-set acknowledgement is
+categorically different from a silent built-in carve-out — that is why it does
+not reopen the threat-model hole rev 3 closed. Prior art: mypy baselines,
+`.gitleaksignore`, Semgrep `--exclude`, ESLint disable-directives.
+
+Three composable layers, shipped in this order:
+
+**(1) `LLM_COUNCIL_COVERAGE_ACK_REASONS` — the sensible default (ship first).**
+A comma-separated set of omission *reasons* the operator pre-accepts, e.g.
+`binary,generated,vendored,too_large,ignored`. The clamp ignores omissions whose
+reason is on the set. This kills ~90% of the noise (nobody expects a `.png`
+reviewed) with one setting, and it is caller-owned — an explicit env choice, not a
+pipeline default — so it satisfies the uniform-clamp constraint. The clamp then
+fires only on the **surprising** residue:
+
+| reason | clamps by default? | why |
+|---|---|---|
+| `binary`, `generated`, `vendored`, `too_large`, `ignored`, `noise` | **no** (recommended default ack set) | expected-unreviewed; the operator knows |
+| `non-text` | **yes** | an *unlisted language the allowlist silently dropped* — the actual #542 bug; you want to hear about it |
+| `not_found` | **yes** | a typo'd or moved path |
+| `truncated` | **yes** | the char budget cut coverage short |
+| `denied_secret` (of a changed file) | **yes** | "we refused to read it" is not "we reviewed it" |
+
+**(2) `.council/coverage-ack` — a committed baseline (add when the tail needs it).**
+A committed, gitignore-syntax file of path globs accepted as permanently
+unreviewed (`vendor/**`, `*.generated.*`). Read **from the snapshot** for
+reproducibility. It travels with the repo, is reviewable in PR diffs, and its
+drift is visible — the `.gitleaksignore` / mypy-baseline pattern. A PR that adds
+an ack shows the ack in its own diff; that is acceptable because the clamp is
+*honesty, not adversarial defense* (see "Threat model and non-goals"), so a
+contributor acknowledging their own omission is in scope, an attacker is not.
+
+**(3) `coverage_ack=[...]` on `run_verification` — the library primitive.** A
+per-call path/glob list for programmatic callers. Offered, not led with: an
+in-code list drifts from repo reality because nothing keeps it synced.
+
+Every acknowledgement is **recorded on the receipt** (`coverage.acked: [...]`
+with the layer that acked each path), so an `unclear` that *would* have fired but
+was acknowledged is still auditable — the ack is visible, never silent.
+
+Two sub-decisions the maintainer confirms before P3.5 implements (both stated as
+recommendations, not settled):
+- **Default ack set.** Recommended: `binary,generated,vendored,too_large,ignored,noise`
+  — i.e. clamp only on `non-text` / `not_found` / `truncated` / `denied_secret`.
+  The crux is whether `non-text` (an unlisted language) is alarming enough to
+  clamp on; the recommendation says yes, because that *is* #542.
+- **`fail` vs `unclear`.** Recommended: `unclear(incomplete_coverage)` (route and
+  retry) over a hard `SnapshotResolutionError`, consistent with ADR-047 P1's
+  `unclear_reason` routing.
 
 ### How we guarantee the convention is actually applied
 
@@ -714,12 +768,15 @@ caller depends on a `pass` verdict over a partially-omitted explicit path (the
 
 ## Open questions for the decision makers
 
-1. **What shape is `coverage_ack`?** The uniform clamp means any commit touching
-   a `.png` returns `unclear`. A noisy gate gets disabled. Options: a
-   caller-supplied path list, a committed `.council/coverage-baseline`, or an
-   omission-reason allowlist per invocation. **This is the highest-risk open
-   item** — get it wrong and either the gate is unusable or the clamp is
-   vacuous.
+1. **~~What shape is `coverage_ack`?~~** **Resolved (2026-07-11).** Three
+   composable layers, caller-owned and auditable so the uniform-clamp constraint
+   holds: (1) `LLM_COUNCIL_COVERAGE_ACK_REASONS` reason-set (ship first, kills the
+   ~90% "binary" noise); (2) a committed `.council/coverage-ack` glob baseline
+   read from the snapshot; (3) a per-call `coverage_ack=[...]` library primitive.
+   Every ack is stamped on the receipt. See "`coverage_ack` — the acknowledgement
+   mechanism". Two sub-decisions still need the maintainer's sign-off before P3.5
+   implements: the **default ack set** (does `non-text` clamp?) and **`fail` vs
+   `unclear`** — both carry recommendations there.
 2. **~~Does `origin=discovered` + `reason=binary` deserve any verdict effect?~~**
    **Dissolved in rev 3.** Both `origin` and `reason` are the wrong axis; every
    unreviewed changed file clamps. See "The clamp".


### PR DESCRIPTION
Resolves ADR-053 **Open Question 1** (`coverage_ack`), which blocks #556 (the coverage clamp). Docs-only. **No new ADR** — it amends ADR-053 + its implementation spec, because it resolves ADR-053's own open question.

## The design

The clamp is uniform (no reason carve-outs, per rev 3's threat model), so the escape must be **caller-owned and auditable** — a caller-set acknowledgement is categorically different from a silent pipeline carve-out, so it does not reopen the hole rev 3 closed. Three composable layers, in build order:

1. **`LLM_COUNCIL_COVERAGE_ACK_REASONS`** — reason-set the operator pre-accepts (default `binary,generated,vendored,too_large,ignored,noise`). Ship first: kills the ~90% "a commit touched a `.png`" noise. The clamp then fires only on the surprising residue — `non-text` (the #542 unlisted-language bug), `not_found`, `truncated`, `denied_secret` of a changed file.
2. **`.council/coverage-ack`** — committed gitignore-syntax glob baseline, read from the snapshot (reproducible, PR-reviewable, drift-visible), reusing the P3.3 `pathspec` matcher. `.gitleaksignore` / mypy-baseline pattern.
3. **`coverage_ack=[...]`** — per-call library primitive.

Every ack is stamped on `coverage.acked`, so a would-have-clamped-but-acked run stays auditable.

## Two sub-decisions still need your sign-off (block P3.5 implementation)

- **Default ack set** — does `non-text` (an unlisted language) clamp? Recommended **yes** — that is exactly #542.
- **`fail` vs `unclear`** — recommended **`unclear(incomplete_coverage)`** (route/retry), consistent with ADR-047 P1.

Everything else about the mechanism is decided; these two are genuinely product calls.

Also marks P3.4/#555 as shipped in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)