### PR TITLE
Release v0.40.0 — content-aware verify file selection + coverage accounting (ADR-053 P3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.40.0] - 2026-07-11
+
+**Content-aware verify file selection + coverage accounting (ADR-053, epic [#546](https://github.com/amiable-dev/llm-council/issues/546) P3).** Completes the file-selection redesign begun in v0.39.0's security fix. Everything here is **opt-in and byte-identical by default** — no verify verdict changes on upgrade. Closes [#542](https://github.com/amiable-dev/llm-council/issues/542) (unlisted languages silently dropped).
+
+> [!IMPORTANT]
+> **Upcoming default change — the coverage clamp will become the default.** Today the clamp is opt-in (`LLM_COUNCIL_COVERAGE_POLICY=warn` by default — receipt only, no verdict effect). **In a future minor release the default flips to `clamp`**, so a `verify`/`gate` `pass` over a changed-or-explicitly-named file the council did **not** review (in the default `allowlist` file selection, that means any unlisted-extension text file — a `.zig`, `.tf`, `.dart`, …) will return `unclear(incomplete_coverage)` instead, and `llm-council gate` will refuse an explicit `LLM_COUNCIL_COVERAGE_POLICY=warn`. **To prepare now:** set `LLM_COUNCIL_COVERAGE_POLICY=clamp` to adopt it early, and/or run `LLM_COUNCIL_FILE_SELECTION=shadow` to see which files content-mode selection would review that the allowlist drops. The flip will ship as its own `### Changed` release with no fewer than two minor releases' notice from this one.
+
+### Added
+
+- **Content-aware file classification (ADR-053 Q1, [#552](https://github.com/amiable-dev/llm-council/issues/552))** — `LLM_COUNCIL_FILE_SELECTION=content` replaces the ~140-entry `TEXT_EXTENSIONS` allowlist with git's own rule (a blob is text iff its first 8000 bytes contain no NUL), read via `git --attr-source=<sha> grep -I`, which also honours the snapshot's `.gitattributes` `binary`/`-diff`. Reviews any text file — `.zig`, `.tf`, `.dart`, `.sol`, `.gleam`, `LICENSE`, `CODEOWNERS`, shebang scripts — with no per-language list edit. `shadow` mode logs what content selection would change while acting on the allowlist; `allowlist` (default) is byte-identical.
+- **Reviewability filtering (ADR-053 Q2, [#553](https://github.com/amiable-dev/llm-council/issues/553))** — in content mode, `linguist-generated`/`linguist-vendored` paths (from the snapshot's `.gitattributes`) are omitted, and `.svg` is treated as noise unless `LLM_COUNCIL_REVIEW_SVG=true`.
+- **`.llmignore` family support (ADR-053 Q3b, [#554](https://github.com/amiable-dev/llm-council/issues/554))** — content mode honours the first present of `.llmignore` → `.aiexclude` → `.aiignore` → `.cursorignore` → `.codeiumignore` (read from the snapshot, gitignore syntax via `pathspec`). Additive narrowing only — the compiled-in secret boundary always wins. New `llm-council ignore` command (`--print-defaults` / `--explain PATH` / `--init`) — ergonomics only; it never writes a file without `--init`.
+- **Coverage receipt (ADR-053, [#555](https://github.com/amiable-dev/llm-council/issues/555))** — every `verify` response carries a typed `coverage` object: which requested paths were `reviewed` vs `omitted` (each with a `{path, reason, origin}` — `denied_secret` records the path only, never the value), an `explicit_omitted` flag, and a `conservation_ok` invariant marker. Machine-readable replacement for parsing `expansion_warnings` prose.
+- **Coverage clamp, opt-in (ADR-053, [#556](https://github.com/amiable-dev/llm-council/issues/556))** — `LLM_COUNCIL_COVERAGE_POLICY` in `clamp` / `fail` / `warn` (**default `warn` — see the upcoming-change note above**). Under `clamp`, a `pass` over an unreviewed changed-or-explicit file becomes `unclear(incomplete_coverage)`; `LLM_COUNCIL_COVERAGE_ACK_REASONS` (default `binary,generated,vendored,too_large,ignored,noise`) acknowledges expected omissions so the clamp fires only on the surprising ones (`non-text`, `not_found`, `truncated`, `denied_secret`). Adds `incomplete_coverage` to the `unclear_reason` taxonomy.
+
+### Fixed
+
+- **Unlisted languages are no longer silently dropped ([#542](https://github.com/amiable-dev/llm-council/issues/542))** — via content-mode selection (they are reviewed) and the coverage receipt/clamp (their omission is visible/actionable). The #533/#539 "add one extension per release" treadmill is over.
+- **`pathspec>=0.12.0`** added as a runtime dependency (pure-Python; used for `.llmignore` matching).
+
 ## [0.39.0] - 2026-07-10
 
 **Verify file-selection trust boundary + verdict-integrity fixes (ADR-053, epic [#546](https://github.com/amiable-dev/llm-council/issues/546))** — closes a credential-transmission defect in `verify()` and repairs three verdict-integrity bugs found while fixing it. Minor release (not patch) because it changes user-facing behaviour on several paths and carries a security advisory; see the "Changed" notes before upgrading a gate you depend on.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ It is a single Python package (`src/llm_council/`) exposing a CLI, an HTTP/REST 
 
 - Install / setup: `make setup` (deps + `.env`), or `make install` (deps only).
 - Run the HTTP API: `llm-council serve [--host H] [--port 8000]` (default port **8000**). Entry point is `llm_council.cli:main`; the FastAPI app lives in `src/llm_council/http_server.py`.
-- Other CLI subcommands: `setup-key` (store API key in keychain, ADR-013), `bias-report` (cross-session bias analysis, ADR-018), `install-skills`, `gate`.
+- Other CLI subcommands: `setup-key` (store API key in keychain, ADR-013), `bias-report` (cross-session bias analysis, ADR-018), `install-skills`, `gate`, `ignore` (inspect the verify file-selection trust boundary — `--print-defaults`/`--explain`/`--init`, ADR-053).
 - Quality gates: `make test` / `make test-fast` / `make test-cov`, `make lint` (ruff), `make typecheck` (mypy), `make check` (lint+typecheck), `make fix`. ~120 test files in `tests/`.
 - `tests/test_openrouter.py` verifies OpenRouter connectivity and that a model identifier resolves before you add it to the council.
 - **Relative imports**: modules import siblings as `from .unified_config import …`. Keep imports relative within the package.
@@ -97,7 +97,7 @@ Streaming (ADR-046)
 Observability & telemetry
 - `observability/` (ADR-030 metrics export — StatsD/Prometheus/NoOp), `telemetry.py` / `telemetry_client.py`, `webhooks/`.
 
-Verification (ADR-034/040/041) — `verification/api.py`
+Verification (ADR-034/040/041/053) — `verification/api.py`, `verification/file_ops.py`, `verification/coverage.py`
 - `run_verification()` wraps `_run_verification_pipeline()` (stages 1–3) in `asyncio.wait_for()` with a global deadline = `tier_contract.deadline_ms/1000 × 2.0` (`VERIFICATION_TIMEOUT_MULTIPLIER`; raised from 1.5 so stage 3 isn't starved on slow days — balanced 180s, high 360s). On timeout, if stage 2 completed, the partial result salvages an advisory rubric/confidence signal (verdict stays `unclear`).
 - **Waterfall time budget (ADR-040):** stage1 = 50% of remaining, stage2 = 70% of what's left, stage3 = the rest; each capped by `tier_timeout["per_model"]`.
 - **Durable partial state:** `partial_state` is updated after each stage and survives `CancelledError`, so a timeout still returns `completed_stages`. `VerifyResponse` carries `timeout_fired`, `completed_stages`, and (ADR-041) `timing` / `input_metrics`.
@@ -107,6 +107,8 @@ Verification (ADR-034/040/041) — `verification/api.py`
 - **Screening judge (ADR-047 P3, #415):** `verification/screening.py` — three-state `LLM_COUNCIL_SCREENING` (off default/shadow/active); eligibility INVARIANTS (blocking evidence — dicts AND Pydantic models — security focus, risk globs, 5K cap) checked before any model call; unanimity rule ≥`LLM_COUNCIL_SCREEN_MIN_SCORE` (9) on every dimension; decisions logged to `.council/screening/decisions.jsonl`; active-pass returns PASS-with-audit-note (`screening.acted=true`, council never ran). Soft-fail ⇒ full council.
 - **Confidence calibration (ADR-047 P2, #414):** `verification/calibration.py` — corpus loader/analyzer over `.council/logs`, PAV isotonic fit against human dispositions (`.council/calibration/dispositions.jsonl` → `mapping.json`), piecewise-linear `CalibrationMapping` (identity fallback, monotonicity enforced on load). `confidence_calibrated` reported on every response; PASS threshold uses it ONLY behind `LLM_COUNCIL_CALIBRATED_CONFIDENCE` (default off). CLI: `llm-council calibration-report [--fit]`.
 - **UNCLEAR disambiguation (ADR-047 P1, #413):** `unclear_reason ∈ {infra_failure, low_confidence, timeout}` on every unclear verdict (`derive_unclear_reason` in `verdict_extractor.py`; timeout checked first, then #403 `error_status`, else low_confidence). Exit code stays 2 — automation routes on the reason: retry infra, accept-and-audit low confidence, re-tier timeouts. None when `error` marker is set (non-deliberated cap results).
+
+**File selection & coverage (ADR-053, epic #546 — v0.39.0 security slice + v0.40.0 P3).** `file_ops.select_blobs(snapshot_id, candidates)` is the SOLE selection chokepoint (every candidate producer — blob/tree/`diff-tree` branches — routes through it; an unfiltered fetch is unrepresentable, AST-test-pinned). Layered, in order: **Q3 secret boundary** (`_is_secret_path`, compiled-in, case-insensitive, NOT overridable — closed the #540/#543 leak, shipped v0.39.0), **Q2 garbage** (path-component match), then **Q1 decodability** gated by `LLM_COUNCIL_FILE_SELECTION` (`allowlist` default = the `TEXT_EXTENSIONS` predicate, byte-identical; `content` = git NUL heuristic + snapshot `.gitattributes` via `git --attr-source=<sha> grep -I` + linguist attrs + `.svg`-noise + the `.llmignore` family via `pathspec`; `shadow` logs the delta). Content-mode helpers make one git call each and pass `--` before pathspecs. **Coverage receipt** (`expansion_metadata["coverage"]` → `CoverageReport`): typed `{path,reason,origin}` omissions + conservation invariant, additive/default-ON. **Coverage clamp** (`verification/coverage.py`, #556): `coverage_policy()`/`coverage_ack_reasons()`/`coverage_clamp_decision()` — a `pass` over an unreviewed changed/explicit file → `unclear(incomplete_coverage)`. **Opt-in: `coverage._DEFAULT_POLICY="warn"`** (byte-identical); the ONE-LINE flip to `clamp` is #557, gated on shadow telemetry, and also activates `gate_rejects_warn()`. ADR ERRATUM: Q1's example list wrongly includes `.envrc`, which Q3a correctly denies (security wins; #573).
 
 ## Key design decisions
 
@@ -140,6 +142,10 @@ Single Pydantic source of truth consolidating ADR-020/022/023/026/030/031. Prior
 | `LLM_COUNCIL_MCP_TASKS` | ADR-045 P1 kill-switch: disable MCP Tasks exposure even on a task-capable SDK (default enabled-when-supported) |
 | `LLM_COUNCIL_PROMPT_CACHING` | ADR-049 D2 kill-switch: Anthropic cache_control breakpoints + OpenRouter session_id on the verify path (default ON — price-class-only; `false` ⇒ byte-identical payloads) |
 | `LLM_COUNCIL_PROMPT_CACHE_TTL` (`5m`\|`1h`) | ADR-049 D5: prompt-cache TTL override; verify defaults 1h, interactive 5m; invalid ⇒ path default. NOT `LLM_COUNCIL_CACHE_TTL` (response cache) |
+| `LLM_COUNCIL_FILE_SELECTION` (`allowlist`\|`content`\|`shadow`) | ADR-053 Q1 verify file classification; default `allowlist` (byte-identical). `content` = NUL heuristic + snapshot `.gitattributes` + linguist + `.llmignore` |
+| `LLM_COUNCIL_REVIEW_SVG` | ADR-053 Q2: review `.svg` in content mode instead of omitting it as noise (default off) |
+| `LLM_COUNCIL_COVERAGE_POLICY` (`warn`\|`clamp`\|`fail`) | ADR-053 #556 coverage clamp; **default `warn` (opt-in, byte-identical)** — flips to `clamp` in a later release (#557). `clamp` ⇒ pass over an unreviewed changed/explicit file → `unclear(incomplete_coverage)` |
+| `LLM_COUNCIL_COVERAGE_ACK_REASONS` | ADR-053 #556: omission reasons the clamp ignores; default `binary,generated,vendored,too_large,ignored,noise` |
 | `LLM_COUNCIL_MODEL_INTELLIGENCE=true` | Enable dynamic model selection (ADR-026) |
 | `LLM_COUNCIL_OFFLINE=true` | Force offline / static provider |
 | `LLM_COUNCIL_DISCOVERY_ENABLED` / `_INTERVAL` (300) / `_MIN_CANDIDATES` (3) | Background discovery (ADR-028) |

--- a/docs/adr/ADR-053-verify-file-selection-trust-boundary.md
+++ b/docs/adr/ADR-053-verify-file-selection-trust-boundary.md
@@ -1,6 +1,6 @@
 # ADR-053: Verify File Selection — Decodability, Reviewability, and the Trust Boundary
 
-**Status:** Partially implemented 2026-07-10 (rev 3) — the security slice (Q0 chokepoint #543, Q3a secret denylist #540, argv hygiene #549) shipped in v0.39.0 as epic [#546](https://github.com/amiable-dev/llm-council/issues/546) P0, together with the P2 verdict-integrity fixes (#544/#545/#560/#561). Q1 content-sniffing, Q2 reviewability, Q3b `.llmignore`, the coverage receipt and the coverage clamp are **deferred** to later P3 work.
+**Status:** Implemented — the security slice (Q0 #543, Q3a #540, argv #549) + P2 verdict-integrity fixes shipped in **v0.39.0** (2026-07-10); the P3 design work (Q1 content-sniffing #552, Q2 reviewability #553, Q3b `.llmignore` #554, coverage receipt #555, coverage clamp #556) shipped **opt-in** in **v0.40.0** (2026-07-11). The coverage-clamp default flips `warn`→`clamp` in a later release (#557) after shadow telemetry.
 
 **Review history:**
 - **rev 1** — initial draft.

--- a/docs/guides/verify.md
+++ b/docs/guides/verify.md
@@ -119,6 +119,73 @@ decouple from `findings`.
 `major`". This is the durable contract; the flag defaults **off** and this
 epic is non-breaking, but the legacy prose-scrape is the path being retired.
 
+## Controlling what gets reviewed (ADR-053)
+
+`verify` decides which files enter the prompt through a layered filter. A
+compiled-in **secret boundary** always runs first and is never overridable:
+credential files (`.env*`, `*.pem`, `id_rsa*`, `.npmrc`, `.aws/credentials`,
+`kubeconfig`, `secrets.y*ml`, …) are never transmitted, even if you name one
+explicitly. Inspect it with `llm-council ignore --print-defaults`, or ask why a
+given path is or isn't reviewed with `llm-council ignore --explain <path>`.
+
+**File classification** — `LLM_COUNCIL_FILE_SELECTION`:
+
+- `allowlist` (default) — the historical `TEXT_EXTENSIONS` list. Byte-identical
+  to older releases. A file whose extension isn't on the list (`.zig`, `.tf`,
+  `.dart`, …) is dropped.
+- `content` — git's own text detection (a blob is text iff its first 8000 bytes
+  contain no NUL), honouring the snapshot's `.gitattributes`. **Reviews any text
+  file regardless of extension** — unlisted languages, `LICENSE`, `CODEOWNERS`,
+  shebang scripts. Also omits `linguist-generated`/`linguist-vendored` paths and
+  (unless `LLM_COUNCIL_REVIEW_SVG=true`) `.svg`.
+- `shadow` — acts on the allowlist but logs what `content` would add or drop, so
+  you can measure the change before adopting it.
+
+**Repo-owned exclusions** — in `content` mode, `verify` honours the first present
+of `.llmignore` → `.aiexclude` → `.aiignore` → `.cursorignore` → `.codeiumignore`
+(read from the snapshot, gitignore syntax). It can only *narrow* what is reviewed;
+it can never re-admit a denied secret. `llm-council ignore --init` writes a
+commented starter file (it never overwrites an existing one, and never runs
+unless you ask).
+
+## Coverage accounting (ADR-053)
+
+Every response carries a `coverage` receipt so a gate can tell **what was
+reviewed vs skipped, and why**, instead of parsing prose:
+
+```json
+"coverage": {
+  "reviewed": ["src/app.py"],
+  "omitted": [{"path": "main.zig", "reason": "non-text", "origin": "discovered"},
+              {"path": ".env",     "reason": "denied_secret", "origin": "discovered"}],
+  "explicit_omitted": false
+}
+```
+
+`reason` distinguishes a dropped source file (`non-text`) from a binary
+(`binary`) from a secret (`denied_secret` — the value is never recorded). Key CI
+logic on `coverage`, not on `expansion_warnings`.
+
+**The coverage clamp** — `LLM_COUNCIL_COVERAGE_POLICY`:
+
+- `warn` (**current default**) — receipt only, no verdict effect. Byte-identical.
+- `clamp` — a `pass` over a changed-or-explicitly-named file the council did
+  **not** review becomes `unclear(incomplete_coverage)` (see `coverage.clamped`).
+  `LLM_COUNCIL_COVERAGE_ACK_REASONS` (default
+  `binary,generated,vendored,too_large,ignored,noise`) acknowledges expected
+  omissions, so the clamp fires only on the surprising ones (`non-text`,
+  `not_found`, `truncated`, `denied_secret`).
+- `fail` — the same condition raises a hard 422 instead.
+
+> **Upcoming default change.** The clamp default will flip from `warn` to `clamp`
+> in a future minor release (with ≥2 releases' notice). When it does, a
+> `verify`/`gate` `pass` over an unreviewed changed/explicit file — in the default
+> `allowlist` selection, any unlisted-extension source file — returns
+> `unclear(incomplete_coverage)`, and `gate` refuses an explicit `warn`. **Adopt
+> early** with `LLM_COUNCIL_COVERAGE_POLICY=clamp`; **preview** the impact with
+> `LLM_COUNCIL_FILE_SELECTION=shadow`. Switching to `content` selection reviews
+> the dropped files so they no longer clamp.
+
 ## Response fields
 
 Every field on the `verify` response (`VerifyResponse`), the nested `Finding`,


### PR DESCRIPTION
Release PR for **v0.40.0**. Ships the ADR-053 P3 file-selection work (#552–#556), all merged to master since v0.39.0 and **unreleased until now**.

## Why this release matters for the flip

This is the release that makes the coverage clamp **available opt-in** *and* **announces** that its default will flip later. That announcement is the piece that makes the eventual flip (#557) safe — users get advance notice, not a surprise. The CHANGELOG carries a prominent `> [!IMPORTANT]` upcoming-change notice.

## Contents (all opt-in, byte-identical by default)

- Content-aware file classification (`LLM_COUNCIL_FILE_SELECTION`, #552)
- Reviewability filtering (linguist/`.svg`, #553)
- `.llmignore` family + `llm-council ignore` CLI (#554)
- Coverage receipt on every response (#555)
- Coverage clamp, opt-in (`LLM_COUNCIL_COVERAGE_POLICY`, default `warn`, #556)
- **Closes #542**; adds `pathspec` runtime dep.

## Sequencing (the point of your question)

```
v0.40.0 (this)     opt-in clamp available + FLIP ANNOUNCED
   │
   ├── v0.41.0     (advance-notice window)
   ├── v0.42.0     (advance-notice window)
   │
   └── vX          flip default warn→clamp  ← #557, scheduled routine opens the draft PR
```

The scheduled flip routine (`trig_01RdNyo1ehBypbyN65D1BHi9`) won't open the flip PR until **2 minor releases past this one**, and it never merges — so there's a real notice window and a human gate.

## After merge

Tag `v0.40.0` from updated master → `publish.yml` → PyPI. Minor bump: new opt-in features, no default behavior change.

## Checks

- `3434 passed, 1 skipped` full suite; docs-drift green; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)