### PR TITLE
docs(adr): ADR-053 erratum — .envrc is denied, not reviewed (#573)

### DIFF
--- a/docs/adr/ADR-053-verify-file-selection-trust-boundary.md
+++ b/docs/adr/ADR-053-verify-file-selection-trust-boundary.md
@@ -300,9 +300,16 @@ regardless of the checked-out tree.
 
 **This dissolves the extensionless-file question entirely.** `LICENSE`,
 `CODEOWNERS`, `Makefile`, `Dockerfile`, `Jenkinsfile`, `Procfile`, `BUILD`,
-`.envrc`, and shebang scripts are all NUL-free and are simply included. No
-filename list, no shebang parser, no `{"makefile", "dockerfile", "jenkinsfile",
-"cmakelists"}` special case. The existing special case is deleted, not extended.
+and shebang scripts are all NUL-free and are simply included. No filename list,
+no shebang parser, no `{"makefile", "dockerfile", "jenkinsfile", "cmakelists"}`
+special case. The existing special case is deleted, not extended.
+
+> **Erratum (#573).** An earlier draft of this list also named `.envrc`. That is
+> wrong: `.envrc` is a direnv shell file that routinely holds `export SECRET=…`,
+> so Q3a (below) denies it, and the Q3 secret boundary runs *before* this Q1
+> step — security wins over the illustrative list. `.envrc` is **not** reviewed;
+> it is a `denied_secret`, pinned by
+> `test_issue552_content_sniffing::test_envrc_stays_denied_adr_erratum`.
 
 **Known blind spot, stated plainly:** UTF-16 source files are full of NUL bytes
 and will be classified binary. Git has the identical blind spot and repos work


### PR DESCRIPTION
Closes #573. **Doc-only** — the code already denies `.envrc` (test-pinned, shipped in v0.40.0); only the ADR-053 Q1 example prose was wrong.

ADR-053 Q1's "simply included" list named `.envrc`, contradicting Q3a (which denies it) and the shipped behavior. Since `.envrc` is a direnv shell file that routinely holds `export SECRET=…` and the secret boundary runs before Q1, it is correctly denied. Fixed with an inline erratum note pointing at `test_envrc_stays_denied_adr_erratum`.

No release needed: docs deploy on push to master (`docs.yml`), so merging republishes the site; the package is unchanged.