### PR TITLE
fix(verify): bound proc.wait() in git-show file fetch to close a pipe-deadlock hang

### DIFF
--- a/src/llm_council/verification/file_ops.py
+++ b/src/llm_council/verification/file_ops.py
@@ -857,6 +857,24 @@ async def _expand_target_paths(
 # =============================================================================
 
 
+async def _wait_killed_process(proc: "asyncio.subprocess.Process") -> None:
+    """Bounded wait for an already-killed process to reap.
+
+    SIGKILL should terminate a process almost immediately regardless of what
+    syscall it's blocked in, but "should" is not "must never hang" — this
+    still uses a short bound rather than a bare ``await proc.wait()`` so a
+    truly wedged process (e.g. stuck in an uninterruptible kernel state)
+    can't reintroduce the same unbounded-hang class this helper exists to
+    close. A short, fixed bound is used rather than ``ASYNC_SUBPROCESS_TIMEOUT``
+    — a killed process reaping is expected to be near-instant, not a full
+    request-level wait.
+    """
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=2.0)
+    except asyncio.TimeoutError:
+        logger.warning("process did not reap within 2s after kill() — abandoning wait")
+
+
 async def _fetch_file_at_commit_async(
     snapshot_id: str,
     file_path: str,
@@ -934,11 +952,38 @@ async def _fetch_file_at_commit_async(
 
             except asyncio.TimeoutError:
                 proc.kill()
-                await proc.wait()
+                await _wait_killed_process(proc)
                 return f"[Error: Timeout reading {file_path}]", False
 
-            # Wait for process to complete (already killed if truncated)
-            await proc.wait()
+            # Wait for process to complete (already killed if truncated).
+            #
+            # BUG (found via a real-world verify() hang, ~15min, no ADR-040
+            # protection reaches this code): reading only stdout here, never
+            # stderr, is the classic Python subprocess pipe deadlock. If the
+            # child (e.g. `git show` triggering an LFS smudge filter, a
+            # submodule warning, or CRLF notices) writes enough to `stderr`
+            # to fill the OS pipe buffer while nobody drains it, the child
+            # blocks *inside the kernel* on that write — it can fully close
+            # stdout (giving EOF, so read_with_limit() above returns cleanly)
+            # while never actually exiting. A bare `await proc.wait()` here
+            # then hangs indefinitely: this file-fetch runs entirely BEFORE
+            # the ADR-040 global deadline wrapper even starts (prompt
+            # building happens ahead of run_verification's asyncio.wait_for),
+            # so nothing else bounds it either.
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=ASYNC_SUBPROCESS_TIMEOUT)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "git show for %s:%s produced all stdout but did not exit "
+                    "within %ss — likely blocked writing to an unread stderr "
+                    "pipe (LFS/submodule/CRLF chatter); force-killed",
+                    snapshot_id,
+                    file_path,
+                    ASYNC_SUBPROCESS_TIMEOUT,
+                )
+                proc.kill()
+                await _wait_killed_process(proc)
+                return f"[Error: git show for {file_path} hung after producing output — killed]", False
 
             if proc.returncode != 0 and not truncated:
                 # Only check return code if we didn't kill it for truncation

--- a/tests/unit/verification/test_async_file_fetch.py
+++ b/tests/unit/verification/test_async_file_fetch.py
@@ -230,6 +230,124 @@ class TestAsyncTimeout:
             mock_proc.kill.assert_called()
 
 
+class TestProcessExitDeadlock:
+    """Regression tests for the classic Python subprocess pipe deadlock:
+    stdout=PIPE + stderr=PIPE with only stdout drained can leave the child
+    blocked writing to a full, unread stderr pipe. It can produce all of
+    stdout (EOF) yet never actually terminate — and proc.wait() had no
+    timeout, so a single pathological file (LFS smudge chatter, submodule
+    warnings, CRLF notices — anything writing enough to stderr) could hang
+    verify() for its full remaining lifetime with zero cap, entirely outside
+    the ADR-040 global deadline (file fetching runs before that wrapper is
+    ever reached).
+    """
+
+    @pytest.mark.asyncio
+    async def test_fetch_does_not_hang_if_process_never_exits_after_stdout_eof(self):
+        """stdout reaches EOF normally, but the process itself never exits
+        (simulating it being stuck writing to a full stderr pipe). The whole
+        fetch must return within a bounded time, not hang indefinitely."""
+        from llm_council.verification.file_ops import _fetch_file_at_commit_async
+
+        async def mock_read(size: int) -> bytes:
+            return b""  # immediate EOF — stdout already fully produced
+
+        mock_stdout = MagicMock()
+        mock_stdout.read = mock_read
+        mock_stderr = MagicMock()
+        mock_stderr.read = AsyncMock(return_value=b"")
+
+        mock_proc = MagicMock()
+        mock_proc.stdout = mock_stdout
+        mock_proc.stderr = mock_stderr
+        mock_proc.returncode = 0
+        mock_proc.kill = MagicMock()
+
+        async def never_returns():
+            await asyncio.Event().wait()  # blocks forever — the stuck process
+
+        mock_proc.wait = never_returns
+
+        with (
+            patch(
+                "llm_council.verification.file_ops._get_git_root_async",
+                new_callable=AsyncMock,
+                return_value="/mock/root",
+            ),
+            patch(
+                "llm_council.verification.file_ops._get_git_semaphore",
+                new_callable=AsyncMock,
+                return_value=asyncio.Semaphore(10),
+            ),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=mock_proc,
+            ),
+            patch("llm_council.verification.file_ops.ASYNC_SUBPROCESS_TIMEOUT", 0.2),
+        ):
+            # Outer bound is a TEST safety net (so an unfixed regression fails
+            # fast instead of hanging the suite) — the fix should make the
+            # inner call itself return well within this.
+            content, truncated = await asyncio.wait_for(
+                _fetch_file_at_commit_async("HEAD", "file.txt"), timeout=3.0
+            )
+            assert "[Error:" in content
+            assert truncated is False
+            mock_proc.kill.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_fetch_does_not_hang_after_kill_if_process_wont_die(self):
+        """The timeout-path proc.wait() (after a kill() from the read-loop
+        timeout) must ALSO be bounded — a SIGKILL'd process should reap
+        promptly, but this must not rely on that being instantaneous."""
+        from llm_council.verification.file_ops import _fetch_file_at_commit_async
+
+        async def slow_read(size: int) -> bytes:
+            await asyncio.sleep(999)  # never resolves within the read-loop timeout
+            return b""
+
+        mock_stdout = MagicMock()
+        mock_stdout.read = slow_read
+        mock_stderr = MagicMock()
+        mock_stderr.read = AsyncMock(return_value=b"")
+
+        mock_proc = MagicMock()
+        mock_proc.stdout = mock_stdout
+        mock_proc.stderr = mock_stderr
+        mock_proc.returncode = 0
+        mock_proc.kill = MagicMock()
+
+        async def never_returns():
+            await asyncio.Event().wait()
+
+        mock_proc.wait = never_returns
+
+        with (
+            patch(
+                "llm_council.verification.file_ops._get_git_root_async",
+                new_callable=AsyncMock,
+                return_value="/mock/root",
+            ),
+            patch(
+                "llm_council.verification.file_ops._get_git_semaphore",
+                new_callable=AsyncMock,
+                return_value=asyncio.Semaphore(10),
+            ),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=mock_proc,
+            ),
+            patch("llm_council.verification.file_ops.ASYNC_SUBPROCESS_TIMEOUT", 0.2),
+        ):
+            content, truncated = await asyncio.wait_for(
+                _fetch_file_at_commit_async("HEAD", "file.txt"), timeout=3.0
+            )
+            assert "[Error:" in content
+            assert truncated is False
+
+
 class TestPathValidation:
     """Tests for path validation security."""
 


### PR DESCRIPTION
Closes #582

## Summary

- `verify()` was observed to hang ~15-16 minutes, twice consecutively, on a real request in another repo's session. Root-caused via code inspection: `_fetch_file_at_commit_async()` (verification/file_ops.py) spawns `git show` with both stdout and stderr piped but only drains stdout; if the child fills the stderr pipe buffer (LFS/submodule/CRLF chatter) before anyone reads it, it can close stdout cleanly while never exiting, and the subsequent unguarded `await proc.wait()` then hangs forever — entirely outside the ADR-040 global verification deadline (file fetch runs before that wrapper starts).
- Fix: added `_wait_killed_process()` (bounded reap-after-kill, 2.0s) and wrapped both `proc.wait()` call sites in `asyncio.wait_for(..., timeout=ASYNC_SUBPROCESS_TIMEOUT)`.
- Added `TestProcessExitDeadlock` regression tests that mock a process whose `.wait()` never resolves, confirmed red against the old code and green after the fix.

## Test plan

- [x] New regression tests fail against pre-fix code (confirmed via git stash), pass after the fix
- [x] `tests/unit/verification/test_async_file_fetch.py` — 22/22 passing
- [x] Broader verification suite (unit/verification, directory-expansion, prompt-segments, verify-file-selection, integration/verification) — 327/327 passing
- [x] Full `make test-fast` — 3576 passed, 1 skipped, 2 deselected
- [x] `make lint` — clean