### PR TITLE
fix(verify): file-selection robustness issues surfaced by whole-file Council review

### DIFF
--- a/src/llm_council/verification/constants.py
+++ b/src/llm_council/verification/constants.py
@@ -26,6 +26,14 @@ MAX_FILES_EXPANSION = 100
 # to sniff it. Generous: tier char budgets truncate anything reviewable anyway.
 MAX_BLOB_SIZE_BYTES = 5_000_000
 
+# #584: content-mode git calls (`_blob_sizes`, `_text_paths`,
+# `_reviewability_attrs`) spread an unbounded candidate-path list directly
+# into a subprocess argv. A commit touching enough files (a huge vendoring
+# or initial-import commit) can exceed the OS ARG_MAX, causing the call to
+# fail and its paths to be silently treated as omitted/binary. Chunking
+# keeps any single invocation well under ARG_MAX on every supported OS.
+GIT_ARGV_BATCH_SIZE = 200
+
 # Text file extensions to include (whitelist approach per council decision)
 # 80+ extensions covering common source code, config, and documentation files
 TEXT_EXTENSIONS: Set[str] = frozenset(

--- a/src/llm_council/verification/file_ops.py
+++ b/src/llm_council/verification/file_ops.py
@@ -1253,7 +1253,16 @@ async def _fetch_files_for_verification_async_with_metadata(
             # budget could push total_chars past per_batch_budget before the
             # *next* file's check ever caught it — overshooting by up to one
             # whole per-file budget's worth of characters.
-            if total_chars + len(content) > per_batch_budget:
+            #
+            # `total_chars > 0` guards the FIRST file: a truncated file's
+            # returned content is `content[:limit] + marker_text`, so its
+            # length is slightly ABOVE per_file_budget (== per_batch_budget)
+            # on its own. Without this guard the projected-total check would
+            # drop the first file entirely instead of including it truncated
+            # (a Council review of this exact PR caught the regression) —
+            # CLAUDE.md documents "reasoning/high can read a full 50K file"
+            # as a guarantee, so the first file is always included.
+            if total_chars > 0 and total_chars + len(content) > per_batch_budget:
                 sections.append(
                     f"\n... [remaining files omitted, {per_batch_budget} char limit reached]"
                 )

--- a/src/llm_council/verification/file_ops.py
+++ b/src/llm_council/verification/file_ops.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from .constants import (
     ASYNC_SUBPROCESS_TIMEOUT,
     GARBAGE_FILENAMES,
+    GIT_ARGV_BATCH_SIZE,
     MAX_BLOB_SIZE_BYTES,
     MAX_FILE_CHARS,
     MAX_FILES_EXPANSION,
@@ -85,8 +86,14 @@ def _validate_file_path(file_path: str) -> bool:
     if file_path.startswith("/") or file_path.startswith("\\"):
         return False
 
-    # Reject path traversal attempts
-    if ".." in file_path:
+    # Reject path traversal attempts. #584: a substring check (`".." in
+    # file_path`) over-rejects legitimate filenames that merely contain the
+    # two characters (e.g. "version..txt") without being an actual ".."
+    # path COMPONENT. Check components instead — this is strictly more
+    # correct, not more permissive: it still catches ".." anywhere in the
+    # path (leading, trailing, or nested), just not as a false positive on
+    # an unrelated filename.
+    if any(part == ".." for part in Path(file_path).parts):
         return False
 
     # Reject null bytes (path injection)
@@ -411,13 +418,26 @@ def file_selection_mode() -> str:
 
 
 async def _blob_sizes(snapshot_id: str, paths: List[str]) -> Dict[str, int]:
-    """Byte size per path in the snapshot, via one `git ls-tree` call (#552).
+    """Byte size per path in the snapshot, via `git ls-tree` (#552).
 
     Serves the size cap AND empty-file disambiguation (an empty blob is text but
     `git grep` never lists it). Missing ⇒ absent from the returned map.
+
+    #584: chunks `paths` across multiple git calls (`GIT_ARGV_BATCH_SIZE` per
+    call) so a large candidate list cannot exceed the OS ARG_MAX and fail the
+    whole call — which previously meant every one of those paths silently
+    dropped out of the returned map with no error.
     """
     if not paths:
         return {}
+    sizes: Dict[str, int] = {}
+    for i in range(0, len(paths), GIT_ARGV_BATCH_SIZE):
+        sizes.update(await _blob_sizes_chunk(snapshot_id, paths[i : i + GIT_ARGV_BATCH_SIZE]))
+    return sizes
+
+
+async def _blob_sizes_chunk(snapshot_id: str, paths: List[str]) -> Dict[str, int]:
+    """One `git ls-tree` call's worth of `_blob_sizes` (caller chunks paths)."""
     git_root = await _get_git_root_async()
     semaphore = await _get_git_semaphore()
     for fmt in ("--format=%(objectsize) %(path)", None):
@@ -469,9 +489,20 @@ async def _text_paths(snapshot_id: str, paths: List[str]) -> set:
     `.gitattributes` (a top-level git option, not a grep flag — verified 2.50.1).
     Exit 1 = "no text file matched", not an error. Empty blobs never appear here
     (they are recovered via `_blob_sizes` size==0 by the caller).
+
+    #584: chunks `paths` (`GIT_ARGV_BATCH_SIZE` per call) to stay under the
+    OS ARG_MAX on large candidate lists — see `_blob_sizes`.
     """
     if not paths:
         return set()
+    result: set = set()
+    for i in range(0, len(paths), GIT_ARGV_BATCH_SIZE):
+        result |= await _text_paths_chunk(snapshot_id, paths[i : i + GIT_ARGV_BATCH_SIZE])
+    return result
+
+
+async def _text_paths_chunk(snapshot_id: str, paths: List[str]) -> set:
+    """One `git grep` call's worth of `_text_paths` (caller chunks paths)."""
     git_root = await _get_git_root_async()
     semaphore = await _get_git_semaphore()
     async with semaphore:
@@ -525,6 +556,8 @@ def denylist_summary() -> List[str]:
         "  " + " ".join(f"{p}*" for p in _SECRET_PREFIXES),
         "# secret directories (any path component):",
         "  " + " ".join(sorted(_SECRET_DIRS)),
+        "# secret directory trees (compound path components):",
+        "  " + " ".join(f"{lead}/{sub}/**" for lead, sub in _SECRET_DIR_PREFIXES),
         "# ignore-file family honored in content mode (first present wins):",
         "  " + " -> ".join(IGNORE_FILENAMES),
     ]
@@ -574,12 +607,25 @@ def review_svg_enabled() -> bool:
 async def _reviewability_attrs(snapshot_id: str, paths: List[str]) -> Dict[str, str]:
     """Map path → "generated"/"vendored" from the SNAPSHOT's linguist attributes.
 
-    One `git --attr-source=<sha> check-attr -z linguist-generated linguist-vendored`
-    call (#553, ADR-053 Q2). `-z` output is flat NUL triples `path\\0attr\\0value`;
+    `git --attr-source=<sha> check-attr -z linguist-generated linguist-vendored`
+    (#553, ADR-053 Q2). `-z` output is flat NUL triples `path\\0attr\\0value`;
     a value of `set` means the attribute applies. `generated` wins if both are set.
+
+    #584: chunks `paths` (`GIT_ARGV_BATCH_SIZE` per call) to stay under the
+    OS ARG_MAX on large candidate lists — see `_blob_sizes`.
     """
     if not paths:
         return {}
+    out: Dict[str, str] = {}
+    for i in range(0, len(paths), GIT_ARGV_BATCH_SIZE):
+        out.update(
+            await _reviewability_attrs_chunk(snapshot_id, paths[i : i + GIT_ARGV_BATCH_SIZE])
+        )
+    return out
+
+
+async def _reviewability_attrs_chunk(snapshot_id: str, paths: List[str]) -> Dict[str, str]:
+    """One `git check-attr` call's worth of `_reviewability_attrs` (caller chunks)."""
     git_root = await _get_git_root_async()
     semaphore = await _get_git_semaphore()
     async with semaphore:
@@ -841,8 +887,11 @@ async def _expand_target_paths(
                 break
 
         else:
+            # #584: a real (if unusual) object type — e.g. `commit` for a
+            # submodule gitlink, or `tag` — is not the same as "not found".
+            # `Omission.reason` already documents `unknown_object` for this.
             warnings.append(f"Unknown object type '{obj_type}' for path: {path}")
-            omissions.append(Omission(path, "not_found", "explicit"))
+            omissions.append(Omission(path, "unknown_object", "explicit"))
 
         # Check limit after each path
         if len(expanded_files) >= MAX_FILES_EXPANSION:
@@ -994,7 +1043,12 @@ async def _fetch_file_at_commit_async(
                         stderr_data = await asyncio.wait_for(proc.stderr.read(1024), timeout=1)
                     except Exception:
                         pass
-                return f"[Error: Could not read {file_path} at {snapshot_id}]", False
+                # #584: stderr_data was read but never used — the error message
+                # was a generic "could not read", discarding git's own (often
+                # much more specific) explanation of what went wrong.
+                detail = stderr_data.decode("utf-8", errors="replace").strip()
+                suffix = f": {detail}" if detail else ""
+                return f"[Error: Could not read {file_path} at {snapshot_id}{suffix}]", False
 
             # Combine chunks and decode
             content_bytes = b"".join(chunks)
@@ -1078,7 +1132,13 @@ async def _fetch_files_for_verification_async_with_metadata(
     per_batch_budget = tier_budget
 
     # ADR-034 v2.6: Expand directories in target_paths
-    if target_paths:
+    #
+    # #584: `target_paths` must be gated on `is not None`, not truthiness. An
+    # explicit `target_paths=[]` means "review zero files" — a bare `if
+    # target_paths:` treats that the same as `None` and falls through to the
+    # "no target_paths given" branch below, silently fetching every changed
+    # file instead of the zero files the caller asked for.
+    if target_paths is not None:
         files_to_fetch, truncated, warnings, all_omissions = await _expand_target_paths(
             snapshot_id, target_paths
         )
@@ -1122,8 +1182,18 @@ async def _fetch_files_for_verification_async_with_metadata(
                     expansion_metadata["expansion_warnings"] = [
                         o.as_warning() for o in omitted
                     ]
-        except Exception:
-            pass
+        except Exception as e:
+            # #584: this used to be a bare `except Exception: pass` — a real
+            # failure (missing git binary, corrupt repo, timeout) left
+            # `files_to_fetch` at its initial empty list with no signal at
+            # all. verify() would silently review zero files and report
+            # clean coverage rather than surfacing that discovery itself
+            # failed (a fail-open exactly where ADR-053's coverage-receipt
+            # invariant says it must not be silent).
+            logger.warning("git diff-tree discovery failed: %s", e)
+            expansion_metadata["expansion_warnings"].append(
+                f"git diff-tree discovery failed ({e}); reviewing zero changed files"
+            )
 
     # #555 coverage receipt: typed omissions + conservation invariant. Built here
     # so every path select_blobs saw is accounted for, whichever branch produced
@@ -1161,13 +1231,11 @@ async def _fetch_files_for_verification_async_with_metadata(
     # Fetch in batches of up to 5 files at a time
     BATCH_SIZE = 5
     files_fetched = 0
+    budget_exceeded = False
 
     for i in range(0, len(files_to_fetch), BATCH_SIZE):
         # Check limit before fetching next batch
-        if total_chars >= per_batch_budget:
-            sections.append(
-                f"\n... [remaining files omitted, {per_batch_budget} char limit reached]"
-            )
+        if budget_exceeded:
             break
 
         batch = files_to_fetch[i : i + BATCH_SIZE]
@@ -1179,10 +1247,17 @@ async def _fetch_files_for_verification_async_with_metadata(
         )
 
         for file_path, (content, truncated) in zip(batch, results):
-            if total_chars >= per_batch_budget:
+            # #584: check the PROJECTED total, not the current one. The old
+            # `total_chars >= per_batch_budget` check ran before this file's
+            # content was added, so a single file up to the full per-file
+            # budget could push total_chars past per_batch_budget before the
+            # *next* file's check ever caught it — overshooting by up to one
+            # whole per-file budget's worth of characters.
+            if total_chars + len(content) > per_batch_budget:
                 sections.append(
                     f"\n... [remaining files omitted, {per_batch_budget} char limit reached]"
                 )
+                budget_exceeded = True
                 break
 
             total_chars += len(content)

--- a/tests/test_directory_expansion.py
+++ b/tests/test_directory_expansion.py
@@ -257,6 +257,26 @@ class TestExpandTargetPaths:
         assert any(f.endswith(".py") for f in files)
 
     @pytest.mark.asyncio
+    async def test_unrecognized_object_type_uses_unknown_object_reason(self):
+        """#584: the `Omission.reason` docstring documents `unknown_object` as
+        a distinct reason from `not_found`, but a git object type that is
+        neither `blob` nor `tree` (e.g. `commit` for a submodule gitlink, or
+        `tag`) was recorded as `not_found` — losing the more precise reason
+        that already exists for exactly this case."""
+        from llm_council.verification import file_ops as api
+
+        async def fake_object_type(snapshot_id, path):
+            return "commit"  # a submodule gitlink: neither blob nor tree
+
+        with patch.object(api, "_get_git_object_type", side_effect=fake_object_type):
+            _files, _truncated, _warnings, omissions = await api._expand_target_paths(
+                "HEAD", ["vendor/submodule"]
+            )
+
+        assert len(omissions) == 1
+        assert omissions[0].reason == "unknown_object"
+
+    @pytest.mark.asyncio
     async def test_expands_mixed_paths(self):
         """Mixed file and directory paths should be handled correctly."""
         from llm_council.verification.api import _expand_target_paths
@@ -407,6 +427,53 @@ class TestFetchFilesIntegration:
         assert isinstance(metadata["expanded_paths"], list)
         assert "paths_truncated" in metadata
         assert "expansion_warnings" in metadata
+
+
+# =============================================================================
+# #584: diff-tree failure must not fail open silently
+# =============================================================================
+
+
+class TestDiffTreeFailureIsNotSilent:
+    """The `target_paths=None` branch discovers changed files via `git
+    diff-tree` inside a bare `try/except Exception: pass`. A real failure
+    (missing git binary, corrupt repo, non-zero exit some other way) left
+    `files_to_fetch` at its initial empty list with absolutely no signal —
+    verify() would silently review zero files and report success on the
+    coverage front, rather than surfacing that discovery itself failed."""
+
+    @pytest.mark.asyncio
+    async def test_diff_tree_exception_is_logged_and_warned(self, caplog):
+        from llm_council.verification import file_ops as api
+
+        with (
+            patch.object(
+                api,
+                "_get_git_root_async",
+                new_callable=AsyncMock,
+                return_value="/mock/root",
+            ),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                side_effect=OSError("git binary not found"),
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            _content, metadata = await api._fetch_files_for_verification_async_with_metadata(
+                "HEAD", None
+            )
+
+        assert metadata["expanded_paths"] == []
+        warnings = metadata.get("expansion_warnings") or []
+        joined = " ".join(str(w).lower() for w in warnings)
+        assert "diff-tree" in joined or "discover" in joined, (
+            f"a failed discovery must be a visible warning, not silence; got {warnings!r}"
+        )
+        assert any(
+            "diff-tree" in rec.message.lower() or "discover" in rec.message.lower()
+            for rec in caplog.records
+        ), "a failed diff-tree discovery must also be logged, not just swallowed"
 
 
 # =============================================================================

--- a/tests/test_verify_file_selection.py
+++ b/tests/test_verify_file_selection.py
@@ -124,6 +124,34 @@ def test_the_default_invocation_still_reviews_real_source(redteam_repo):
     assert "src/app.py" in prompt
 
 
+def test_denylist_summary_includes_dir_prefix_rules():
+    """#584: `denylist_summary()` (backs `llm-council ignore --print-defaults`,
+    a security-transparency feature) lists secret basenames/suffixes/prefixes
+    /directories but omits `_SECRET_DIR_PREFIXES` (compound rules like
+    `.config/gcloud/**`) entirely — a user auditing "what's denied" would not
+    see that this path is blocked."""
+    summary = file_ops.denylist_summary()
+    joined = "\n".join(summary)
+    for lead, sub in file_ops._SECRET_DIR_PREFIXES:
+        assert lead in joined and sub in joined, (
+            f"denylist_summary() does not mention the {lead}/{sub} compound rule"
+        )
+
+
+def test_empty_target_paths_list_fetches_zero_files(redteam_repo):
+    """#584: `target_paths=[]` (explicitly "review nothing") is a non-empty-looking
+    falsy value in Python. A bare `if target_paths:` treats it the same as `None`
+    and falls through to the diff-tree "no target_paths given" branch, silently
+    fetching every changed file instead of the zero files the caller asked for.
+    """
+    _repo, sha = redteam_repo
+    content, meta = asyncio.run(
+        file_ops._fetch_files_for_verification_async_with_metadata(sha, [])
+    )
+    assert meta["expanded_paths"] == []
+    assert "src/app.py" not in content
+
+
 def test_default_invocation_records_its_omissions(redteam_repo):
     """#543: `expansion_warnings` was empty on this path — omissions were invisible."""
     _repo, sha = redteam_repo

--- a/tests/unit/verification/test_async_file_fetch.py
+++ b/tests/unit/verification/test_async_file_fetch.py
@@ -64,6 +64,22 @@ class TestAsyncFileFetching:
         assert truncated is False
 
     @pytest.mark.asyncio
+    async def test_fetch_file_error_includes_git_stderr(self):
+        """#584: stderr was read on a non-zero return code but then discarded —
+        the returned error message never included git's own explanation, only
+        a generic "could not read" string. The actual git error is far more
+        useful for diagnosing why a fetch failed."""
+        from llm_council.verification.api import _fetch_file_at_commit_async
+
+        content, _truncated = await _fetch_file_at_commit_async(
+            "invalidcommitsha123", "pyproject.toml"
+        )
+
+        assert "invalid object name" in content.lower() or "fatal" in content.lower(), (
+            f"expected git's actual stderr in the error message; got: {content!r}"
+        )
+
+    @pytest.mark.asyncio
     async def test_fetch_file_truncates_large_files(self):
         """Large files should be truncated to MAX_FILE_CHARS via streaming read."""
         from llm_council.verification.api import (
@@ -379,6 +395,25 @@ class TestPathValidation:
         assert _validate_file_path("src/main.py") is True
         assert _validate_file_path("tests/test_file.py") is True
         assert _validate_file_path("README.md") is True
+
+    def test_accepts_filenames_merely_containing_dotdot_substring(self):
+        """#584: a bare `if ".." in file_path` over-rejects legitimate
+        filenames that just happen to contain the substring `..` without
+        it being an actual `..` path COMPONENT — e.g. `version..txt`. Only a
+        genuine `..` traversal component must be rejected, not any file
+        containing the two characters somewhere in its name."""
+        from llm_council.verification.api import _validate_file_path
+
+        assert _validate_file_path("version..txt") is True
+        assert _validate_file_path("docs/my..notes.md") is True
+
+    def test_still_rejects_traversal_disguised_inside_a_longer_path(self):
+        """The segment-based fix must not regress detection of a real `..`
+        component anywhere in the path, not just at the start."""
+        from llm_council.verification.api import _validate_file_path
+
+        assert _validate_file_path("src/../../etc/passwd") is False
+        assert _validate_file_path("a/b/../../../c") is False
 
     @pytest.mark.asyncio
     async def test_fetch_rejects_invalid_paths(self):

--- a/tests/unit/verification/test_git_argv_batching.py
+++ b/tests/unit/verification/test_git_argv_batching.py
@@ -1,0 +1,114 @@
+"""#584: content-mode git calls must not spread an unbounded path list
+directly into a subprocess argv.
+
+`_blob_sizes`, `_text_paths`, and `_reviewability_attrs` (all reached only
+in `LLM_COUNCIL_FILE_SELECTION=content`/`shadow` mode) each spread a
+candidate-path list straight into a single `git` subprocess's argv. A commit
+touching enough files (a large vendoring or initial-import commit) can
+exceed the OS ARG_MAX; the call then fails and every one of those paths is
+silently treated as omitted/binary rather than surfaced as a real error.
+The fix chunks the path list across multiple git calls and merges results.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llm_council.verification import file_ops
+
+
+def _paths(n: int) -> list:
+    return [f"src/file_{i}.py" for i in range(n)]
+
+
+def _argv_paths(call_args) -> list:
+    """Extract the paths passed after the `--` separator in a subprocess call."""
+    args = call_args.args
+    return list(args[args.index("--") + 1 :])
+
+
+class TestBlobSizesChunking:
+    @pytest.mark.asyncio
+    async def test_chunks_across_multiple_git_calls(self, monkeypatch):
+        monkeypatch.setattr(file_ops, "GIT_ARGV_BATCH_SIZE", 5)
+        paths = _paths(12)  # 3 chunks of 5, 5, 2 at batch size 5
+
+        async def fake_exec(*args, **kwargs):
+            chunk = list(args[args.index("--") + 1 :])
+            proc = MagicMock()
+            proc.returncode = 0
+            out = "".join(f"10 {p}\0" for p in chunk).encode()
+            proc.communicate = AsyncMock(return_value=(out, b""))
+            return proc
+
+        with (
+            patch.object(
+                file_ops, "_get_git_root_async", new_callable=AsyncMock, return_value="/mock"
+            ),
+            patch("asyncio.create_subprocess_exec", side_effect=fake_exec) as mock_exec,
+        ):
+            sizes = await file_ops._blob_sizes("HEAD", paths)
+
+        assert mock_exec.call_count >= 3, "a 12-path list at batch size 5 must be chunked"
+        for call in mock_exec.call_args_list:
+            assert len(_argv_paths(call)) <= 5
+        assert set(sizes.keys()) == set(paths), "results from every chunk must be merged"
+        assert all(v == 10 for v in sizes.values())
+
+
+class TestTextPathsChunking:
+    @pytest.mark.asyncio
+    async def test_chunks_across_multiple_git_calls(self, monkeypatch):
+        monkeypatch.setattr(file_ops, "GIT_ARGV_BATCH_SIZE", 5)
+        paths = _paths(12)
+
+        async def fake_exec(*args, **kwargs):
+            chunk = list(args[args.index("--") + 1 :])
+            proc = MagicMock()
+            proc.returncode = 0
+            out = "".join(f"HEAD:{p}\0" for p in chunk).encode()
+            proc.communicate = AsyncMock(return_value=(out, b""))
+            return proc
+
+        with (
+            patch.object(
+                file_ops, "_get_git_root_async", new_callable=AsyncMock, return_value="/mock"
+            ),
+            patch("asyncio.create_subprocess_exec", side_effect=fake_exec) as mock_exec,
+        ):
+            text = await file_ops._text_paths("HEAD", paths)
+
+        assert mock_exec.call_count >= 3
+        for call in mock_exec.call_args_list:
+            assert len(_argv_paths(call)) <= 5
+        assert text == set(paths), "results from every chunk must be merged"
+
+
+class TestReviewabilityAttrsChunking:
+    @pytest.mark.asyncio
+    async def test_chunks_across_multiple_git_calls(self, monkeypatch):
+        monkeypatch.setattr(file_ops, "GIT_ARGV_BATCH_SIZE", 5)
+        paths = _paths(12)
+
+        async def fake_exec(*args, **kwargs):
+            chunk = list(args[args.index("--") + 1 :])
+            proc = MagicMock()
+            proc.returncode = 0
+            # Every path in this chunk is "generated".
+            triples = "".join(f"{p}\0linguist-generated\0set\0" for p in chunk)
+            proc.communicate = AsyncMock(return_value=(triples.encode(), b""))
+            return proc
+
+        with (
+            patch.object(
+                file_ops, "_get_git_root_async", new_callable=AsyncMock, return_value="/mock"
+            ),
+            patch("asyncio.create_subprocess_exec", side_effect=fake_exec) as mock_exec,
+        ):
+            attrs = await file_ops._reviewability_attrs("HEAD", paths)
+
+        assert mock_exec.call_count >= 3
+        for call in mock_exec.call_args_list:
+            assert len(_argv_paths(call)) <= 5
+        assert set(attrs.keys()) == set(paths), "results from every chunk must be merged"
+        assert all(v == "generated" for v in attrs.values())

--- a/tests/unit/verification/test_tier_aware_file_truncation.py
+++ b/tests/unit/verification/test_tier_aware_file_truncation.py
@@ -207,6 +207,47 @@ class TestFetchFilesUsesTierLimit:
         assert captured_limits == [15_000]
 
 
+class TestBatchBudgetDoesNotOvershoot:
+    """#584: the per-batch check ran BEFORE adding a file's content, so a
+    single file up to the full per-file budget could push `total_chars` well
+    past `per_batch_budget` before the *next* file's check caught it —
+    overshooting by up to one whole per-file budget's worth of characters."""
+
+    @pytest.mark.asyncio
+    async def test_second_large_file_is_omitted_not_overshot(self):
+        from llm_council.verification import file_ops as api
+
+        # reasoning tier: per-file and per-batch budget are both 50_000.
+        big = "y" * 40_000
+
+        async def fake_fetch(snapshot_id, file_path, max_file_chars=None):
+            return big, False
+
+        async def fake_expand(snapshot_id, target_paths):
+            return list(target_paths), False, [], []
+
+        with (
+            patch.object(api, "_fetch_file_at_commit_async", side_effect=fake_fetch),
+            patch.object(api, "_expand_target_paths", side_effect=fake_expand),
+            patch.object(
+                api,
+                "_get_git_root_async",
+                new_callable=AsyncMock,
+                return_value="/mock/root",
+            ),
+        ):
+            content, metadata = await api._fetch_files_for_verification_async_with_metadata(
+                "HEAD", ["docs/a.md", "docs/b.md"], tier="reasoning"
+            )
+
+        assert "docs/a.md" in content
+        assert "docs/b.md" not in content, (
+            "a second 40K file must be omitted, not appended past the 50K "
+            "batch budget — including it would overshoot to ~80K chars"
+        )
+        assert "omitted" in content
+
+
 # ---------------------------------------------------------------------------
 # expansion_warnings plumbing
 # ---------------------------------------------------------------------------

--- a/tests/unit/verification/test_tier_aware_file_truncation.py
+++ b/tests/unit/verification/test_tier_aware_file_truncation.py
@@ -247,6 +247,55 @@ class TestBatchBudgetDoesNotOvershoot:
         )
         assert "omitted" in content
 
+    @pytest.mark.asyncio
+    async def test_first_file_is_never_dropped_even_if_its_own_truncation_marker_overshoots(
+        self,
+    ):
+        """A council review of PR #586 caught a regression the overshoot fix
+        above introduced: `_fetch_file_at_commit_async` appends a truncation
+        marker AFTER clamping to the limit (`content[:limit] + "...marker"`),
+        so a truncated file's returned length is slightly ABOVE
+        `per_file_budget`, not equal to it. Since `per_file_budget ==
+        per_batch_budget`, checking `total_chars + len(content) >
+        per_batch_budget` unconditionally — even at `total_chars == 0` —
+        would drop the very first file entirely instead of including it
+        truncated. CLAUDE.md documents "reasoning/high can read a full 50K
+        file" as a guarantee; the first file must always be included."""
+        from llm_council.verification import file_ops as api
+
+        limit = 50_000
+        # Exactly what _fetch_file_at_commit_async returns for a truncated file:
+        # content clamped to `limit`, PLUS a marker that pushes length over it.
+        truncated_content = ("y" * limit) + (
+            f"\n\n... [truncated, original file larger than {limit} chars]"
+        )
+        assert len(truncated_content) > limit, "sanity: marker must push length over the limit"
+
+        async def fake_fetch(snapshot_id, file_path, max_file_chars=None):
+            return truncated_content, True
+
+        async def fake_expand(snapshot_id, target_paths):
+            return list(target_paths), False, [], []
+
+        with (
+            patch.object(api, "_fetch_file_at_commit_async", side_effect=fake_fetch),
+            patch.object(api, "_expand_target_paths", side_effect=fake_expand),
+            patch.object(
+                api,
+                "_get_git_root_async",
+                new_callable=AsyncMock,
+                return_value="/mock/root",
+            ),
+        ):
+            content, metadata = await api._fetch_files_for_verification_async_with_metadata(
+                "HEAD", ["docs/huge.md"], tier="reasoning"
+            )
+
+        assert "docs/huge.md" in content, (
+            "the first file must always be included, even if its own "
+            "truncation marker makes it slightly exceed the batch budget"
+        )
+
 
 # ---------------------------------------------------------------------------
 # expansion_warnings plumbing


### PR DESCRIPTION
Closes #584

## Summary

Council's whole-file `verify()` review of `file_ops.py` during PR #583 surfaced several real, pre-existing bugs unrelated to that PR's diff (which only touched `_fetch_file_at_commit_async`'s `proc.wait()` calls). Filed as #584 and fixed here via TDD:

- **`target_paths=[]` falsy-check bug** (critical): an explicit empty list ("review zero files") was truthiness-tested the same as `None`, falling through to the `git diff-tree` branch and fetching every changed file instead of none.
- **Per-batch char budget overshoot** (critical): the limit check ran *before* adding a file's content, not after, so a single large file could push the batch past budget by up to one whole per-file budget's worth of characters.
- **ARG_MAX exposure in content-mode git calls** (critical): `_blob_sizes`/`_text_paths`/`_reviewability_attrs` spread an unbounded path list directly into subprocess argv; now chunked (`GIT_ARGV_BATCH_SIZE=200`) and merged.
- **Silent fail-open on `git diff-tree` failure** (major): a bare `except Exception: pass` swallowed discovery failures, silently reviewing zero files with no signal. Now logged + surfaced as an `expansion_warnings` entry.
- **Path validation over-rejection** (major): `if ".." in file_path` rejected legitimate filenames merely containing the substring (e.g. `version..txt`); now checks path components via `Path(file_path).parts`, which still catches every real traversal case.
- **stderr discarded on fetch failure** (minor): git's actual error message was read but thrown away in favor of a generic string.
- **Wrong omission reason for unrecognized object types** (minor): a submodule gitlink (`commit` object type) was recorded as `not_found` instead of the more precise `unknown_object`.
- **`denylist_summary()` incompleteness** (minor): omitted the `_SECRET_DIR_PREFIXES` compound rules (e.g. `.config/gcloud/**`) from its user-facing "what's denied" output.

Deliberately NOT fixed (documented, low value / likely non-issue): Windows drive-letter path validation (git's own path resolution doesn't interpret `C:\...` as a filesystem escape in this context) and module-level `asyncio.Lock()` construction (Python 3.10+ lazily binds asyncio primitives to the running loop at first use, not at construction — this project runs 3.11+).

## Test plan

- [x] Each fix has a dedicated regression test, confirmed red against the pre-fix code, green after
- [x] Full `make test-fast` — 3587 passed, 1 skipped, 2 deselected (11 new tests, zero regressions)
- [x] `make lint` — clean