### PR TITLE
feat(verify): persist shadow-mode selection deltas to .council/selection/decisions.jsonl

### DIFF
--- a/src/llm_council/verification/file_ops.py
+++ b/src/llm_council/verification/file_ops.py
@@ -4,8 +4,10 @@ Verbatim move — no logic changes. Back-compat re-exports live in api.py.
 """
 
 import asyncio
+import json
 import logging
 import os
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -776,10 +778,46 @@ async def select_blobs(
                     "LLM_COUNCIL_FILE_SELECTION=shadow: content would add %s, drop %s",
                     would_add, would_drop,
                 )
+            _log_shadow_decision(
+                snapshot_id, len(survivors), len(selected), would_add, would_drop
+            )
         except Exception:  # shadow telemetry must never break selection
             logger.debug("shadow content classification failed", exc_info=True)
 
     return selected, omitted
+
+
+DEFAULT_SELECTION_DECISIONS_PATH = Path(".council") / "selection" / "decisions.jsonl"
+
+
+def _log_shadow_decision(
+    snapshot_id: str,
+    candidates: int,
+    selected: int,
+    would_add: List[str],
+    would_drop: List[str],
+    path: Optional[Path] = None,
+) -> None:
+    """Append one shadow-mode selection record (#595). Paths only; soft-fail.
+
+    Every shadow run is recorded — empty deltas included — so the #557 flip
+    review can compute a delta *rate*, not just read the deltas.
+    """
+    p = path if path is not None else DEFAULT_SELECTION_DECISIONS_PATH
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "ts": time.time(),
+            "snapshot_id": snapshot_id,
+            "candidates": candidates,
+            "selected": selected,
+            "would_add": would_add,
+            "would_drop": would_drop,
+        }
+        with p.open("a") as fh:
+            fh.write(json.dumps(record) + "\n")
+    except Exception as exc:
+        logger.debug("shadow selection decision log failed (%s)", exc)
 
 
 def _is_text_file(file_path: str) -> bool:

--- a/tests/test_issue552_content_sniffing.py
+++ b/tests/test_issue552_content_sniffing.py
@@ -15,6 +15,7 @@ first and `.envrc` genuinely holds `export SECRET=…`, so it STAYS denied here.
 """
 
 import asyncio
+import json
 import subprocess
 from pathlib import Path
 
@@ -157,6 +158,51 @@ class TestShadowMode:
         # shadow ACTS on allowlist: .zig stays omitted
         selected, omitted = asyncio.run(_select(sha, ["src/main.zig", "app.py"]))
         assert "src/main.zig" not in {b.path for b in selected}
+
+    def test_shadow_run_appends_decision_record(self, sniff_repo, monkeypatch):
+        """#595: the delta must survive as a reviewable record, not just a log line."""
+        monkeypatch.setenv("LLM_COUNCIL_FILE_SELECTION", "shadow")
+        _repo, sha = sniff_repo
+        asyncio.run(_select(sha, ["src/main.zig", "empty.py"]))
+        log = Path(".council") / "selection" / "decisions.jsonl"  # cwd is the repo
+        assert log.exists()
+        rec = json.loads(log.read_text().splitlines()[-1])
+        assert rec["snapshot_id"] == sha
+        assert rec["would_add"] == ["src/main.zig"]
+        assert rec["would_drop"] == []
+        assert rec["candidates"] == 2
+        assert rec["selected"] == 1
+        assert "ts" in rec
+
+    def test_shadow_empty_delta_still_appends(self, sniff_repo, monkeypatch):
+        """Empty deltas are the denominator — the #557 review needs the rate."""
+        monkeypatch.setenv("LLM_COUNCIL_FILE_SELECTION", "shadow")
+        _repo, sha = sniff_repo
+        asyncio.run(_select(sha, ["empty.py"]))
+        log = Path(".council") / "selection" / "decisions.jsonl"
+        rec = json.loads(log.read_text().splitlines()[-1])
+        assert rec["would_add"] == []
+        assert rec["would_drop"] == []
+        assert rec["candidates"] == 1
+        assert rec["selected"] == 1
+
+    def test_shadow_log_failure_never_breaks_selection(self, sniff_repo, monkeypatch, tmp_path):
+        monkeypatch.setenv("LLM_COUNCIL_FILE_SELECTION", "shadow")
+        _repo, sha = sniff_repo
+        blocker = tmp_path / "blocker"
+        blocker.write_text("")  # a FILE where a directory is needed ⇒ mkdir raises
+        monkeypatch.setattr(
+            file_ops, "DEFAULT_SELECTION_DECISIONS_PATH", blocker / "decisions.jsonl"
+        )
+        selected, omitted = asyncio.run(_select(sha, ["src/main.zig", "empty.py"]))
+        assert {b.path for b in selected} == {"empty.py"}
+        assert any(o.path == "src/main.zig" for o in omitted)
+
+    def test_allowlist_mode_writes_no_decision_log(self, sniff_repo, monkeypatch):
+        monkeypatch.delenv("LLM_COUNCIL_FILE_SELECTION", raising=False)
+        _repo, sha = sniff_repo
+        asyncio.run(_select(sha, ["src/main.zig", "empty.py"]))
+        assert not (Path(".council") / "selection" / "decisions.jsonl").exists()
 
 
 class TestModeParsing:


### PR DESCRIPTION
Closes #595.

## Why

The #557 default flips (`LLM_COUNCIL_FILE_SELECTION=content`, coverage-clamp default) are gated on reviewing shadow-mode telemetry — but that telemetry was only a `logger.info` line, and neither the CLI nor the MCP server configures INFO logging. Confirmed empirically (2026-08-20): with `shadow` enabled, the classification runs but leaves **zero reviewable evidence**. The monthly #557 flip routine would eventually ask the maintainer to review telemetry that doesn't exist.

## What

- `_log_shadow_decision()` in `verification/file_ops.py`, called from the shadow branch of `select_blobs`: appends `{ts, snapshot_id, candidates, selected, would_add, would_drop}` to `.council/selection/decisions.jsonl` (mirrors ADR-047's `.council/screening/decisions.jsonl` pattern).
- Every shadow run is recorded, empty deltas included — the flip review needs the delta *rate*, not just the deltas.
- Paths only, never file contents (ADR-050 D3 convention).
- Soft-fail: inside the existing shadow `try/except`, plus its own guard — telemetry can never break selection (test-pinned: unwritable path ⇒ selection unaffected).
- `allowlist` (default) and `content` modes write nothing — byte-identical default preserved (test-pinned).
- Existing log line kept.

## Tests

4 new tests in `tests/test_issue552_content_sniffing.py::TestShadowMode` (record shape, empty-delta denominator, soft-fail, allowlist-writes-nothing). `make test-fast`: 3592 passed. Lint clean; mypy error count unchanged from master (97 baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1sSV9YoaFE8F35vXMUY7S