### PR TITLE
fix(config): support both documented YAML shapes; warn instead of dropping silently

### DIFF
--- a/llm_council.yaml.example
+++ b/llm_council.yaml.example
@@ -35,6 +35,7 @@ evaluation:
     # store_path: data/bias_metrics.jsonl
     # consent_level: LOCAL_ONLY    # OFF|LOCAL_ONLY|ANONYMOUS|ENHANCED|RESEARCH
 
-metrics:
-  enabled: false                   # ADR-030: none | statsd | prometheus
-  # backend: statsd
+observability:
+  metrics:
+    enabled: false                 # ADR-030: none | statsd | prometheus
+    # backend: statsd

--- a/llm_council.yaml.example
+++ b/llm_council.yaml.example
@@ -37,5 +37,5 @@ evaluation:
 
 observability:
   metrics:
-    enabled: false                 # ADR-030: none | statsd | prometheus
-    # backend: statsd
+    enabled: false                 # ADR-030: emit metrics at all
+    # backend: none                # none | statsd | prometheus

--- a/src/llm_council/unified_config.py
+++ b/src/llm_council/unified_config.py
@@ -7,7 +7,22 @@ This module provides a unified configuration system that consolidates settings f
 
 Configuration Priority: YAML > Environment Variables > Defaults
 
-Example YAML configuration (llm_council.yaml):
+Two YAML shapes are supported (#591). Neither is deprecated; they are told
+apart exactly, because UnifiedConfig and CouncilConfig field names are disjoint.
+
+**Flat** — sections at the top level, with ``council:`` holding council fields.
+This is the shape ``llm_council.yaml.example`` ships:
+
+    council:
+      models: [openai/gpt-5.4, anthropic/claude-opus-4.8]
+      chairman: google/gemini-3.1-pro-preview
+    tiers:
+      default: high
+    gateways:
+      default: openrouter
+
+**Envelope** — a single top-level ``council:`` key wrapping the sections. This
+is the shape this repo's own ``llm_council.yaml`` uses:
 
     council:
       tiers:
@@ -25,10 +40,17 @@ Example YAML configuration (llm_council.yaml):
         fallback:
           enabled: true
           chain: [openrouter, requesty, direct]
+
+To set council models under the envelope shape, nest an inner ``council:``
+(``council: {council: {models: [...]}}``).
+
+Unrecognised top-level keys are logged as warnings rather than dropped in
+silence, and raise under ``load_config(..., strict=True)``.
 """
 
 import fnmatch
 import json
+import logging
 import os
 import re
 from contextvars import ContextVar
@@ -40,6 +62,8 @@ import yaml
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, field_validator, model_validator
 
 from .tier_contract import TierContract, create_tier_contract
+
+logger = logging.getLogger(__name__)
 
 
 # =============================================================================
@@ -1071,6 +1095,85 @@ def _merge_dicts(base: Dict, override: Dict) -> Dict:
     return result
 
 
+def _normalize_config_shape(raw_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve a parsed YAML mapping to ``UnifiedConfig`` keyword shape (#591).
+
+    Two shapes exist in the wild, and this repo ships one of each:
+
+    * **envelope** — one top-level ``council:`` key wrapping UnifiedConfig
+      sections, e.g. ``council: {tiers: ..., gateways: ...}``. Documented in
+      this module's docstring and used by this repo's own ``llm_council.yaml``.
+    * **flat** — ``council:`` is a *sibling* of the other sections and holds
+      ``CouncilConfig`` fields, e.g. ``council: {models: ...}`` next to a
+      top-level ``tiers:``. Used by ``llm_council.yaml.example``, the template
+      users are told to copy.
+
+    Previously only the envelope was honoured (``UnifiedConfig(**raw["council"])``),
+    so every flat config was almost entirely discarded: sibling sections were
+    never read, and ``council:``'s own contents were dropped by pydantic
+    ``extra="ignore"`` because ``models``/``chairman`` are not UnifiedConfig
+    fields. No error, no warning — the hardcoded defaults silently applied.
+
+    Detection is exact rather than heuristic: ``UnifiedConfig`` and
+    ``CouncilConfig`` field names are disjoint sets, so the keys under
+    ``council:`` identify the shape unambiguously. Both shapes remain
+    supported — neither is deprecated, since both are documented.
+    """
+    council_section = raw_config.get("council")
+    if not isinstance(council_section, dict) or not council_section:
+        return raw_config
+
+    keys = set(council_section)
+    unified_hits = keys & set(UnifiedConfig.model_fields)
+    council_hits = keys & set(CouncilConfig.model_fields)
+
+    if unified_hits and council_hits:
+        # Genuinely ambiguous: `council:` mixes section names with
+        # CouncilConfig fields. Treat as flat (the documented-template shape)
+        # but say so, because one half will not land where the author expects.
+        logger.warning(
+            "Ambiguous config: the 'council:' section mixes UnifiedConfig "
+            "section names (%s) with CouncilConfig fields (%s). Treating it as "
+            "a CouncilConfig block; move the section names to the top level.",
+            ", ".join(sorted(unified_hits)),
+            ", ".join(sorted(council_hits)),
+        )
+        return raw_config
+
+    if unified_hits:
+        # Envelope shape: unwrap it, as load_config has always done.
+        return council_section
+
+    # Flat shape (or a council block we cannot classify): use as-is.
+    return raw_config
+
+
+def _check_unknown_top_level_keys(config_dict: Dict[str, Any], strict: bool = False) -> None:
+    """Surface top-level config keys that ``UnifiedConfig`` would discard (#591).
+
+    Pydantic's default ``extra="ignore"`` is what turned every shape mismatch
+    and key typo into a silent no-op. This does not change that behaviour
+    (making it ``extra="forbid"`` would be a breaking change for anyone whose
+    config carries an unrecognised section today) — it makes it *audible*, and
+    hard-fails only under ``strict=True``, which already means "raise instead
+    of falling back to defaults".
+
+    Note the check is top-level only; nested unknown keys are still dropped
+    quietly. Deeper validation is deliberately out of scope here.
+    """
+    unknown = sorted(set(config_dict) - set(UnifiedConfig.model_fields))
+    if not unknown:
+        return
+
+    message = (
+        f"Unknown top-level configuration key(s) ignored: {', '.join(unknown)}. "
+        f"Valid sections: {', '.join(sorted(UnifiedConfig.model_fields))}."
+    )
+    if strict:
+        raise ValueError(message)
+    logger.warning(message)
+
+
 def load_config(
     config_path: Optional[Path] = None,
     strict: bool = False,
@@ -1101,11 +1204,13 @@ def load_config(
         # Substitute environment variables
         raw_config = _substitute_env_vars(raw_config)
 
-        # Extract council section
-        council_config = raw_config.get("council", {})
+        # #591: resolve which of the two shipped YAML shapes this is, then
+        # surface anything that would otherwise be dropped in silence.
+        config_dict = _normalize_config_shape(raw_config)
+        _check_unknown_top_level_keys(config_dict, strict=strict)
 
         # Build config from YAML
-        return UnifiedConfig(**council_config)
+        return UnifiedConfig(**config_dict)
 
     except yaml.YAMLError as e:
         if strict:

--- a/src/llm_council/unified_config.py
+++ b/src/llm_council/unified_config.py
@@ -1138,9 +1138,20 @@ def _normalize_config_shape(
     section_keys = {k for k in council_section if k in unified_fields}
 
     if not section_keys:
-        # Flat shape: `council:` holds CouncilConfig fields (or keys we cannot
-        # classify, which _check_unknown_top_level_keys will not see because
-        # they are nested — see that function's note on nested keys).
+        # Flat shape: `council:` holds CouncilConfig fields. Anything in there
+        # that neither model claims still has to be reported — `CouncilConfig`
+        # inherits pydantic's `extra="ignore"`, so it would otherwise be eaten
+        # in silence, and this branch never reaches the top-level key check.
+        unknown_in_council = sorted(set(council_section) - council_fields - unified_fields)
+        if unknown_in_council:
+            message = (
+                "Unknown key(s) under 'council:' ignored: "
+                f"{', '.join(unknown_in_council)}. "
+                f"Valid council fields: {', '.join(sorted(council_fields))}."
+            )
+            if strict:
+                raise ValueError(message)
+            logger.warning(message)
         return raw_config
 
     # `council:` names at least one UnifiedConfig section, so it is an
@@ -1186,10 +1197,13 @@ def _normalize_config_shape(
         else:
             envelope["council"] = council_fields_inside
 
-    overlapping = sorted(set(siblings) & set(envelope))
+    # Any key defined in two places loses one of its values on merge, so say so
+    # — including for unknown keys, which are dropped later but should not also
+    # disappear from the report that names them.
+    overlapping = sorted(set(siblings) & (set(envelope) | set(unknown_inside)))
     if overlapping:
         logger.warning(
-            "Config sections %s appear both at the top level and inside the "
+            "Config key(s) %s appear both at the top level and inside the "
             "'council:' envelope; the 'council:' values win.",
             ", ".join(overlapping),
         )
@@ -1209,8 +1223,11 @@ def _check_unknown_top_level_keys(config_dict: Dict[str, Any], strict: bool = Fa
     hard-fails only under ``strict=True``, which already means "raise instead
     of falling back to defaults".
 
-    Note the check is top-level only; nested unknown keys are still dropped
-    quietly. Deeper validation is deliberately out of scope here.
+    Scope: this checks the top level. ``_normalize_config_shape`` separately
+    reports unknown keys sitting inside a ``council:`` block, so both levels
+    that #591 touches are covered. Unknown keys nested deeper inside other
+    sections are still dropped quietly — full recursive validation is
+    deliberately out of scope.
     """
     unknown = sorted(set(config_dict) - set(UnifiedConfig.model_fields))
     if not unknown:

--- a/src/llm_council/unified_config.py
+++ b/src/llm_council/unified_config.py
@@ -1095,7 +1095,9 @@ def _merge_dicts(base: Dict, override: Dict) -> Dict:
     return result
 
 
-def _normalize_config_shape(raw_config: Dict[str, Any]) -> Dict[str, Any]:
+def _normalize_config_shape(
+    raw_config: Dict[str, Any], strict: bool = False
+) -> Dict[str, Any]:
     """Resolve a parsed YAML mapping to ``UnifiedConfig`` keyword shape (#591).
 
     Two shapes exist in the wild, and this repo ships one of each:
@@ -1116,36 +1118,85 @@ def _normalize_config_shape(raw_config: Dict[str, Any]) -> Dict[str, Any]:
 
     Detection is exact rather than heuristic: ``UnifiedConfig`` and
     ``CouncilConfig`` field names are disjoint sets, so the keys under
-    ``council:`` identify the shape unambiguously. Both shapes remain
-    supported — neither is deprecated, since both are documented.
+    ``council:`` identify the shape unambiguously. That invariant is
+    load-bearing and pinned by
+    ``TestConfigShapeNoSilentLoss::test_unified_and_council_field_names_stay_disjoint``.
+    Both shapes remain supported — neither is deprecated, since both are
+    documented.
+
+    Nothing is ever dropped to make a shape fit. An envelope carrying council
+    fields, or sitting beside top-level siblings, is split and merged rather
+    than truncated; a mixed ``council:`` block warns (and raises under
+    ``strict``) but still applies both halves.
     """
     council_section = raw_config.get("council")
     if not isinstance(council_section, dict) or not council_section:
         return raw_config
 
-    keys = set(council_section)
-    unified_hits = keys & set(UnifiedConfig.model_fields)
-    council_hits = keys & set(CouncilConfig.model_fields)
+    unified_fields = set(UnifiedConfig.model_fields)
+    council_fields = set(CouncilConfig.model_fields)
+    section_keys = {k for k in council_section if k in unified_fields}
 
-    if unified_hits and council_hits:
-        # Genuinely ambiguous: `council:` mixes section names with
-        # CouncilConfig fields. Treat as flat (the documented-template shape)
-        # but say so, because one half will not land where the author expects.
-        logger.warning(
-            "Ambiguous config: the 'council:' section mixes UnifiedConfig "
-            "section names (%s) with CouncilConfig fields (%s). Treating it as "
-            "a CouncilConfig block; move the section names to the top level.",
-            ", ".join(sorted(unified_hits)),
-            ", ".join(sorted(council_hits)),
-        )
+    if not section_keys:
+        # Flat shape: `council:` holds CouncilConfig fields (or keys we cannot
+        # classify, which _check_unknown_top_level_keys will not see because
+        # they are nested — see that function's note on nested keys).
         return raw_config
 
-    if unified_hits:
-        # Envelope shape: unwrap it, as load_config has always done.
-        return council_section
+    # `council:` names at least one UnifiedConfig section, so it is an
+    # envelope. Split rather than unwrap wholesale: an envelope may also carry
+    # CouncilConfig fields, and the file may carry top-level siblings. Dropping
+    # either half is the exact silent-loss failure this function exists to end.
+    #
+    # Classification is three-way, not binary. A key that belongs to neither
+    # model is *unknown*, not a council field — burying it in `council:` would
+    # hand it to CouncilConfig's extra="ignore" and drop it in silence, the very
+    # bug being fixed. Unknown keys are lifted to the top level instead, so
+    # _check_unknown_top_level_keys names them.
+    siblings = {k: v for k, v in raw_config.items() if k != "council"}
+    envelope = {k: v for k, v in council_section.items() if k in unified_fields}
+    council_fields_inside = {
+        k: v for k, v in council_section.items() if k in council_fields
+    }
+    unknown_inside = {
+        k: v
+        for k, v in council_section.items()
+        if k not in unified_fields and k not in council_fields
+    }
 
-    # Flat shape (or a council block we cannot classify): use as-is.
-    return raw_config
+    if council_fields_inside:
+        # Mixed shape. Salvage both halves, but this is malformed enough to be
+        # worth saying out loud — and to hard-fail under strict.
+        message = (
+            "Ambiguous config: the 'council:' section mixes UnifiedConfig "
+            f"section names ({', '.join(sorted(envelope))}) with council "
+            f"fields ({', '.join(sorted(council_fields_inside))}). Both halves "
+            "were applied; move the section names to the top level to remove "
+            "the ambiguity."
+        )
+        if strict:
+            raise ValueError(message)
+        logger.warning(message)
+
+        # Preserve the council half. If the envelope also carried an explicit
+        # inner `council:` block, that one is more specific and wins per key.
+        inner = envelope.get("council")
+        if isinstance(inner, dict):
+            envelope["council"] = {**council_fields_inside, **inner}
+        else:
+            envelope["council"] = council_fields_inside
+
+    overlapping = sorted(set(siblings) & set(envelope))
+    if overlapping:
+        logger.warning(
+            "Config sections %s appear both at the top level and inside the "
+            "'council:' envelope; the 'council:' values win.",
+            ", ".join(overlapping),
+        )
+
+    # Envelope wins on conflict: it is the more deeply-qualified location.
+    # Unknown keys ride along at the top level so they get reported, not buried.
+    return {**siblings, **unknown_inside, **envelope}
 
 
 def _check_unknown_top_level_keys(config_dict: Dict[str, Any], strict: bool = False) -> None:
@@ -1206,7 +1257,7 @@ def load_config(
 
         # #591: resolve which of the two shipped YAML shapes this is, then
         # surface anything that would otherwise be dropped in silence.
-        config_dict = _normalize_config_shape(raw_config)
+        config_dict = _normalize_config_shape(raw_config, strict=strict)
         _check_unknown_top_level_keys(config_dict, strict=strict)
 
         # Build config from YAML

--- a/tests/test_unified_config.py
+++ b/tests/test_unified_config.py
@@ -2280,3 +2280,54 @@ council:
             "_normalize_config_shape cannot classify a shared key — resolve the "
             "collision or give shape detection an explicit precedence rule."
         )
+
+    def test_unknown_key_inside_flat_council_block_is_reported(self, tmp_path, caplog):
+        """Round-3 council review: the flat branch buried unknown keys.
+
+        `council:` holding only CouncilConfig fields takes an early return, so
+        an unrecognised key beside them never reached the top-level check and
+        was eaten by CouncilConfig's `extra="ignore"` without a word.
+        """
+        config_file = tmp_path / "llm_council.yaml"
+        config_file.write_text("""
+council:
+  models: [my/model-a]
+  typo_key: 1
+""")
+        with caplog.at_level("WARNING"):
+            config = load_config(config_file)
+
+        assert config.council.models == ["my/model-a"]
+        joined = " ".join(r.message for r in caplog.records)
+        assert "typo_key" in joined, (
+            f"unknown key under council: must be reported; got {[r.message for r in caplog.records]!r}"
+        )
+
+    def test_strict_mode_raises_on_unknown_key_inside_flat_council_block(self, tmp_path):
+        """Consistent with every other unknown-key path."""
+        config_file = tmp_path / "llm_council.yaml"
+        config_file.write_text("""
+council:
+  models: [my/model-a]
+  typo_key: 1
+""")
+        with pytest.raises(ValueError, match="typo_key"):
+            load_config(config_file, strict=True)
+
+    def test_key_defined_in_both_places_is_reported(self, tmp_path, caplog):
+        """A key present at top level AND in the envelope loses one value."""
+        config_file = tmp_path / "llm_council.yaml"
+        config_file.write_text("""
+council:
+  tiers:
+    default: balanced
+
+tiers:
+  default: quick
+""")
+        with caplog.at_level("WARNING"):
+            config = load_config(config_file)
+
+        assert config.tiers.default == "balanced", "envelope should win"
+        joined = " ".join(r.message for r in caplog.records)
+        assert "tiers" in joined, "a value silently discarded by merge must be reported"

--- a/tests/test_unified_config.py
+++ b/tests/test_unified_config.py
@@ -2049,3 +2049,143 @@ class TestTierPoolsConfig:
 
         for tier in ["quick", "balanced", "high", "reasoning"]:
             assert tier in pools or hasattr(pools, tier)
+
+
+class TestConfigShapeCompatibility:
+    """#591: `load_config()` silently discarded most real-world configs.
+
+    Two YAML shapes exist in the wild, and both are shipped by this repo:
+
+    * **envelope** — a single top-level ``council:`` key wrapping UnifiedConfig
+      sections (``council: {tiers: ..., gateways: ...}``). This is what the
+      module docstring documents and what ``llm_council.yaml`` in this repo
+      uses. It worked, because ``load_config`` unwrapped ``council:`` and
+      splatted its contents as ``UnifiedConfig`` kwargs.
+    * **flat** — ``council:`` is a *sibling* of the other sections and holds
+      ``CouncilConfig`` fields (``council: {models: ...}`` alongside a
+      top-level ``tiers:``). This is what ``llm_council.yaml.example`` — the
+      template users are told to copy — uses, and it was **entirely inert**:
+      every top-level section other than ``council:`` was never read, and
+      ``council:``'s own contents were dropped by pydantic ``extra="ignore"``
+      because ``models``/``chairman`` are not ``UnifiedConfig`` fields.
+
+    Disambiguation is exact, not heuristic: ``UnifiedConfig`` and
+    ``CouncilConfig`` field names are disjoint sets.
+    """
+
+    def test_flat_shape_council_models_are_applied(self, tmp_path):
+        """#591 repro: `council: {models, chairman}` was silently dropped."""
+        config_file = tmp_path / "llm_council.yaml"
+        config_file.write_text("""
+council:
+  models:
+    - my/model-a
+    - my/model-b
+  chairman: my/model-a
+""")
+        config = load_config(config_file)
+        assert config.council.models == ["my/model-a", "my/model-b"]
+        assert config.council.chairman == "my/model-a"
+
+    def test_flat_shape_sibling_sections_are_applied(self, tmp_path):
+        """The `llm_council.yaml.example` shape: `council:` beside `tiers:`.
+
+        Every one of these top-level sections was previously ignored.
+        """
+        config_file = tmp_path / "llm_council.yaml"
+        config_file.write_text("""
+council:
+  synthesis_mode: debate
+  exclude_self_votes: false
+
+tiers:
+  default: quick
+
+gateways:
+  default: requesty
+
+triage:
+  enabled: true
+""")
+        config = load_config(config_file)
+        assert config.council.synthesis_mode == "debate"
+        assert config.council.exclude_self_votes is False
+        assert config.tiers.default == "quick"
+        assert config.gateways.default == "requesty"
+        assert config.triage.enabled is True
+
+    def test_legacy_envelope_shape_still_works(self, tmp_path):
+        """Regression guard: the shape this repo's own llm_council.yaml uses.
+
+        Test-pinned by the pre-existing TestYAMLParsing cases; must not break.
+        """
+        config_file = tmp_path / "llm_council.yaml"
+        config_file.write_text("""
+council:
+  tiers:
+    default: balanced
+  gateways:
+    default: requesty
+""")
+        config = load_config(config_file)
+        assert config.tiers.default == "balanced"
+        assert config.gateways.default == "requesty"
+
+    def test_double_nested_workaround_still_works(self, tmp_path):
+        """The workaround #591's reporter adopted must not silently break.
+
+        `council: {council: {...}, gateways: {...}}` is the envelope shape with
+        an explicit inner CouncilConfig. Fixing the bug must not punish the
+        people who worked around it.
+        """
+        config_file = tmp_path / "llm_council.yaml"
+        config_file.write_text("""
+council:
+  council:
+    models: [my/model-a, my/model-b]
+    chairman: my/model-a
+  gateways:
+    default: openrouter
+""")
+        config = load_config(config_file)
+        assert config.council.models == ["my/model-a", "my/model-b"]
+        assert config.council.chairman == "my/model-a"
+        assert config.gateways.default == "openrouter"
+
+    def test_unknown_top_level_key_is_warned_not_silently_dropped(self, tmp_path, caplog):
+        """#591 root cause: pydantic `extra="ignore"` made every typo silent.
+
+        `metrics:` is not a UnifiedConfig field (the real sections are
+        `observability`/`telemetry`) — yet it is shipped in
+        llm_council.yaml.example. A user gets zero effect and zero signal.
+        """
+        config_file = tmp_path / "llm_council.yaml"
+        config_file.write_text("""
+tiers:
+  default: quick
+
+metrics:
+  enabled: true
+""")
+        with caplog.at_level("WARNING"):
+            config = load_config(config_file)
+
+        assert config.tiers.default == "quick"
+        joined = " ".join(rec.message for rec in caplog.records).lower()
+        assert "metrics" in joined, (
+            f"unknown top-level config key must be surfaced, not dropped silently; "
+            f"got: {[r.message for r in caplog.records]!r}"
+        )
+
+    def test_strict_mode_raises_on_unknown_top_level_key(self, tmp_path):
+        """`strict=True` already means 'raise instead of falling back'."""
+        config_file = tmp_path / "llm_council.yaml"
+        config_file.write_text("""
+tiers:
+  default: quick
+
+metrics:
+  enabled: true
+""")
+        with pytest.raises(ValueError, match="metrics"):
+            load_config(config_file, strict=True)

--- a/tests/test_unified_config.py
+++ b/tests/test_unified_config.py
@@ -14,6 +14,7 @@ import pytest
 # Will be created
 from llm_council.unified_config import (
     UnifiedConfig,
+    CouncilConfig,
     TierConfig,
     TriageConfig,
     GatewayConfig,
@@ -2189,3 +2190,93 @@ metrics:
 """)
         with pytest.raises(ValueError, match="metrics"):
             load_config(config_file, strict=True)
+
+
+class TestConfigShapeNoSilentLoss:
+    """Council review of PR #605 found the first cut still had drop paths.
+
+    The point of #591 is that config must never vanish in silence. The
+    original `_normalize_config_shape` had two ways it still could:
+
+    * **envelope + siblings** — unwrapping ``council:`` returned *only* that
+      section, discarding any valid top-level sibling section outright.
+    * **mixed keys** — a ``council:`` block holding both section names and
+      CouncilConfig fields was handed back whole, so the section-name half was
+      then dropped by ``CouncilConfig``'s ``extra="ignore"``.
+
+    Both are now split and merged rather than dropped.
+    """
+
+    def test_envelope_with_top_level_siblings_keeps_both(self, tmp_path):
+        """Envelope `council:` beside a top-level section must keep both."""
+        config_file = tmp_path / "llm_council.yaml"
+        config_file.write_text("""
+council:
+  tiers:
+    default: balanced
+
+observability:
+  metrics:
+    enabled: true
+""")
+        config = load_config(config_file)
+        assert config.tiers.default == "balanced", "envelope contents lost"
+        assert config.observability.metrics.enabled is True, "top-level sibling lost"
+
+    def test_mixed_council_block_keeps_both_halves(self, tmp_path):
+        """`council:` holding BOTH a section name and CouncilConfig fields.
+
+        Neither half may be dropped: the section name is lifted to top level,
+        the council fields stay in the council block.
+        """
+        config_file = tmp_path / "llm_council.yaml"
+        config_file.write_text("""
+council:
+  models: [my/model-a, my/model-b]
+  tiers:
+    default: quick
+""")
+        config = load_config(config_file)
+        assert config.council.models == ["my/model-a", "my/model-b"], "council half lost"
+        assert config.tiers.default == "quick", "section half lost"
+
+    def test_mixed_council_block_warns(self, tmp_path, caplog):
+        """The mixed shape is salvaged, but the author should still be told."""
+        config_file = tmp_path / "llm_council.yaml"
+        config_file.write_text("""
+council:
+  models: [my/model-a]
+  tiers:
+    default: quick
+""")
+        with caplog.at_level("WARNING"):
+            load_config(config_file)
+        joined = " ".join(r.message for r in caplog.records).lower()
+        assert "council" in joined and "tiers" in joined
+
+    def test_strict_mode_raises_on_mixed_council_block(self, tmp_path):
+        """`strict=True` means hard-fail on a malformed config, consistently."""
+        config_file = tmp_path / "llm_council.yaml"
+        config_file.write_text("""
+council:
+  models: [my/model-a]
+  tiers:
+    default: quick
+""")
+        with pytest.raises(ValueError, match="(?i)council"):
+            load_config(config_file, strict=True)
+
+    def test_unified_and_council_field_names_stay_disjoint(self):
+        """Load-bearing invariant behind shape detection — pin it explicitly.
+
+        Shape detection classifies the keys under `council:` by which model
+        owns them. If a future field name were added to BOTH models, that key
+        would be genuinely undecidable and detection would silently misroute
+        config. This test is the guard the logic itself cannot provide.
+        """
+        overlap = set(UnifiedConfig.model_fields) & set(CouncilConfig.model_fields)
+        assert overlap == set(), (
+            f"UnifiedConfig and CouncilConfig now share field name(s): {sorted(overlap)}. "
+            "_normalize_config_shape cannot classify a shared key — resolve the "
+            "collision or give shape detection an explicit precedence rule."
+        )


### PR DESCRIPTION
Part of #591 (Bug 1).

## The bug

`load_config()` did `UnifiedConfig(**raw_config["council"])`, so it only ever honoured the **envelope** shape (one top-level `council:` key wrapping UnifiedConfig sections). Any **flat** config — sections at the top level, `council:` holding `CouncilConfig` fields — was almost entirely discarded:

- sibling top-level sections (`tiers:`, `gateways:`, `triage:`, `evaluation:`) were **never read**;
- `council:`'s own contents were dropped by pydantic `extra="ignore"`, because `models`/`chairman` are `CouncilConfig` fields, not `UnifiedConfig` fields.

No error, no warning — the hardcoded defaults silently applied.

## Why it went unnoticed: this repo ships one of each shape

| File | Shape | Status before this PR |
|---|---|---|
| `llm_council.yaml` (repo's own) | envelope | worked |
| `llm_council.yaml.example` (**the template users copy**) | flat | **entirely inert — every setting in it did nothing** |

The existing `TestYAMLParsing` cases all pin the envelope shape, so the suite was green while the shipped template was dead.

## Fix

**Detection is exact, not heuristic.** `UnifiedConfig` and `CouncilConfig` field names are disjoint sets (verified — zero overlap), so the keys under `council:` identify the shape unambiguously.

Both shapes remain supported and **neither is deprecated**, since both are documented (module docstring documents the envelope; the template uses flat). The double-nested workaround #591's reporter adopted (`council: {council: {...}}`) also keeps working — the fix must not punish people who worked around the bug.

## Root cause, not just this instance

`extra="ignore"` is what turned every shape mismatch and key typo into a silent no-op. Unknown top-level keys are now **logged**, and **raise under `strict=True`** (which already means "raise instead of falling back").

`extra="forbid"` was deliberately *not* used — it would hard-break any config carrying an unrecognised section today. The check is top-level only; nested unknown keys are still dropped quietly, which is called out in the docstring as out of scope.

**The new warning immediately found four more dead keys:**
- `metrics:` in `llm_council.yaml.example` — invalid; belongs under `observability:`. **Fixed here**, so the template doesn't warn on first copy.
- `bias_audit:`, `bias_persistence:`, `scoring:` in this repo's own `llm_council.yaml` — silently ignored all along. **Deliberately left alone**: activating them would change this repo's council behaviour and belongs in its own change.

## Not in scope

**#591 Bug 2** (health check reports `_get_council_models()` while a real run resolves `tier_contract.allowed_models`) folds into **#596** — same design flaw as the chairman-liveness gap, and better solved together. #591 stays open for it.

## Test plan

- [x] 6 new tests in `TestConfigShapeCompatibility`, **confirmed red before the fix** (4 failing / 2 passing — the 2 passing are the regression guards for envelope + double-nested workaround, which had to keep working)
- [x] Verified against the real shipped files: `llm_council.yaml` still loads (`tiers.default=high`), `llm_council.yaml.example` now actually applies its settings and loads warning-free
- [x] All config suites: 295 passed
- [x] `make test-fast`: 3598 passed, 1 skipped, 2 deselected
- [x] `make lint`: clean