### PR TITLE
fix(health): report the config a real run uses; add opt-in chairman probe

### DIFF
--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -99,6 +99,7 @@ Verify the council is ready.
 
 **Parameters:**
 
+- `tier` (default `"high"`): report readiness for the tier a real run would use. Mirrors `consult_council`'s resolution, including its fallback to `high` for an unrecognised value.
 - `deep` (default `false`): also probe the configured **chairman** model. Costs one real chairman call. The default probe only checks general API reachability via a cheap lite model, which cannot detect a chairman-specific outage.
 
 **Returns:**

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -97,12 +97,24 @@ Retrieve the persisted transcript for a past verification (by
 
 Verify the council is ready.
 
+**Parameters:**
+
+- `deep` (default `false`): also probe the configured **chairman** model. Costs one real chairman call. The default probe only checks general API reachability via a cheap lite model, which cannot detect a chairman-specific outage.
+
 **Returns:**
 
 - `api_key_configured`: Whether key is set
 - `key_source`: Where key came from
-- `council_size`: Number of models
+- `default_tier`: The tier whose models are reported below
+- `council_size` / `models`: The models a real `consult_council` run would use — resolved from the tier pool, which is what the council actually runs
+- `configured_council_models` / `config_warnings`: Present **only** when the flat `council.models` list disagrees with the resolved tier pool, so the two cannot diverge silently
+- `api_connectivity.probe_scope`: `connectivity_only` for the default probe, with a `caveat` naming what it does not cover
+- `chairman_connectivity`: Present only with `deep=true`
 - `ready`: Whether council is operational
+
+!!! warning "`ready: true` does not mean synthesis will succeed"
+
+    The default probe pings a lite model, so it answers *"is the API reachable"*, not *"will the council complete"*. During a chairman outage those diverge: stage-3 synthesis is a single point of failure, so a healthy API can still yield runs with no verdict. Pass `deep=true` before a high-stakes run to probe the chairman itself.
 
 ## Jury Mode
 

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -342,7 +342,7 @@ async def consult_council(
 
 
 @mcp.tool()
-async def council_health_check(deep: bool = False) -> str:
+async def council_health_check(deep: bool = False, tier: str = "high") -> str:
     """
     Check LLM Council health before expensive operations (ADR-012).
 
@@ -372,16 +372,31 @@ async def council_health_check(deep: bool = False) -> str:
     # import-time COUNCIL_MODELS constant) meant the health check could name a
     # completely different council than the one that runs, with no signal — and
     # being import-time-bound, it also never reflected a config reload.
-    default_tier = "high"
-    try:
-        effective_models = list(create_tier_contract(default_tier).allowed_models)
-    except Exception:  # tier resolution must never break the health check
-        effective_models = list(_get_council_models())
+    # Mirror consult_council's own resolution, including its fallback for an
+    # unrecognised value, so the reported tier is the one that would run.
+    default_tier = tier if tier in TIER_MODEL_POOLS else "high"
+
     configured_models = list(_get_council_models())
     chairman_model = _get_chairman_model()
-
     config_warnings = []
-    if sorted(configured_models) != sorted(effective_models):
+    tier_error = None
+
+    try:
+        effective_models = list(create_tier_contract(default_tier).allowed_models)
+    except Exception as e:
+        # Do NOT silently fall back. consult_council has no such fallback, so
+        # a config that breaks tier resolution breaks a real run — reporting
+        # ready:true here would recreate exactly the misrepresentation this
+        # function was just fixed to avoid (council review of #608).
+        tier_error = f"{type(e).__name__}: {e}"
+        effective_models = []
+        config_warnings.append(
+            f"Tier '{default_tier}' could not be resolved ({tier_error}). "
+            "consult_council resolves the same contract with no fallback, so a "
+            "real run would fail."
+        )
+
+    if tier_error is None and sorted(configured_models) != sorted(effective_models):
         config_warnings.append(
             "council.models and the resolved tier pool disagree: a real "
             f"consult_council run at the '{default_tier}' tier uses "
@@ -436,8 +451,25 @@ async def council_health_check(deep: bool = False) -> str:
             }
 
             if response["status"] == STATUS_OK:
-                checks["ready"] = True
-                checks["message"] = "Council is ready. Use consult_council to ask questions."
+                # Connectivity is necessary but not sufficient: a council with
+                # no resolvable models cannot deliberate however healthy the
+                # API is (council review of #608).
+                if tier_error is not None:
+                    checks["ready"] = False
+                    checks["message"] = (
+                        f"Tier '{default_tier}' could not be resolved ({tier_error}). "
+                        "consult_council would fail on this configuration."
+                    )
+                elif not effective_models:
+                    checks["ready"] = False
+                    checks["message"] = (
+                        f"Tier '{default_tier}' resolved to no models, so the council "
+                        "has nothing to deliberate with. Configure "
+                        f"tiers.pools.{default_tier}.models or council.models."
+                    )
+                else:
+                    checks["ready"] = True
+                    checks["message"] = "Council is ready. Use consult_council to ask questions."
             else:
                 checks["ready"] = False
                 checks["message"] = (
@@ -472,7 +504,7 @@ async def council_health_check(deep: bool = False) -> str:
                     checks["chairman_connectivity"] = {
                         "status": "error",
                         "model": chairman_model,
-                        "error": f"{type(e).__name__}: {e}" or repr(e),
+                        "error": f"{type(e).__name__}: {e}",
                     }
                     checks["ready"] = False
                     checks["message"] = f"Chairman probe failed: {type(e).__name__}: {e}"

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -376,10 +376,29 @@ async def council_health_check(deep: bool = False, tier: str = "high") -> str:
     # unrecognised value, so the reported tier is the one that would run.
     default_tier = tier if tier in TIER_MODEL_POOLS else "high"
 
-    configured_models = list(_get_council_models())
-    chairman_model = _get_chairman_model()
     config_warnings = []
     tier_error = None
+
+    # These lookups can themselves raise on a malformed config. A health check
+    # that throws is strictly worse than one reporting not-ready, so degrade
+    # into the same structured answer rather than propagating.
+    try:
+        configured_models = list(_get_council_models())
+        chairman_model = _get_chairman_model()
+    except Exception as e:
+        config_error = f"{type(e).__name__}: {e}"
+        return json.dumps(
+            {
+                "version": council_version,
+                "ready": False,
+                "message": f"Configuration could not be loaded ({config_error}).",
+                "config_warnings": [
+                    f"Reading council configuration failed ({config_error}); "
+                    "consult_council would fail on this configuration."
+                ],
+            },
+            indent=2,
+        )
 
     try:
         effective_models = list(create_tier_contract(default_tier).allowed_models)
@@ -416,6 +435,9 @@ async def council_health_check(deep: bool = False, tier: str = "high") -> str:
             "quick": "~20-30 seconds (fastest models)",
             "balanced": "~45-60 seconds (most models)",
             "high": f"~60-90 seconds (all {len(effective_models)} models)",
+            # `reasoning` is a tier consult_council accepts; omitting it left a
+            # real option undocumented in the health check's own output.
+            "reasoning": "~3-6 minutes (extended thinking; raise MCP_TIMEOUT)",
         },
     }
 

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -342,12 +342,20 @@ async def consult_council(
 
 
 @mcp.tool()
-async def council_health_check() -> str:
+async def council_health_check(deep: bool = False) -> str:
     """
     Check LLM Council health before expensive operations (ADR-012).
 
-    Returns status of API connectivity, configured models, and estimated response time.
-    Use this to verify the council is working before calling consult_council.
+    Returns status of API connectivity, the models a real run would use, and
+    estimated response time. Use this to verify the council is working before
+    calling consult_council.
+
+    Args:
+        deep: Also probe the configured chairman model (#596). Costs one real
+            chairman call. The default probe only checks general API
+            connectivity via a cheap lite model, which cannot detect a
+            chairman-specific outage — stage 3 is the single point of failure
+            that turns an otherwise-successful run into a verdict-less one.
     """
     from importlib.metadata import version as pkg_version
 
@@ -356,19 +364,49 @@ async def council_health_check() -> str:
     except Exception:
         council_version = "unknown"
 
+    # #591 Bug 2: report what a real run would actually use.
+    #
+    # `consult_council` always builds a TierContract and runs
+    # `tier_contract.allowed_models`; it never consults the flat
+    # `council.models` list. Reporting the flat list (previously via the
+    # import-time COUNCIL_MODELS constant) meant the health check could name a
+    # completely different council than the one that runs, with no signal — and
+    # being import-time-bound, it also never reflected a config reload.
+    default_tier = "high"
+    try:
+        effective_models = list(create_tier_contract(default_tier).allowed_models)
+    except Exception:  # tier resolution must never break the health check
+        effective_models = list(_get_council_models())
+    configured_models = list(_get_council_models())
+    chairman_model = _get_chairman_model()
+
+    config_warnings = []
+    if sorted(configured_models) != sorted(effective_models):
+        config_warnings.append(
+            "council.models and the resolved tier pool disagree: a real "
+            f"consult_council run at the '{default_tier}' tier uses "
+            f"{effective_models}, not {configured_models}. Set "
+            f"tiers.pools.{default_tier}.models to match, or rely on the tier pool."
+        )
+
     checks = {
         "version": council_version,
         "api_key_configured": bool(OPENROUTER_API_KEY),
         "key_source": get_key_source(),  # ADR-013: Show where key came from (not the key itself)
-        "council_size": len(COUNCIL_MODELS),
-        "chairman_model": CHAIRMAN_MODEL,
-        "models": COUNCIL_MODELS,
+        "default_tier": default_tier,
+        "council_size": len(effective_models),
+        "chairman_model": chairman_model,
+        "models": effective_models,
         "estimated_duration": {
             "quick": "~20-30 seconds (fastest models)",
             "balanced": "~45-60 seconds (most models)",
-            "high": f"~60-90 seconds (all {len(COUNCIL_MODELS)} models)",
+            "high": f"~60-90 seconds (all {len(effective_models)} models)",
         },
     }
+
+    if config_warnings:
+        checks["configured_council_models"] = configured_models
+        checks["config_warnings"] = config_warnings
 
     # Quick connectivity test with a fast, cheap model
     if checks["api_key_configured"]:
@@ -385,6 +423,16 @@ async def council_health_check() -> str:
                 "status": response["status"],
                 "latency_ms": latency_ms,
                 "test_model": DEFAULT_HEALTH_CHECK_MODEL,
+                # #596: say what this probe does and does not cover. It pings a
+                # cheap lite model, so it answers "is the API reachable", not
+                # "will the council complete" — during a chairman outage those
+                # diverge, and this reported ready:true for an hour while every
+                # real run failed.
+                "probe_scope": "connectivity_only",
+                "caveat": (
+                    "Probes a lite model only; does not exercise the chairman or "
+                    "the council models. Pass deep=true to probe the chairman."
+                ),
             }
 
             if response["status"] == STATUS_OK:
@@ -395,6 +443,39 @@ async def council_health_check() -> str:
                 checks["message"] = (
                     f"API connectivity issue: {response.get('error', 'Unknown error')}"
                 )
+
+            # #596: opt-in probe of the model that actually performs synthesis.
+            if deep:
+                try:
+                    chair_start = time.time()
+                    chair_response = await query_model_with_status(
+                        chairman_model,
+                        [{"role": "user", "content": "ping"}],
+                        timeout=30.0,
+                    )
+                    chair_latency = int((time.time() - chair_start) * 1000)
+                    checks["chairman_connectivity"] = {
+                        "status": chair_response["status"],
+                        "latency_ms": chair_latency,
+                        "model": chairman_model,
+                    }
+                    if chair_response["status"] != STATUS_OK:
+                        detail = chair_response.get("error") or "no detail returned"
+                        checks["chairman_connectivity"]["error"] = detail
+                        checks["ready"] = False
+                        checks["message"] = (
+                            f"Chairman model {chairman_model} is not answering "
+                            f"({chair_response['status']}: {detail}). Stage-3 synthesis "
+                            "would fail, so the council cannot produce a verdict."
+                        )
+                except Exception as e:
+                    checks["chairman_connectivity"] = {
+                        "status": "error",
+                        "model": chairman_model,
+                        "error": f"{type(e).__name__}: {e}" or repr(e),
+                    }
+                    checks["ready"] = False
+                    checks["message"] = f"Chairman probe failed: {type(e).__name__}: {e}"
 
         except Exception as e:
             checks["api_connectivity"] = {

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -407,3 +407,186 @@ async def test_shared_results_populated_incrementally():
         assert len(result) == 2
         assert len(shared) == 2
         assert result is shared  # They should be the same object
+
+
+class TestHealthCheckReportsEffectiveConfig:
+    """#591 Bug 2 + #596: the health check reported a code path real runs don't take.
+
+    Two independent reports, one root cause — `council_health_check` described
+    a configuration and a connectivity story that a real `consult_council`
+    call does not follow:
+
+    * **#591 Bug 2** — it reported `COUNCIL_MODELS` (the flat `council.models`
+      list, captured at import time), while `consult_council` always builds a
+      `TierContract` and runs `tier_contract.allowed_models`. The two can name
+      completely different models with no signal that they disagree.
+    * **#596** — it pinged a fixed cheap lite model, so it answered "is the API
+      reachable at all", not "will the council complete". During a ~1h chairman
+      outage it reported `ready: true` throughout while every real run failed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reports_models_a_real_run_would_use(self):
+        """The reported models must come from the tier a real run resolves."""
+        from llm_council.mcp_server import council_health_check
+
+        with (
+            patch("llm_council.mcp_server.OPENROUTER_API_KEY", None),
+            patch(
+                "llm_council.mcp_server.create_tier_contract",
+            ) as mk,
+        ):
+            mk.return_value = MagicMock(allowed_models=["tier/one", "tier/two"])
+            data = json.loads(await council_health_check())
+
+        assert data["models"] == ["tier/one", "tier/two"], (
+            "health check must report the tier-resolved models a real "
+            f"consult_council run would use; got {data.get('models')!r}"
+        )
+        assert data["council_size"] == 2
+        assert data["default_tier"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_warns_when_configured_models_diverge_from_effective(self):
+        """The exact #591 Bug 2 symptom: two sources, silently disagreeing."""
+        from llm_council.mcp_server import council_health_check
+
+        with (
+            patch("llm_council.mcp_server.OPENROUTER_API_KEY", None),
+            patch("llm_council.mcp_server._get_council_models", return_value=["cfg/a", "cfg/b"]),
+            patch("llm_council.mcp_server.create_tier_contract") as mk,
+        ):
+            mk.return_value = MagicMock(allowed_models=["tier/x"])
+            data = json.loads(await council_health_check())
+
+        assert data.get("configured_council_models") == ["cfg/a", "cfg/b"]
+        warnings = " ".join(data.get("config_warnings", [])).lower()
+        assert "council.models" in warnings or "tier" in warnings, (
+            f"divergence must be surfaced, not silent; got {data.get('config_warnings')!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_divergence_warning_when_they_agree(self):
+        """No false alarms for the ordinary, correctly-configured case."""
+        from llm_council.mcp_server import council_health_check
+
+        with (
+            patch("llm_council.mcp_server.OPENROUTER_API_KEY", None),
+            patch("llm_council.mcp_server._get_council_models", return_value=["same/a"]),
+            patch("llm_council.mcp_server.create_tier_contract") as mk,
+        ):
+            mk.return_value = MagicMock(allowed_models=["same/a"])
+            data = json.loads(await council_health_check())
+
+        assert not data.get("config_warnings")
+        assert "configured_council_models" not in data
+
+    @pytest.mark.asyncio
+    async def test_models_are_resolved_at_call_time_not_import_time(self):
+        """`COUNCIL_MODELS` was a module-level constant bound at import.
+
+        A config reload therefore never reached the health check output.
+        """
+        from llm_council.mcp_server import council_health_check
+
+        with (
+            patch("llm_council.mcp_server.OPENROUTER_API_KEY", None),
+            patch("llm_council.mcp_server.create_tier_contract") as mk,
+        ):
+            mk.return_value = MagicMock(allowed_models=["first/model"])
+            first = json.loads(await council_health_check())
+            mk.return_value = MagicMock(allowed_models=["second/model"])
+            second = json.loads(await council_health_check())
+
+        assert first["models"] == ["first/model"]
+        assert second["models"] == ["second/model"], (
+            "health check is caching models from import time; a reconfigured "
+            "council is not reflected"
+        )
+
+    @pytest.mark.asyncio
+    async def test_shallow_probe_is_labelled_as_not_covering_the_chairman(self):
+        """#596: `ready` must not imply the chairman is healthy."""
+        from llm_council.mcp_server import council_health_check
+        from llm_council.openrouter import STATUS_OK
+
+        with (
+            patch("llm_council.mcp_server.OPENROUTER_API_KEY", "k"),
+            patch(
+                "llm_council.mcp_server.query_model_with_status",
+                new_callable=AsyncMock,
+                return_value={"status": STATUS_OK, "content": "pong", "latency_ms": 5},
+            ),
+        ):
+            data = json.loads(await council_health_check())
+
+        assert data["api_connectivity"]["probe_scope"] == "connectivity_only"
+        assert "chairman" in data["api_connectivity"]["caveat"].lower()
+
+    @pytest.mark.asyncio
+    async def test_deep_probe_queries_the_configured_chairman(self):
+        """#596: opt-in probe of the model that actually performs synthesis."""
+        from llm_council.mcp_server import council_health_check
+        from llm_council.openrouter import STATUS_OK
+
+        calls = []
+
+        async def fake(model, messages, **kwargs):
+            calls.append(model)
+            return {"status": STATUS_OK, "content": "pong", "latency_ms": 7}
+
+        with (
+            patch("llm_council.mcp_server.OPENROUTER_API_KEY", "k"),
+            patch("llm_council.mcp_server._get_chairman_model", return_value="chair/model"),
+            patch("llm_council.mcp_server.query_model_with_status", side_effect=fake),
+        ):
+            data = json.loads(await council_health_check(deep=True))
+
+        assert "chair/model" in calls, f"deep probe never called the chairman; called {calls}"
+        assert data["chairman_connectivity"]["status"] == STATUS_OK
+        assert data["chairman_connectivity"]["model"] == "chair/model"
+
+    @pytest.mark.asyncio
+    async def test_deep_probe_failure_makes_ready_false(self):
+        """The outage case: lite model fine, chairman broken => NOT ready."""
+        from llm_council.mcp_server import council_health_check
+        from llm_council.openrouter import STATUS_OK, STATUS_ERROR
+
+        async def fake(model, messages, **kwargs):
+            if model == "chair/model":
+                return {"status": STATUS_ERROR, "error": "502 upstream", "latency_ms": 9}
+            return {"status": STATUS_OK, "content": "pong", "latency_ms": 5}
+
+        with (
+            patch("llm_council.mcp_server.OPENROUTER_API_KEY", "k"),
+            patch("llm_council.mcp_server._get_chairman_model", return_value="chair/model"),
+            patch("llm_council.mcp_server.query_model_with_status", side_effect=fake),
+        ):
+            data = json.loads(await council_health_check(deep=True))
+
+        assert data["ready"] is False, (
+            "a failing chairman must not report ready:true — this is the #596 outage"
+        )
+        assert "chairman" in data["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_deep_probe_is_opt_in(self):
+        """Default stays cheap: one lite ping, no chairman call."""
+        from llm_council.mcp_server import council_health_check
+        from llm_council.openrouter import STATUS_OK
+
+        calls = []
+
+        async def fake(model, messages, **kwargs):
+            calls.append(model)
+            return {"status": STATUS_OK, "content": "pong", "latency_ms": 5}
+
+        with (
+            patch("llm_council.mcp_server.OPENROUTER_API_KEY", "k"),
+            patch("llm_council.mcp_server._get_chairman_model", return_value="chair/model"),
+            patch("llm_council.mcp_server.query_model_with_status", side_effect=fake),
+        ):
+            data = json.loads(await council_health_check())
+
+        assert calls == [__import__("llm_council.gateway.base", fromlist=["x"]).DEFAULT_HEALTH_CHECK_MODEL]
+        assert "chairman_connectivity" not in data

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -680,3 +680,32 @@ class TestHealthCheckReportsEffectiveConfig:
 
         assert data["default_tier"] == "high"
         assert mk.call_args.args[0] == "high"
+
+    @pytest.mark.asyncio
+    async def test_config_failure_returns_json_not_a_crash(self):
+        """A health check that raises is worse than one reporting not-ready.
+
+        The config lookups ran before any try/except, so a malformed config
+        made the tool itself throw instead of answering.
+        """
+        from llm_council.mcp_server import council_health_check
+
+        with patch(
+            "llm_council.mcp_server._get_council_models",
+            side_effect=RuntimeError("malformed config"),
+        ):
+            data = json.loads(await council_health_check())
+
+        assert data["ready"] is False
+        assert "malformed config" in json.dumps(data)
+
+    @pytest.mark.asyncio
+    async def test_estimated_duration_covers_every_supported_tier(self):
+        """`reasoning` is a real tier consult_council accepts; it was omitted."""
+        from llm_council.mcp_server import council_health_check
+
+        with patch("llm_council.mcp_server.OPENROUTER_API_KEY", None):
+            data = json.loads(await council_health_check())
+
+        for tier_name in ("quick", "balanced", "high", "reasoning"):
+            assert tier_name in data["estimated_duration"], f"{tier_name} missing"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -590,3 +590,93 @@ class TestHealthCheckReportsEffectiveConfig:
 
         assert calls == [__import__("llm_council.gateway.base", fromlist=["x"]).DEFAULT_HEALTH_CHECK_MODEL]
         assert "chairman_connectivity" not in data
+
+    @pytest.mark.asyncio
+    async def test_tier_resolution_failure_is_not_ready(self):
+        """Council review of #608: the fallback recreated the very bug.
+
+        Wrapping `create_tier_contract` in `except Exception` and quietly
+        falling back to the flat list let the health check report ready:true
+        for a config under which `consult_council` — which has no such
+        fallback — would raise. That is the same 'health check misrepresents
+        reality' failure this PR exists to fix.
+        """
+        from llm_council.mcp_server import council_health_check
+        from llm_council.openrouter import STATUS_OK
+
+        with (
+            patch("llm_council.mcp_server.OPENROUTER_API_KEY", "k"),
+            patch(
+                "llm_council.mcp_server.create_tier_contract",
+                side_effect=ValueError("bad tier pool config"),
+            ),
+            patch(
+                "llm_council.mcp_server.query_model_with_status",
+                new_callable=AsyncMock,
+                return_value={"status": STATUS_OK, "content": "pong", "latency_ms": 5},
+            ),
+        ):
+            data = json.loads(await council_health_check())
+
+        assert data["ready"] is False, (
+            "tier resolution failed, so a real run would raise — must not report ready"
+        )
+        joined = (data["message"] + " ".join(data.get("config_warnings", []))).lower()
+        assert "tier" in joined
+        assert "bad tier pool config" in joined, "the underlying error must be surfaced"
+
+    @pytest.mark.asyncio
+    async def test_empty_effective_pool_is_not_ready(self):
+        """A council of zero models cannot deliberate, however healthy the API."""
+        from llm_council.mcp_server import council_health_check
+        from llm_council.openrouter import STATUS_OK
+
+        with (
+            patch("llm_council.mcp_server.OPENROUTER_API_KEY", "k"),
+            patch("llm_council.mcp_server.create_tier_contract") as mk,
+            patch(
+                "llm_council.mcp_server.query_model_with_status",
+                new_callable=AsyncMock,
+                return_value={"status": STATUS_OK, "content": "pong", "latency_ms": 5},
+            ),
+        ):
+            mk.return_value = MagicMock(allowed_models=[])
+            data = json.loads(await council_health_check())
+
+        assert data["council_size"] == 0
+        assert data["ready"] is False
+        assert "no models" in data["message"].lower() or "empty" in data["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_reports_the_tier_that_was_asked_about(self):
+        """`consult_council` runs whichever tier the caller picks.
+
+        Reporting only 'high' misrepresents readiness for the others.
+        """
+        from llm_council.mcp_server import council_health_check
+
+        with (
+            patch("llm_council.mcp_server.OPENROUTER_API_KEY", None),
+            patch("llm_council.mcp_server.create_tier_contract") as mk,
+        ):
+            mk.return_value = MagicMock(allowed_models=["quick/one"])
+            data = json.loads(await council_health_check(tier="quick"))
+
+        assert data["default_tier"] == "quick"
+        assert data["models"] == ["quick/one"]
+        assert mk.call_args.args[0] == "quick"
+
+    @pytest.mark.asyncio
+    async def test_unknown_tier_falls_back_to_high_like_consult_council(self):
+        """Mirrors consult_council: an unrecognised tier resolves to 'high'."""
+        from llm_council.mcp_server import council_health_check
+
+        with (
+            patch("llm_council.mcp_server.OPENROUTER_API_KEY", None),
+            patch("llm_council.mcp_server.create_tier_contract") as mk,
+        ):
+            mk.return_value = MagicMock(allowed_models=["h/1"])
+            data = json.loads(await council_health_check(tier="nonsense"))
+
+        assert data["default_tier"] == "high"
+        assert mk.call_args.args[0] == "high"


### PR DESCRIPTION
Closes #596. Closes #591 (Bug 2 — Bug 1 shipped in #605).

## One root cause, two independent reports

`council_health_check` described a configuration *and* a connectivity story that a real `consult_council` call does not follow.

### #591 Bug 2 — it reported a model list the council never runs

`consult_council` always builds a `TierContract` and runs `tier_contract.allowed_models`; it never consults the flat `council.models` list. The health check reported the flat list, so the two could name **completely different councils** with no signal.

Now it reports the **tier-resolved** models, names the tier (`default_tier`), and when the two disagree adds `configured_council_models` plus an explicit `config_warnings` entry. When they agree, neither field appears — no false alarms.

**A third problem neither issue mentioned:** `COUNCIL_MODELS` was a module-level constant bound at **import time**, so a config reload never reached the output. Resolution is now at call time, pinned by a test.

### #596 — `ready: true` during a chairman outage

The probe pings a fixed cheap lite model, so it answers *"is the API reachable"*, not *"will the council complete"*. During a ~1h chairman outage it reported `ready: true` throughout while every real run failed.

- The default probe now declares `probe_scope: "connectivity_only"` with a `caveat` naming what it does **not** cover.
- `deep=true` additionally probes the **configured chairman**, setting `ready: false` with a message naming the model when synthesis would fail.

`deep` is opt-in because it costs a real chairman call — the default path still makes exactly one lite call (test-pinned).

## Verified against a simulation of the actual outage

Lite model healthy at 2.9s, chairman erroring:

```
shallow -> ready: True   (now labelled probe_scope=connectivity_only)
deep    -> ready: False
           "Chairman model google/gemini-3.1-pro-preview is not answering
            (error: no detail returned). Stage-3 synthesis would fail, so the
            council cannot produce a verdict."
```

Note `no detail returned` — that is **#594** (chairman errors whose `str(e)` is empty) showing through. This PR handles it defensively with an `or` fallback so the message is never a bare `(error: )`; #594 remains the fix at source.

## Test plan

- [x] 8 new tests in `TestHealthCheckReportsEffectiveConfig`, confirmed red first (6 failing / 2 correctly passing)
- [x] Covers: tier-resolved reporting, divergence warning, **no** warning when they agree, call-time (not import-time) resolution, shallow-probe scope labelling, deep probe calling the chairman, deep failure ⇒ `ready: false`, deep is opt-in
- [x] Full MCP suite: 23 passed, no regressions
- [x] `make test-fast`: 3631 passed, 1 skipped, 2 deselected
- [x] `make lint`: clean
- [x] `docs/guides/mcp.md` updated, including an explicit warning that `ready: true` does not mean synthesis will succeed