### PR TITLE
fix(openrouter): never surface an empty chairman error detail

### DIFF
--- a/src/llm_council/council_stages.py
+++ b/src/llm_council/council_stages.py
@@ -1113,7 +1113,13 @@ STAGE 2 - Peer Rankings:
         # Fallback if chairman fails — SURFACE the status + underlying error
         # so operators can tell an infra outage apart from a code defect.
         error_status = status_response.get("status", "error")
-        error_detail = status_response.get("error", "no detail returned")
+        # #594: `.get(key, default)` does NOT fire its default for a
+        # present-but-empty value, so an upstream `"error": ""` rendered as
+        # "(error: )" for a whole outage. `or` covers empty/None regardless of
+        # which producer supplied the response — query_model_with_status is
+        # fixed at source, but the gateway adapter and any future router are
+        # separate producers of this same shape.
+        error_detail = status_response.get("error") or "no detail returned"
         logger.warning(
             "stage-3 chairman synthesis failed: %s — %s (model=%s, latency=%sms)",
             error_status,

--- a/src/llm_council/gateway/direct.py
+++ b/src/llm_council/gateway/direct.py
@@ -287,7 +287,11 @@ class DirectGateway(BaseRouter):
             return {
                 "status": "error",
                 "latency_ms": latency_ms,
-                "error": str(e),
+                # #594: `str(e)` is "" for a message-less exception, and this
+                # dict shares the status/error contract that rendered
+                # "(error: )" to operators for a whole outage. Name the type so
+                # the detail is non-empty by construction.
+                "error": f"{type(e).__name__}: {e}" if str(e) else type(e).__name__,
             }
 
     async def _query_openai(

--- a/src/llm_council/gateway/openrouter.py
+++ b/src/llm_council/gateway/openrouter.py
@@ -392,7 +392,11 @@ class OpenRouterGateway(BaseRouter):
             return {
                 "status": "error",
                 "latency_ms": latency_ms,
-                "error": str(e),
+                # #594: `str(e)` is "" for a message-less exception, and this
+                # dict shares the status/error contract that rendered
+                # "(error: )" to operators for a whole outage. Name the type so
+                # the detail is non-empty by construction.
+                "error": f"{type(e).__name__}: {e}" if str(e) else type(e).__name__,
             }
 
     async def complete(self, request: GatewayRequest) -> GatewayResponse:

--- a/src/llm_council/gateway/requesty.py
+++ b/src/llm_council/gateway/requesty.py
@@ -279,7 +279,11 @@ class RequestyGateway(BaseRouter):
             return {
                 "status": "error",
                 "latency_ms": latency_ms,
-                "error": str(e),
+                # #594: `str(e)` is "" for a message-less exception, and this
+                # dict shares the status/error contract that rendered
+                # "(error: )" to operators for a whole outage. Name the type so
+                # the detail is non-empty by construction.
+                "error": f"{type(e).__name__}: {e}" if str(e) else type(e).__name__,
             }
 
     async def complete(self, request: GatewayRequest) -> GatewayResponse:

--- a/src/llm_council/openrouter.py
+++ b/src/llm_council/openrouter.py
@@ -5,6 +5,7 @@ ADR-026 Phase 2: Added reasoning_params support for reasoning models.
 
 import httpx
 import asyncio
+import logging
 import time
 from typing import TYPE_CHECKING, List, Dict, Any, Optional, Callable, Awaitable
 
@@ -12,6 +13,8 @@ from typing import TYPE_CHECKING, List, Dict, Any, Optional, Callable, Awaitable
 from llm_council.unified_config import get_api_key
 
 from llm_council.gateway.resolver import resolve_endpoint, resolve_model_name
+
+logger = logging.getLogger(__name__)
 
 # Default OpenRouter API URL (can be overridden via gateways config)
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
@@ -240,11 +243,20 @@ async def query_model_with_status(
 
     except Exception as e:
         latency_ms = int((time.time() - start_time) * 1000)
-        print(f"Error querying model {model}: {e}")
+        # #594: `str(e)` is "" for any exception constructed without a message
+        # (e.g. a bare IndexError from an unexpected response shape), and that
+        # empty string travelled all the way to the operator as
+        # "Unable to generate final synthesis (error: )" during the 2026-07-16
+        # chairman outage — undiagnosable. Always name the type, so the detail
+        # is non-empty by construction. This is the same goal as #397 (don't
+        # collapse failures to None) and #403 (distinguish infra from defect);
+        # an empty detail defeats both.
+        detail = f"{type(e).__name__}: {e}" if str(e) else type(e).__name__
+        logger.warning("Error querying model %s: %s", model, detail)
         return {
             "status": STATUS_ERROR,
             "latency_ms": latency_ms,
-            "error": str(e),
+            "error": detail,
         }
 
 

--- a/tests/test_stage3_error_surfacing.py
+++ b/tests/test_stage3_error_surfacing.py
@@ -86,3 +86,101 @@ async def test_success_path_unchanged(monkeypatch):
     assert result["response"] == "SYNTHESIS: all good"
     assert "error_status" not in result
     assert usage["prompt_tokens"] == 10
+
+
+class TestErrorDetailIsNeverEmpty:
+    """#594: the detail was surfaced correctly but arrived empty.
+
+    Observed live on 2026-07-16 during a chairman outage. stage3.json held:
+
+        "response": "Error: Unable to generate final synthesis (error: )",
+        "error_status": "error",
+        "error_detail": ""
+
+    7 seconds, zero tokens — a provider-boundary error, not a slow generation.
+    `council_stages` does the right thing (`status_response.get("error",
+    "no detail returned")`), but the default never fires because the value is
+    present-and-empty rather than missing. The empty string is produced
+    upstream: `query_model_with_status`'s generic handler returns `str(e)`,
+    which is `""` for any exception constructed without a message.
+
+    #397 added the status-preserving variant so a billing outage could be told
+    from a dead model; #403 added `unclear_reason=infra_failure` for the same
+    goal. An empty detail defeats both.
+    """
+
+    @pytest.mark.asyncio
+    async def test_message_less_exception_still_yields_a_detail(self):
+        """`str(IndexError())` is `""` — the exact shape that shipped empty."""
+        import httpx
+        from unittest.mock import patch
+        from llm_council.openrouter import query_model_with_status, STATUS_ERROR
+
+        with (
+            patch("llm_council.openrouter._get_openrouter_api_key", return_value="k"),
+            patch.object(
+                httpx.AsyncClient, "post", side_effect=IndexError()
+            ),
+        ):
+            result = await query_model_with_status("m/a", [{"role": "user", "content": "q"}])
+
+        assert result["status"] == STATUS_ERROR
+        detail = result.get("error", "")
+        assert detail, "error detail is empty — the #594 bug"
+        assert "IndexError" in detail, (
+            f"detail must name the exception type to be diagnosable; got {detail!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_exception_with_message_keeps_its_message(self):
+        """The common case must not regress into type-only output."""
+        import httpx
+        from unittest.mock import patch
+        from llm_council.openrouter import query_model_with_status
+
+        with (
+            patch("llm_council.openrouter._get_openrouter_api_key", return_value="k"),
+            patch.object(
+                httpx.AsyncClient, "post", side_effect=RuntimeError("upstream 502")
+            ),
+        ):
+            result = await query_model_with_status("m/a", [{"role": "user", "content": "q"}])
+
+        assert "upstream 502" in result["error"]
+        assert "RuntimeError" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_failure_is_logged_not_printed(self, caplog):
+        """A bare `print` in a library call path is unroutable and untestable."""
+        import httpx
+        from unittest.mock import patch
+        from llm_council.openrouter import query_model_with_status
+
+        with (
+            patch("llm_council.openrouter._get_openrouter_api_key", return_value="k"),
+            patch.object(
+                httpx.AsyncClient, "post", side_effect=RuntimeError("upstream 502")
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            await query_model_with_status("m/a", [{"role": "user", "content": "q"}])
+
+        logged = " ".join(r.message for r in caplog.records)
+        assert "upstream 502" in logged, f"failure not logged; records={caplog.records!r}"
+
+    @pytest.mark.asyncio
+    async def test_stage3_never_renders_empty_parentheses(self, monkeypatch):
+        """End-to-end: the operator-facing string the outage actually showed."""
+        async def message_less_failure(model, messages, disable_tools=False, timeout=120.0, **kw):
+            # What the pre-fix openrouter handler returned for `IndexError()`.
+            return {"status": "error", "error": "", "latency_ms": 6944}
+
+        monkeypatch.setattr(council_mod, "query_model_with_status", message_less_failure)
+        result, _usage, _ = await council_mod.stage3_synthesize_final(
+            "q", _stage1(), _stage2(), _agg()
+        )
+
+        assert "(error: )" not in result["response"], (
+            f"empty parens are the #594 symptom; got {result['response']!r}"
+        )
+        assert result["error_detail"], "error_detail must never be empty"

--- a/tests/test_stage3_error_surfacing.py
+++ b/tests/test_stage3_error_surfacing.py
@@ -98,11 +98,13 @@ class TestErrorDetailIsNeverEmpty:
         "error_detail": ""
 
     7 seconds, zero tokens — a provider-boundary error, not a slow generation.
-    `council_stages` does the right thing (`status_response.get("error",
-    "no detail returned")`), but the default never fires because the value is
-    present-and-empty rather than missing. The empty string is produced
-    upstream: `query_model_with_status`'s generic handler returns `str(e)`,
-    which is `""` for any exception constructed without a message.
+    Two independent causes. Upstream, `query_model_with_status`'s generic
+    handler returned `str(e)`, which is `""` for any exception constructed
+    without a message. Downstream, `council_stages` read
+    `status_response.get("error", "no detail returned")` — whose default does
+    NOT fire for a present-but-empty value, so the empty string passed
+    straight through. Both are fixed: the source names the exception type, and
+    the consumer uses `or` so it holds for any producer of this shape.
 
     #397 added the status-preserving variant so a billing outage could be told
     from a dead model; #403 added `unclear_reason=infra_failure` for the same
@@ -150,8 +152,13 @@ class TestErrorDetailIsNeverEmpty:
         assert "RuntimeError" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_failure_is_logged_not_printed(self, caplog):
-        """A bare `print` in a library call path is unroutable and untestable."""
+    async def test_failure_is_logged_not_printed(self, caplog, capsys):
+        """A bare `print` in a library call path is unroutable and untestable.
+
+        Asserts both halves of its own name: the failure reaches logging, AND
+        nothing is written to stdout. Checking only the first half would let
+        the `print` survive alongside the logger (council review of #610).
+        """
         import httpx
         from unittest.mock import patch
         from llm_council.openrouter import query_model_with_status
@@ -167,6 +174,7 @@ class TestErrorDetailIsNeverEmpty:
 
         logged = " ".join(r.message for r in caplog.records)
         assert "upstream 502" in logged, f"failure not logged; records={caplog.records!r}"
+        assert capsys.readouterr().out == "", "library call path must not print to stdout"
 
     @pytest.mark.asyncio
     async def test_stage3_never_renders_empty_parentheses(self, monkeypatch):


### PR DESCRIPTION
Closes #594.

## The symptom you could actually see

During the 2026-07-16 chairman outage, `stage3.json` held:

```json
"response": "Error: Unable to generate final synthesis (error: )",
"error_status": "error",
"error_detail": ""
```

7 seconds, **zero tokens** — a provider-boundary error, not a slow generation — and no way to tell which. Those empty parentheses *are* the bug.

## Two independent causes, both fixed

**Source** — `query_model_with_status`'s generic handler returned `str(e)`, which is `""` for any exception constructed without a message (a bare `IndexError` from an unexpected response shape, say). It now names the exception type, so the detail is non-empty by construction. Also replaces a bare `print()` — unroutable and untestable in a library call path — with `logger.warning`.

**Consumer** — `council_stages` read `status_response.get("error", "no detail returned")`. `.get`'s default **does not fire for a present-but-empty value**, so the empty string passed straight through. Now uses `or`.

Fixed at both ends deliberately: `query_model_with_status` is not the only producer of this shape.

## Before / after

```
IndexError()                  ->  (error: )                            ->  (error: IndexError)
KeyError()                    ->  (error: )                            ->  (error: KeyError)
RuntimeError('upstream 502')  ->  (error: upstream 502)                ->  (error: RuntimeError: upstream 502)
```

## Sibling instances

Applied the same source fix to `gateway/openrouter.py`, `gateway/requesty.py`, `gateway/direct.py` — they return the **identical** `status`/`latency_ms`/`error` dict consumed by the same code, so they'd reproduce #594 the moment the gateway layer becomes reachable (#524).

Checked and **not** changed:
- `verification/api.py:1255` — already carries `type(e).__name__` separately; unaffected.
- `council.py`, `mcp_server.py`, `webhooks/`, `metadata/registry.py` — same `str(e)` idiom but different contexts and consumers; they belong to the **#603** sweep rather than being swept up here.

## Why it matters beyond one string

#397 added the status-preserving variant so a billing outage could be told from a dead model. #403 added `unclear_reason=infra_failure` for the same goal. **An empty detail defeated both** — you could see *that* synthesis failed, never *why*.

## Test plan

- [x] 4 new tests in `TestErrorDetailIsNeverEmpty`, confirmed red first
- [x] Covers: message-less exception yields a type-bearing detail; an exception *with* a message keeps it (no regression to type-only); failure is logged rather than printed; and an **end-to-end** test asserting stage 3 never renders `(error: )` — that one mocks the response directly, so it pins the consumer independently of the source fix
- [x] Gateway router suites: 39 passed
- [x] `make test-fast`: 3641 passed, 1 skipped, 2 deselected
- [x] `make lint`: clean