### PR TITLE
fix(bias): record display position, not the reviewer's ranking index

### DIFF
--- a/src/llm_council/bias_aggregation.py
+++ b/src/llm_council/bias_aggregation.py
@@ -677,6 +677,12 @@ def generate_bias_report_csv(
     # Header
     writer.writerow(
         [
+            # #611: `position` means the reviewer's ranking index below
+            # schema 1.2.0 and the display index at/above it. The export is
+            # raw data rather than an analysis, so rows are NOT dropped —
+            # instead the schema travels with them, so a downstream analyst
+            # can separate the two semantics instead of averaging them.
+            "schema_version",
             "session_id",
             "timestamp",
             "reviewer_id",
@@ -692,6 +698,7 @@ def generate_bias_report_csv(
     for r in records:
         writer.writerow(
             [
+                r.schema_version,
                 r.session_id,
                 r.timestamp,
                 r.reviewer_id,

--- a/src/llm_council/bias_aggregation.py
+++ b/src/llm_council/bias_aggregation.py
@@ -400,8 +400,16 @@ def aggregate_position_bias(
         PositionBiasReport or None if insufficient position variation
     """
     # Group scores by position
+    #
+    # #611: `position` held the reviewer's RANKING index before schema 1.2.0.
+    # Pooling those with display indices would average two different
+    # quantities under one name, so older records are skipped here. They stay
+    # valid for the length/score and reviewer-calibration analyses, which is
+    # why this is gated per-consumer rather than at the read layer.
     position_scores: Dict[int, List[float]] = {}
     for r in records:
+        if not getattr(r, "position_is_display_order", False):
+            continue
         pos = r.position
         if pos not in position_scores:
             position_scores[pos] = []

--- a/src/llm_council/bias_amplification.py
+++ b/src/llm_council/bias_amplification.py
@@ -55,12 +55,32 @@ def _pearson(x: List[float], y: List[float]) -> float:
     return sxy / (sxx * syy) ** 0.5
 
 
+# #611: `position` meant the reviewer's RANKING index before schema 1.2.0 and
+# the DISPLAY index from 1.2.0 onward. Position analysis over a mixed store
+# would silently average two different quantities, so older records are
+# excluded rather than reinterpreted.
+POSITION_IS_DISPLAY_ORDER_SINCE = (1, 2, 0)
+
+
+def _position_is_display_order(schema_version: str) -> bool:
+    """True if this record's `position` field means display order (#611)."""
+    try:
+        parts = tuple(int(x) for x in str(schema_version).split(".")[:3])
+    except (TypeError, ValueError):
+        return False
+    return parts >= POSITION_IS_DISPLAY_ORDER_SINCE
+
+
 def session_agreement_decomposition(
     records: List[BiasMetricRecord],
 ) -> List[SessionDecomposition]:
     """Decompose reviewer agreement per session. Pure; report-only."""
     by_session: Dict[str, List[BiasMetricRecord]] = {}
     for r in records:
+        # #611: skip records whose `position` is a ranking index, not display
+        # order. Bumping the schema version only helps if a reader acts on it.
+        if not _position_is_display_order(r.schema_version):
+            continue
         by_session.setdefault(r.session_id, []).append(r)
 
     out: List[SessionDecomposition] = []

--- a/src/llm_council/bias_amplification.py
+++ b/src/llm_council/bias_amplification.py
@@ -65,10 +65,12 @@ POSITION_IS_DISPLAY_ORDER_SINCE = (1, 2, 0)
 def _position_is_display_order(schema_version: str) -> bool:
     """True if this record's `position` field means display order (#611)."""
     try:
-        parts = tuple(int(x) for x in str(schema_version).split(".")[:3])
+        components = [int(x) for x in str(schema_version).split(".")[:3]]
     except (TypeError, ValueError):
         return False
-    return parts >= POSITION_IS_DISPLAY_ORDER_SINCE
+    # "1.2" must parse as (1, 2, 0); an unpadded (1, 2) compares LESS.
+    components += [0] * (3 - len(components))
+    return tuple(components) >= POSITION_IS_DISPLAY_ORDER_SINCE
 
 
 def session_agreement_decomposition(

--- a/src/llm_council/bias_audit.py
+++ b/src/llm_council/bias_audit.py
@@ -221,6 +221,48 @@ def calculate_position_bias(
     return round(pos_variance, 3), detected
 
 
+def derive_label_positions(label_to_model: Optional[Dict[str, Any]]) -> Dict[str, int]:
+    """Derive {label: display position} from a label_to_model mapping.
+
+    Position is a property of the LABEL, not of the model: one model may appear
+    under two labels, shown at two different positions. Keying by model
+    collapses that (#613 review), so this label-keyed form is the primitive and
+    ``derive_position_mapping`` is the model-keyed view built on top of it.
+
+    Supports the enhanced format ({"model": ..., "display_index": N}) and the
+    legacy format ({"Response A": "model"}), falling back to letter order when
+    `display_index` is absent.
+
+    A label whose position cannot be derived is OMITTED rather than guessed —
+    callers must be able to tell "unknown" from a plausible-looking wrong value.
+
+    INVARIANT: labels are assigned in lexicographic order corresponding to
+    presentation order (A=first, B=second). ADR-017.
+    """
+    if not label_to_model:
+        return {}
+
+    import re
+
+    positions: Dict[str, int] = {}
+    for label, value in label_to_model.items():
+        if isinstance(value, dict):
+            if not value.get("model"):
+                continue
+            display_index = value.get("display_index")
+            if display_index is not None:
+                positions[label] = display_index
+                continue
+        elif not value:
+            continue
+
+        match = re.match(r"^[Rr]esponse\s+([A-Za-z])$", label.strip())
+        if match:
+            positions[label] = ord(match.group(1).upper()) - ord("A")
+
+    return positions
+
+
 def derive_position_mapping(label_to_model: Optional[Dict[str, Any]]) -> Dict[str, int]:
     """Derive position mapping from label_to_model mapping.
 

--- a/src/llm_council/bias_persistence.py
+++ b/src/llm_council/bias_persistence.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 # Configuration (loaded from unified_config - ADR-031)
 # =============================================================================
 
+from .bias_audit import derive_position_mapping
 from .unified_config import get_config
 
 
@@ -119,7 +120,7 @@ class BiasMetricRecord:
         query_metadata: Optional metadata about the query
     """
 
-    schema_version: str = "1.1.0"
+    schema_version: str = "1.2.0"
     session_id: str = ""
     timestamp: str = ""
     consent_level: int = 1  # LOCAL_ONLY default
@@ -497,6 +498,9 @@ def create_bias_records_from_session(
             return val.get("model", "")
         return str(val) if val else ""
 
+    # #611: model -> display index, from the same mapping the labels come from.
+    position_by_model = derive_position_mapping(label_to_model)
+
     # Parse all rankings first
     for ranking_result in stage2_results:
         # One record per (reviewer, candidate) pair
@@ -522,8 +526,23 @@ def create_bias_records_from_session(
             # Get the score if available
             score_value = float(scores.get(label, 0.0))
 
-            # Position is 0-indexed index in the processed list
-            position = idx
+            # #611: DISPLAY position, not the reviewer's ranking index.
+            #
+            # This used to be `position = idx`, i.e. the index into
+            # `labels_to_process`, which is the reviewer's OUTPUT RANKING. The
+            # field is documented as "Display position during peer review", and
+            # bias_amplification.position_alignment correlates -position against
+            # consensus score to detect agreement that tracks DISPLAY order.
+            # Fed a ranking index instead, it correlated reviewers' rankings
+            # against a consensus derived from those same rankings — close to a
+            # restatement of agreement_index, and skewed toward false positives
+            # by the -position sign convention.
+            #
+            # derive_position_mapping is reused rather than re-deriving the
+            # label parsing a third time; it already handles the enhanced
+            # (display_index) and legacy (letter-order) formats, and owns the
+            # ADR-017 invariant that labels are assigned in presentation order.
+            position = position_by_model.get(model_id, idx)
 
             # Find usage stats if available
             # Note: We don't have per-candidate response length easily accessible here
@@ -535,7 +554,7 @@ def create_bias_records_from_session(
                     break
 
             record = BiasMetricRecord(
-                schema_version="1.1.0",
+                schema_version="1.2.0",
                 session_id=session_id,
                 timestamp=timestamp,
                 consent_level=consent_level.value

--- a/src/llm_council/bias_persistence.py
+++ b/src/llm_council/bias_persistence.py
@@ -111,7 +111,10 @@ class BiasMetricRecord:
         consent_level: Privacy consent level (0-4)
         reviewer_id: Model that gave the score
         model_id: Model being scored
-        position: Display position during peer review (0-indexed)
+        position: Display position during peer review (0-indexed).
+            NOTE (#611): records at schema_version < 1.2.0 hold the reviewer's
+            RANKING index here instead. Any consumer treating this as display
+            order must gate on `position_is_display_order`.
         response_length_chars: Character count of the response
         score_value: Numeric score given by reviewer
         score_scale: Scale description (e.g., "1-10")
@@ -133,6 +136,22 @@ class BiasMetricRecord:
     council_config_version: str = "0.1.0"
     query_hash: Optional[str] = None
     query_metadata: Optional[Dict[str, Any]] = None
+
+    @property
+    def position_is_display_order(self) -> bool:
+        """True if `position` means display order rather than ranking (#611).
+
+        Exposed on the record so a consumer cannot reasonably use `position`
+        without meeting the question. Filtering at the read layer was
+        considered and rejected: pre-1.2.0 records remain fully valid for
+        score, reviewer and response-length analysis, and dropping them there
+        would discard good data to protect one field.
+        """
+        try:
+            parts = tuple(int(x) for x in str(self.schema_version).split(".")[:3])
+        except (TypeError, ValueError):
+            return False
+        return parts >= (1, 2, 0)
 
     def to_jsonl_line(self) -> str:
         """Serialize to single JSONL line.
@@ -485,9 +504,13 @@ def create_bias_records_from_session(
     position_by_label = derive_label_positions(label_to_model)
 
     # Precomputed once; this was an O(n^2) rescan of stage1_results per ranking.
-    response_length_by_model = {
-        r.get("model", ""): len(r.get("response", "") or "") for r in stage1_results
-    }
+    # First-wins, matching the `break` in the loop this replaced — a dict
+    # comprehension would silently flip it to last-wins for duplicate models.
+    response_length_by_model: Dict[str, int] = {}
+    for _r in stage1_results:
+        response_length_by_model.setdefault(
+            _r.get("model", ""), len(_r.get("response", "") or "")
+        )
 
     # Parse all rankings first
     for ranking_result in stage2_results:
@@ -526,7 +549,7 @@ def create_bias_records_from_session(
             # restatement of agreement_index, and skewed toward false positives
             # by the -position sign convention.
             #
-            # derive_position_mapping is reused rather than re-deriving the
+            # derive_label_positions owns the parsing rather than re-deriving the
             # label parsing a third time; it already handles the enhanced
             # (display_index) and legacy (letter-order) formats, and owns the
             # ADR-017 invariant that labels are assigned in presentation order.

--- a/src/llm_council/bias_persistence.py
+++ b/src/llm_council/bias_persistence.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 # Configuration (loaded from unified_config - ADR-031)
 # =============================================================================
 
-from .bias_audit import derive_position_mapping
+from .bias_audit import derive_label_positions
 from .unified_config import get_config
 
 
@@ -397,25 +397,6 @@ def _get_model_from_label_value(label_value: Any) -> str:
     return str(label_value)
 
 
-def _get_position_from_label(label: str, label_value: Any) -> int:
-    """Extract position from label_to_model entry.
-
-    Uses display_index from enhanced format, or derives from label letter.
-    """
-    if isinstance(label_value, dict) and "display_index" in label_value:
-        return label_value["display_index"]
-
-    # Fall back to deriving from label letter (A=0, B=1, etc.)
-    # Label format: "Response A", "Response B", etc.
-    parts = label.split()
-    if len(parts) >= 2:
-        letter = parts[-1].upper()
-        if letter.isalpha() and len(letter) == 1:
-            return ord(letter) - ord("A")
-
-    return 0
-
-
 def _extract_query_metadata(query: str) -> Dict[str, Any]:
     """Extract metadata from the user query for bias analysis (ADR-018).
 
@@ -498,8 +479,15 @@ def create_bias_records_from_session(
             return val.get("model", "")
         return str(val) if val else ""
 
-    # #611: model -> display index, from the same mapping the labels come from.
-    position_by_model = derive_position_mapping(label_to_model)
+    # #611: LABEL -> display index, from the same mapping the labels come from.
+    # Keyed by label, not model: one model can appear under two labels at two
+    # different positions, and keying by model collapses them (#613 review).
+    position_by_label = derive_label_positions(label_to_model)
+
+    # Precomputed once; this was an O(n^2) rescan of stage1_results per ranking.
+    response_length_by_model = {
+        r.get("model", ""): len(r.get("response", "") or "") for r in stage1_results
+    }
 
     # Parse all rankings first
     for ranking_result in stage2_results:
@@ -542,16 +530,26 @@ def create_bias_records_from_session(
             # label parsing a third time; it already handles the enhanced
             # (display_index) and legacy (letter-order) formats, and owns the
             # ADR-017 invariant that labels are assigned in presentation order.
-            position = position_by_model.get(model_id, idx)
+            # No fallback to `idx`: that IS the ranking index this fix removes,
+            # and reinstating it for unmapped labels would silently restore the
+            # bug for exactly the records we cannot verify (#613 review). A
+            # record whose display position is unknown is dropped instead.
+            if label not in position_by_label:
+                logger.warning(
+                    "No display position derivable for label %r (model %s) in "
+                    "session %s; dropping the bias record rather than recording "
+                    "a ranking index.",
+                    label,
+                    model_id,
+                    session_id,
+                )
+                continue
+            position = position_by_label[label]
 
             # Find usage stats if available
             # Note: We don't have per-candidate response length easily accessible here
             # without looking back at stage1_results, but we can do a quick lookup
-            response_length = 0
-            for r in stage1_results:
-                if r.get("model") == model_id:
-                    response_length = len(r.get("response", ""))
-                    break
+            response_length = response_length_by_model.get(model_id, 0)
 
             record = BiasMetricRecord(
                 schema_version="1.2.0",

--- a/src/llm_council/bias_persistence.py
+++ b/src/llm_council/bias_persistence.py
@@ -148,10 +148,13 @@ class BiasMetricRecord:
         would discard good data to protect one field.
         """
         try:
-            parts = tuple(int(x) for x in str(self.schema_version).split(".")[:3])
+            components = [int(x) for x in str(self.schema_version).split(".")[:3]]
         except (TypeError, ValueError):
             return False
-        return parts >= (1, 2, 0)
+        # Pad: "1.2" must parse as (1, 2, 0), not (1, 2) — the latter compares
+        # LESS than (1, 2, 0) and would wrongly read as pre-fix (#613 review).
+        components += [0] * (3 - len(components))
+        return tuple(components) >= (1, 2, 0)
 
     def to_jsonl_line(self) -> str:
         """Serialize to single JSONL line.

--- a/tests/test_bias_aggregation.py
+++ b/tests/test_bias_aggregation.py
@@ -89,3 +89,57 @@ class TestBiasAggregation:
         # Check for chart elements
         assert "Average Score per Position" in report
         assert "Pos 1" in report
+
+
+class TestLegacyPositionsExcludedFromPositionBias:
+    """#611/#613 round 2: a SECOND position consumer lived here.
+
+    `aggregate_position_bias` groups scores by `position`. Before schema 1.2.0
+    that field held the reviewer's ranking index, so pooling old and new
+    records averages two different quantities under one name.
+
+    Gated per-consumer rather than at the read layer on purpose: pre-1.2.0
+    records stay fully valid for the length/score and reviewer-calibration
+    analyses, and dropping them at read would discard good data to protect
+    one field.
+    """
+
+    def _rec(self, schema, position, score, reviewer="rev/1", model="m/a"):
+        from llm_council.bias_persistence import BiasMetricRecord
+
+        return BiasMetricRecord(
+            schema_version=schema,
+            session_id="s1",
+            reviewer_id=reviewer,
+            model_id=model,
+            position=position,
+            score_value=score,
+            response_length_chars=100,
+        )
+
+    def test_legacy_records_alone_yield_no_position_report(self):
+        from llm_council.bias_aggregation import aggregate_position_bias
+
+        legacy = [
+            self._rec("1.1.0", 0, 9.0),
+            self._rec("1.1.0", 1, 5.0),
+            self._rec("1.1.0", 2, 3.0),
+        ]
+        assert aggregate_position_bias(legacy) is None, (
+            "ranking indices must not be analysed as display positions"
+        )
+
+    def test_current_records_are_analysed(self):
+        from llm_council.bias_aggregation import aggregate_position_bias
+
+        current = [
+            self._rec("1.2.0", 0, 9.0),
+            self._rec("1.2.0", 1, 5.0),
+        ]
+        assert aggregate_position_bias(current) is not None
+
+    def test_record_exposes_the_predicate(self):
+        """Consumers need a discoverable way to ask, not a version string."""
+        assert self._rec("1.2.0", 0, 1.0).position_is_display_order is True
+        assert self._rec("1.1.0", 0, 1.0).position_is_display_order is False
+        assert self._rec("garbage", 0, 1.0).position_is_display_order is False

--- a/tests/test_bias_aggregation.py
+++ b/tests/test_bias_aggregation.py
@@ -143,3 +143,16 @@ class TestLegacyPositionsExcludedFromPositionBias:
         assert self._rec("1.2.0", 0, 1.0).position_is_display_order is True
         assert self._rec("1.1.0", 0, 1.0).position_is_display_order is False
         assert self._rec("garbage", 0, 1.0).position_is_display_order is False
+
+    def test_abbreviated_version_is_not_treated_as_pre_fix(self):
+        """"1.2" parses to (1, 2), which compares LESS than (1, 2, 0)."""
+        assert self._rec("1.2", 0, 1.0).position_is_display_order is True
+        assert self._rec("2", 0, 1.0).position_is_display_order is True
+        assert self._rec("1.1", 0, 1.0).position_is_display_order is False
+
+    def test_csv_export_carries_the_schema_version(self):
+        """The export is raw data; rows are kept, but the semantic travels."""
+        from llm_council.bias_aggregation import generate_bias_report_csv
+        import inspect
+
+        assert "schema_version" in inspect.getsource(generate_bias_report_csv)

--- a/tests/test_bias_amplification.py
+++ b/tests/test_bias_amplification.py
@@ -136,3 +136,68 @@ class TestCouncilRound1:
         # the high agreement must NOT be flagged as positional.
         assert abs(s.position_alignment) < 0.01
         assert s.amplification_suspect is False
+
+
+class TestPositionAlignmentUsesDisplayOrder:
+    """#611: the amplification signal was inverted by the position defect.
+
+    `position_alignment` correlates `-position` against consensus score to
+    detect "agreement that tracks DISPLAY order". While `position` held the
+    reviewer's ranking index instead, a session where reviewers agreed on
+    favouring the LAST-displayed model produced a strongly POSITIVE alignment
+    and flagged `amplification_suspect` — the exact opposite of the truth.
+    """
+
+    def test_agreeing_on_the_last_displayed_model_is_not_a_suspect(self):
+        from llm_council.bias_persistence import (
+            create_bias_records_from_session,
+            ConsentLevel,
+        )
+        from llm_council.bias_amplification import session_agreement_decomposition
+
+        label_to_model = {
+            "Response A": {"model": "m/alpha", "display_index": 0},
+            "Response B": {"model": "m/beta", "display_index": 1},
+            "Response C": {"model": "m/gamma", "display_index": 2},
+        }
+        stage1 = [
+            {"model": "m/alpha", "response": "a"},
+            {"model": "m/beta", "response": "b"},
+            {"model": "m/gamma", "response": "c"},
+        ]
+        # Both reviewers strongly agree — and both favour gamma, shown LAST.
+        # Display order cannot explain this agreement.
+        stage2 = [
+            {
+                "model": f"rev/{i}",
+                "parsed_ranking": {
+                    "ranking": ["Response C", "Response B", "Response A"],
+                    "scores": {
+                        "Response A": 4.0 + i * 0.5,
+                        "Response B": 6.0 + i * 0.5,
+                        "Response C": 9.0 + i * 0.5,
+                    },
+                },
+            }
+            for i in (1, 2)
+        ]
+
+        records = create_bias_records_from_session(
+            session_id="s1",
+            stage1_results=stage1,
+            stage2_results=stage2,
+            label_to_model=label_to_model,
+            consent_level=ConsentLevel.LOCAL_ONLY,
+        )
+        decomposition = session_agreement_decomposition(records)[0]
+
+        assert decomposition.agreement_index > 0.8, "sanity: reviewers do agree here"
+        assert decomposition.position_alignment < 0, (
+            "the favoured model was displayed LAST, so alignment must be "
+            f"negative; got {decomposition.position_alignment} — position is "
+            "probably holding the ranking index again (#611)"
+        )
+        assert decomposition.amplification_suspect is False, (
+            "high agreement that does NOT track display order is not an "
+            "amplification suspect"
+        )

--- a/tests/test_bias_amplification.py
+++ b/tests/test_bias_amplification.py
@@ -201,3 +201,35 @@ class TestPositionAlignmentUsesDisplayOrder:
             "high agreement that does NOT track display order is not an "
             "amplification suspect"
         )
+
+    def test_pre_fix_records_are_excluded_from_position_analysis(self):
+        """#611/#613: records written before the fix hold a different quantity.
+
+        Bumping `schema_version` only helps if a reader acts on it. Pooled
+        cross-session analysis (ADR-018) must not mix ranking indices from
+        1.1.0 records with display indices from 1.2.0 ones under the same
+        field name.
+        """
+        from llm_council.bias_persistence import BiasMetricRecord
+        from llm_council.bias_amplification import session_agreement_decomposition
+
+        def rec(schema, reviewer, model, position, score):
+            return BiasMetricRecord(
+                schema_version=schema,
+                session_id="legacy",
+                reviewer_id=reviewer,
+                model_id=model,
+                position=position,
+                score_value=score,
+            )
+
+        legacy = [
+            rec("1.1.0", "rev/1", "m/a", 0, 9.0),
+            rec("1.1.0", "rev/1", "m/b", 1, 5.0),
+            rec("1.1.0", "rev/2", "m/a", 0, 9.5),
+            rec("1.1.0", "rev/2", "m/b", 1, 4.5),
+        ]
+        assert session_agreement_decomposition(legacy) == [], (
+            "pre-1.2.0 records carry ranking indices under `position` and must "
+            "not be analysed as display order"
+        )

--- a/tests/test_bias_persistence.py
+++ b/tests/test_bias_persistence.py
@@ -23,7 +23,9 @@ class TestBiasMetricRecord:
 
         record = BiasMetricRecord()
 
-        assert record.schema_version == "1.1.0"
+        # 1.2.0 (#611): `position` now means DISPLAY position; records written
+        # at 1.1.0 hold the reviewer's ranking index under the same field name.
+        assert record.schema_version == "1.2.0"
         assert record.session_id == ""
         assert record.timestamp == ""
         assert record.consent_level == 1  # LOCAL_ONLY default
@@ -161,7 +163,7 @@ class TestBiasMetricRecord:
         data = json.loads(line)
 
         assert "schema_version" in data
-        assert data["schema_version"] == "1.1.0"
+        assert data["schema_version"] == "1.2.0"
 
 
 class TestConsentLevel:
@@ -959,3 +961,173 @@ class TestPersistSessionBiasData:
                     )
 
             assert custom_path.exists()
+
+
+class TestPositionIsDisplayPosition:
+    """#611: `position` recorded the reviewer's ranking, not display order.
+
+    `BiasMetricRecord.position` is documented as "Display position during peer
+    review (0-indexed)", but `create_bias_records_from_session` populated it
+    from `enumerate()` over `parsed["ranking"]` — the order the reviewer
+    *ranked* the candidates, not the order they were *shown*.
+
+    That defeats `bias_amplification.position_alignment` (ADR-047 P4), which
+    correlates `-position` against consensus score to detect "agreement that
+    tracks display order". Fed the reviewer's own ranking instead, it
+    correlates rankings against a consensus derived from those same rankings —
+    near-tautological with `agreement_index`, and biased toward false
+    positives by the `-position` sign convention.
+
+    The display index was available in `label_to_model` all along.
+    """
+
+    def _label_to_model(self):
+        # Display order: A=alpha(0), B=beta(1), C=gamma(2)
+        return {
+            "Response A": {"model": "m/alpha", "display_index": 0},
+            "Response B": {"model": "m/beta", "display_index": 1},
+            "Response C": {"model": "m/gamma", "display_index": 2},
+        }
+
+    def _stage1(self):
+        return [
+            {"model": "m/alpha", "response": "a"},
+            {"model": "m/beta", "response": "b"},
+            {"model": "m/gamma", "response": "c"},
+        ]
+
+    def test_position_is_display_index_not_ranking_index(self):
+        """The reviewer ranks in reverse; positions must NOT follow the ranking."""
+        from llm_council.bias_persistence import (
+            create_bias_records_from_session,
+            ConsentLevel,
+        )
+
+        stage2 = [
+            {
+                "model": "rev/1",
+                "parsed_ranking": {
+                    "ranking": ["Response C", "Response B", "Response A"],
+                    "scores": {"Response A": 5.0, "Response B": 7.0, "Response C": 9.0},
+                },
+            }
+        ]
+        records = create_bias_records_from_session(
+            session_id="s1",
+            stage1_results=self._stage1(),
+            stage2_results=stage2,
+            label_to_model=self._label_to_model(),
+            consent_level=ConsentLevel.LOCAL_ONLY,
+        )
+
+        positions = {r.model_id: r.position for r in records}
+        assert positions == {"m/alpha": 0, "m/beta": 1, "m/gamma": 2}, (
+            f"position must be display order, not the reviewer's ranking; got {positions}"
+        )
+
+    def test_two_reviewers_ranking_differently_share_display_positions(self):
+        """Display order is a property of the session, not of a reviewer.
+
+        With one shared shuffle (today's behaviour), every reviewer saw the
+        same order — so their recorded positions must agree, however
+        differently they ranked.
+        """
+        from llm_council.bias_persistence import (
+            create_bias_records_from_session,
+            ConsentLevel,
+        )
+
+        stage2 = [
+            {
+                "model": "rev/1",
+                "parsed_ranking": {
+                    "ranking": ["Response A", "Response B", "Response C"],
+                    "scores": {"Response A": 9.0, "Response B": 7.0, "Response C": 5.0},
+                },
+            },
+            {
+                "model": "rev/2",
+                "parsed_ranking": {
+                    "ranking": ["Response C", "Response A", "Response B"],
+                    "scores": {"Response A": 6.0, "Response B": 4.0, "Response C": 8.0},
+                },
+            },
+        ]
+        records = create_bias_records_from_session(
+            session_id="s1",
+            stage1_results=self._stage1(),
+            stage2_results=stage2,
+            label_to_model=self._label_to_model(),
+            consent_level=ConsentLevel.LOCAL_ONLY,
+        )
+
+        by_reviewer = {}
+        for r in records:
+            by_reviewer.setdefault(r.reviewer_id, {})[r.model_id] = r.position
+
+        assert by_reviewer["rev/1"] == by_reviewer["rev/2"], (
+            "reviewers saw one shared display order, so positions must match; "
+            f"got {by_reviewer}"
+        )
+
+    def test_legacy_label_format_falls_back_to_letter_order(self):
+        """Legacy `{"Response A": "model"}` has no display_index."""
+        from llm_council.bias_persistence import (
+            create_bias_records_from_session,
+            ConsentLevel,
+        )
+
+        stage2 = [
+            {
+                "model": "rev/1",
+                "parsed_ranking": {
+                    "ranking": ["Response C", "Response A", "Response B"],
+                    "scores": {"Response A": 5.0, "Response B": 6.0, "Response C": 7.0},
+                },
+            }
+        ]
+        records = create_bias_records_from_session(
+            session_id="s1",
+            stage1_results=self._stage1(),
+            stage2_results=stage2,
+            label_to_model={
+                "Response A": "m/alpha",
+                "Response B": "m/beta",
+                "Response C": "m/gamma",
+            },
+            consent_level=ConsentLevel.LOCAL_ONLY,
+        )
+
+        positions = {r.model_id: r.position for r in records}
+        assert positions == {"m/alpha": 0, "m/beta": 1, "m/gamma": 2}
+
+    def test_schema_version_distinguishes_corrected_records(self):
+        """Records written before the fix carry a different position semantic.
+
+        Pooled cross-session analyses (ADR-018) would otherwise silently mix
+        two incompatible meanings of the same field.
+        """
+        from llm_council.bias_persistence import (
+            create_bias_records_from_session,
+            ConsentLevel,
+        )
+
+        stage2 = [
+            {
+                "model": "rev/1",
+                "parsed_ranking": {
+                    "ranking": ["Response A"],
+                    "scores": {"Response A": 8.0},
+                },
+            }
+        ]
+        records = create_bias_records_from_session(
+            session_id="s1",
+            stage1_results=self._stage1(),
+            stage2_results=stage2,
+            label_to_model=self._label_to_model(),
+            consent_level=ConsentLevel.LOCAL_ONLY,
+        )
+        assert records[0].schema_version != "1.1.0", (
+            "position semantics changed; the schema version must change with it"
+        )

--- a/tests/test_bias_persistence.py
+++ b/tests/test_bias_persistence.py
@@ -1131,3 +1131,89 @@ class TestPositionIsDisplayPosition:
         assert records[0].schema_version != "1.1.0", (
             "position semantics changed; the schema version must change with it"
         )
+
+    def test_unmappable_label_does_not_fall_back_to_ranking_index(self):
+        """Council review of #613: the fallback reintroduced the bug.
+
+        `position_by_model.get(model_id, idx)` quietly restored the ranking
+        index whenever a model was missing from the mapping — the exact
+        semantic this fix removes. A record whose display position cannot be
+        determined must not be written with a plausible-looking wrong one.
+        """
+        from llm_council.bias_persistence import (
+            create_bias_records_from_session,
+            ConsentLevel,
+        )
+
+        # "Response Alpha" yields a model but no derivable position: it has no
+        # display_index and its label is not the single-letter form the legacy
+        # fallback can parse. That is a genuine mapping miss.
+        stage2 = [
+            {
+                "model": "rev/1",
+                "parsed_ranking": {
+                    "ranking": ["Response Alpha", "Response A"],
+                    "scores": {"Response Alpha": 9.0, "Response A": 5.0},
+                },
+            }
+        ]
+        records = create_bias_records_from_session(
+            session_id="s1",
+            stage1_results=self._stage1(),
+            stage2_results=stage2,
+            label_to_model={
+                "Response Alpha": {"model": "m/unmappable"},
+                "Response A": {"model": "m/alpha", "display_index": 0},
+            },
+            consent_level=ConsentLevel.LOCAL_ONLY,
+        )
+        positions = {r.model_id: r.position for r in records}
+        assert "m/unmappable" not in positions, (
+            "a record whose display position cannot be determined must be "
+            f"dropped, not written with the ranking index; got {positions}"
+        )
+        assert positions == {"m/alpha": 0}
+
+    def test_duplicate_model_keeps_distinct_display_positions(self):
+        """Positions are a property of the LABEL, not of the model.
+
+        If the same model appears under two labels, keying the lookup by model
+        collapses them and assigns one of the two positions to both.
+        """
+        from llm_council.bias_persistence import (
+            create_bias_records_from_session,
+            ConsentLevel,
+        )
+
+        label_to_model = {
+            "Response A": {"model": "m/dup", "display_index": 0},
+            "Response B": {"model": "m/other", "display_index": 1},
+            "Response C": {"model": "m/dup", "display_index": 2},
+        }
+        stage2 = [
+            {
+                "model": "rev/1",
+                "parsed_ranking": {
+                    "ranking": ["Response C", "Response B", "Response A"],
+                    "scores": {
+                        "Response A": 5.0,
+                        "Response B": 6.0,
+                        "Response C": 7.0,
+                    },
+                },
+            }
+        ]
+        records = create_bias_records_from_session(
+            session_id="s1",
+            stage1_results=[
+                {"model": "m/dup", "response": "a"},
+                {"model": "m/other", "response": "b"},
+            ],
+            stage2_results=stage2,
+            label_to_model=label_to_model,
+            consent_level=ConsentLevel.LOCAL_ONLY,
+        )
+        dup_positions = sorted(r.position for r in records if r.model_id == "m/dup")
+        assert dup_positions == [0, 2], (
+            f"the two labels for m/dup were shown at 0 and 2; got {dup_positions}"
+        )

--- a/tests/test_council_integration.py
+++ b/tests/test_council_integration.py
@@ -119,7 +119,11 @@ async def test_integration_persistence_enabled(temp_bias_store):
                                 assert len(lines) > 0
                                 # Check content of first record
                                 record = json.loads(lines[0])
-                                assert record["schema_version"] == "1.1.0"
+                                # 1.2.0 (#611): `position` now records the
+                                # DISPLAY index, not the reviewer's ranking
+                                # index, so the semantic — and the version —
+                                # changed together.
+                                assert record["schema_version"] == "1.2.0"
                                 assert "session_id" in record
                                 assert record["consent_level"] == 1  # Default LOCAL_ONLY
 


### PR DESCRIPTION
Closes #611. Prerequisite for #602 (proposed in #612).

## The bug

`BiasMetricRecord.position` is documented as *"Display position during peer review (0-indexed)"* but was populated from `enumerate()` over `parsed["ranking"]` — the order the reviewer **ranked** the candidates, not the order they were **shown**. The display index was sitting in `label_to_model` in the same function, unused.

| model | recorded `.position` (before) | true `display_index` |
|---|---|---|
| `m/alpha` | 2 | 0 |
| `m/beta` | 1 | 1 |
| `m/gamma` | 0 | 2 |

## It inverted the ADR-047 P4 amplification signal

`bias_amplification.position_alignment` correlates `-position` against consensus score to detect *"agreement that tracks display order = amplification suspect"*. Fed a ranking index, it correlated reviewers' rankings against a consensus derived from **those same rankings** — near-tautological with `agreement_index`, and skewed toward false positives by the `-position` sign convention.

**Demonstrated.** One session, two reviewers agreeing strongly, both favouring the model displayed **last** — display order cannot explain their agreement:

```
pre-fix    position_alignment = +0.993    amplification_suspect = True    <- false positive
post-fix   position_alignment = -0.993    amplification_suspect = False   <- correct
```

The sign flipped. `llm-council bias-report --amplification` would have flagged a clean session as a bias-amplification suspect. Pinned by a regression test.

## Implementation notes

- **Reuses `derive_position_mapping`** rather than re-deriving the label parsing a third time. It already handles the enhanced (`display_index`) and legacy (letter-order) formats, and owns the ADR-017 presentation-order invariant. No import cycle — `bias_audit` imports only `unified_config`.
- **`schema_version` 1.1.0 → 1.2.0**, because the meaning of an existing field changed. Pooled cross-session analyses (ADR-018) can now distinguish corrected records rather than silently mixing two meanings of the same number. Existing `1.1.0` records stay readable; their round-trip fixtures are deliberately left at `1.1.0`.

## Two position paths, now consistent

| Path | Before | After |
|---|---|---|
| `derive_position_mapping` → `run_bias_audit` (per-session) | ✅ `display_index` | ✅ unchanged |
| persisted `BiasMetricRecord` → `bias_amplification` (cross-session) | ❌ ranking index | ✅ `display_index` |

## Test plan

- [x] 4 new tests in `TestPositionIsDisplayPosition`, confirmed red first: display-not-ranking; two reviewers sharing one display order; legacy label-format fallback; schema version changed
- [x] 1 new regression test in `TestPositionAlignmentUsesDisplayOrder` pinning the sign inversion
- [x] Whole bias subsystem (persistence, amplification, audit, aggregation): 98 passed
- [x] `make test-fast`: 3646 passed, 1 skipped, 2 deselected
- [x] `make lint`: clean
- [x] Three pre-existing `schema_version == "1.1.0"` assertions updated with rationale; legacy-record fixtures left alone