### PR TITLE
fix(mcp): resolve config aliases lazily instead of freezing them at import

### DIFF
--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -124,6 +124,11 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+def __dir__():
+    """Include the lazily-resolved aliases in introspection (PEP 562)."""
+    return sorted(set(globals()) | set(_LAZY_ALIASES))
+
+
 mcp = FastMCP("LLM Council")
 
 
@@ -158,7 +163,9 @@ def _build_confidence_configs() -> dict:
 
 
 # Build configs at import time (can be refreshed if needed)
-CONFIDENCE_CONFIGS = _build_confidence_configs()
+# #609 (round-2 review): this reads tier timeouts from live config, so
+# assigning it at import froze them exactly like the aliases above.
+_LAZY_ALIASES["CONFIDENCE_CONFIGS"] = lambda: _build_confidence_configs()
 
 
 @mcp.tool()
@@ -218,7 +225,9 @@ async def consult_council(
     except ValueError:
         verdict_type_enum = VerdictType.SYNTHESIS
     # Get confidence configuration (ADR-012 Section 5: Tier-Sovereign Timeouts)
-    config = CONFIDENCE_CONFIGS.get(confidence, CONFIDENCE_CONFIGS["high"])
+    # Resolved live; a module global here would be the import-time snapshot.
+    confidence_configs = _build_confidence_configs()
+    config = confidence_configs.get(confidence, confidence_configs["high"])
     total_timeout = config.get("total", TIMEOUT_SYNTHESIS_TRIGGER)
     per_model_timeout = config.get("per_model", 90)  # Default to high tier
 
@@ -409,6 +418,9 @@ async def council_health_check(deep: bool = False, tier: str = "high") -> str:
         # #609: resolved live. Read from the module global this was a frozen
         # import-time snapshot, so a key configured afterwards stayed invisible.
         api_key = _get_openrouter_api_key()
+        # Also re-resolves the key underneath, so it belongs inside the
+        # same guard rather than able to bypass the not-ready path.
+        key_source = get_key_source()
     except Exception as e:
         config_error = f"{type(e).__name__}: {e}"
         return json.dumps(
@@ -450,7 +462,7 @@ async def council_health_check(deep: bool = False, tier: str = "high") -> str:
     checks = {
         "version": council_version,
         "api_key_configured": bool(api_key),
-        "key_source": get_key_source(),  # ADR-013: Show where key came from (not the key itself)
+        "key_source": key_source,  # ADR-013: where the key came from, never the key
         "default_tier": default_tier,
         "council_size": len(effective_models),
         "chairman_model": chairman_model,

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -117,7 +117,14 @@ _LAZY_ALIASES = {
 
 
 def __getattr__(name: str):
-    """Resolve the back-compat config aliases on access rather than at import."""
+    """Resolve the back-compat config aliases on access rather than at import.
+
+    CAVEAT: ``from llm_council.mcp_server import OPENROUTER_API_KEY`` evaluates
+    this hook once, at the *importing* module's import time, and binds the
+    result there — re-freezing the value in that namespace. Import the module
+    and read the attribute (``mcp_server.OPENROUTER_API_KEY``) to keep lazy
+    resolution. Audited: no production consumer uses the from-import form.
+    """
     resolver = _LAZY_ALIASES.get(name)
     if resolver is not None:
         return resolver()

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -97,11 +97,31 @@ def get_key_source() -> str:
     return _get_key_source()
 
 
-# Module-level aliases for backwards compatibility
-COUNCIL_MODELS = _get_council_models()
-CHAIRMAN_MODEL = _get_chairman_model()
-OPENROUTER_API_KEY = _get_openrouter_api_key()
-TIER_MODEL_POOLS = _get_tier_model_pools()
+# Module-level aliases for backwards compatibility.
+#
+# #609: these were computed once at import, so a key or pool configured
+# afterwards — a keychain re-auth, `llm-council setup-key`, an env change in a
+# long-lived server process — never reached them, and the health check
+# reported a frozen snapshot. Resolved lazily instead (PEP 562), so the public
+# names stay available and are never stale.
+#
+# `unittest.mock.patch` still works on them: it setattr()s a real module
+# attribute, which shadows this hook, then delattr()s on exit to restore lazy
+# resolution. Verified, and pinned by tests.
+_LAZY_ALIASES = {
+    "COUNCIL_MODELS": lambda: _get_council_models(),
+    "CHAIRMAN_MODEL": lambda: _get_chairman_model(),
+    "OPENROUTER_API_KEY": lambda: _get_openrouter_api_key(),
+    "TIER_MODEL_POOLS": lambda: _get_tier_model_pools(),
+}
+
+
+def __getattr__(name: str):
+    """Resolve the back-compat config aliases on access rather than at import."""
+    resolver = _LAZY_ALIASES.get(name)
+    if resolver is not None:
+        return resolver()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 mcp = FastMCP("LLM Council")
@@ -203,7 +223,8 @@ async def consult_council(
     per_model_timeout = config.get("per_model", 90)  # Default to high tier
 
     # Create TierContract for tier-appropriate model selection (ADR-022)
-    tier = confidence if confidence in TIER_MODEL_POOLS else "high"
+    # #609: resolve live — a module global would be the import-time snapshot.
+    tier = confidence if confidence in _get_tier_model_pools() else "high"
     tier_contract = create_tier_contract(tier)
 
     # Progress reporting helper that bridges MCP context to council callback
@@ -374,7 +395,7 @@ async def council_health_check(deep: bool = False, tier: str = "high") -> str:
     # being import-time-bound, it also never reflected a config reload.
     # Mirror consult_council's own resolution, including its fallback for an
     # unrecognised value, so the reported tier is the one that would run.
-    default_tier = tier if tier in TIER_MODEL_POOLS else "high"
+    default_tier = tier if tier in _get_tier_model_pools() else "high"
 
     config_warnings = []
     tier_error = None
@@ -385,6 +406,9 @@ async def council_health_check(deep: bool = False, tier: str = "high") -> str:
     try:
         configured_models = list(_get_council_models())
         chairman_model = _get_chairman_model()
+        # #609: resolved live. Read from the module global this was a frozen
+        # import-time snapshot, so a key configured afterwards stayed invisible.
+        api_key = _get_openrouter_api_key()
     except Exception as e:
         config_error = f"{type(e).__name__}: {e}"
         return json.dumps(
@@ -425,7 +449,7 @@ async def council_health_check(deep: bool = False, tier: str = "high") -> str:
 
     checks = {
         "version": council_version,
-        "api_key_configured": bool(OPENROUTER_API_KEY),
+        "api_key_configured": bool(api_key),
         "key_source": get_key_source(),  # ADR-013: Show where key came from (not the key itself)
         "default_tier": default_tier,
         "council_size": len(effective_models),

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -173,7 +173,10 @@ async def test_council_health_check_no_api_key():
     """Test health check when API key is not configured."""
     from llm_council.mcp_server import council_health_check
 
-    with patch("llm_council.mcp_server.OPENROUTER_API_KEY", None):
+    # #609: the health check resolves the key live rather than reading the
+    # import-time alias, so the resolver is the thing to patch. Patching the
+    # alias would only affect external readers of the module attribute.
+    with patch("llm_council.mcp_server._get_openrouter_api_key", return_value=None):
         result = await council_health_check()
         data = json.loads(result)
 
@@ -709,3 +712,77 @@ class TestHealthCheckReportsEffectiveConfig:
 
         for tier_name in ("quick", "balanced", "high", "reasoning"):
             assert tier_name in data["estimated_duration"], f"{tier_name} missing"
+
+
+class TestConfigIsResolvedLiveNotAtImport:
+    """#609: module-level aliases were frozen at import.
+
+    `OPENROUTER_API_KEY`, `TIER_MODEL_POOLS`, `COUNCIL_MODELS` and
+    `CHAIRMAN_MODEL` were computed once when `mcp_server` was first imported,
+    so a key added afterwards (keychain re-auth, `llm-council setup-key`, an
+    env change in a long-lived server process) never reached them. The health
+    check then reported `api_key_configured` from a stale value.
+
+    Same class as the #608 fix for the model list, and the same class as #591
+    Bug 2 — the health check describing something other than what a real run
+    would do.
+    """
+
+    def test_api_key_alias_reflects_current_config(self):
+        import llm_council.mcp_server as m
+
+        with patch.object(m, "_get_openrouter_api_key", return_value="fresh-key"):
+            assert m.OPENROUTER_API_KEY == "fresh-key", (
+                "module alias is frozen at import; a key configured later is invisible"
+            )
+
+    def test_tier_pools_alias_reflects_current_config(self):
+        import llm_council.mcp_server as m
+
+        with patch.object(m, "_get_tier_model_pools", return_value={"custom": ["x/y"]}):
+            assert m.TIER_MODEL_POOLS == {"custom": ["x/y"]}
+
+    def test_council_aliases_reflect_current_config(self):
+        import llm_council.mcp_server as m
+
+        with patch.object(m, "_get_council_models", return_value=["live/model"]):
+            assert m.COUNCIL_MODELS == ["live/model"]
+        with patch.object(m, "_get_chairman_model", return_value="live/chair"):
+            assert m.CHAIRMAN_MODEL == "live/chair"
+
+    @pytest.mark.asyncio
+    async def test_health_check_sees_a_key_configured_after_import(self):
+        """The reported symptom: key added post-import, still 'not configured'."""
+        import llm_council.mcp_server as m
+
+        with (
+            patch.object(m, "_get_openrouter_api_key", return_value=""),
+            patch.object(m, "create_tier_contract") as mk,
+        ):
+            mk.return_value = MagicMock(allowed_models=["a/b"])
+            before = json.loads(await m.council_health_check())
+
+        with (
+            patch.object(m, "_get_openrouter_api_key", return_value="now-configured"),
+            patch.object(m, "create_tier_contract") as mk,
+            patch.object(
+                m,
+                "query_model_with_status",
+                new_callable=AsyncMock,
+                return_value={"status": "ok", "content": "pong", "latency_ms": 5},
+            ),
+        ):
+            mk.return_value = MagicMock(allowed_models=["a/b"])
+            after = json.loads(await m.council_health_check())
+
+        assert before["api_key_configured"] is False
+        assert after["api_key_configured"] is True, (
+            "a key configured after import must be visible to the health check"
+        )
+
+    def test_unknown_module_attribute_still_raises(self):
+        """The lazy hook must not swallow genuine typos."""
+        import llm_council.mcp_server as m
+
+        with pytest.raises(AttributeError):
+            m.NO_SUCH_SETTING

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -192,7 +192,7 @@ async def test_council_health_check_success():
     from llm_council.mcp_server import council_health_check
     from llm_council.openrouter import STATUS_OK
 
-    with patch("llm_council.mcp_server.OPENROUTER_API_KEY", "test-key"):
+    with patch("llm_council.mcp_server._get_openrouter_api_key", return_value="test-key"):
         result = await council_health_check()
         data = json.loads(result)
 
@@ -215,7 +215,7 @@ async def test_council_health_check_api_error():
     }
 
     with (
-        patch("llm_council.mcp_server.OPENROUTER_API_KEY", "invalid-key"),
+        patch("llm_council.mcp_server._get_openrouter_api_key", return_value="invalid-key"),
         patch("llm_council.mcp_server.query_model_with_status", return_value=mock_response),
     ):
         result = await council_health_check()
@@ -231,7 +231,7 @@ async def test_council_health_check_includes_estimates():
     """Test health check includes duration estimates (ADR-012)."""
     from llm_council.mcp_server import council_health_check
 
-    with patch("llm_council.mcp_server.OPENROUTER_API_KEY", None):
+    with patch("llm_council.mcp_server._get_openrouter_api_key", return_value=None):
         result = await council_health_check()
         data = json.loads(result)
 
@@ -434,7 +434,7 @@ class TestHealthCheckReportsEffectiveConfig:
         from llm_council.mcp_server import council_health_check
 
         with (
-            patch("llm_council.mcp_server.OPENROUTER_API_KEY", None),
+            patch("llm_council.mcp_server._get_openrouter_api_key", return_value=None),
             patch(
                 "llm_council.mcp_server.create_tier_contract",
             ) as mk,
@@ -455,7 +455,7 @@ class TestHealthCheckReportsEffectiveConfig:
         from llm_council.mcp_server import council_health_check
 
         with (
-            patch("llm_council.mcp_server.OPENROUTER_API_KEY", None),
+            patch("llm_council.mcp_server._get_openrouter_api_key", return_value=None),
             patch("llm_council.mcp_server._get_council_models", return_value=["cfg/a", "cfg/b"]),
             patch("llm_council.mcp_server.create_tier_contract") as mk,
         ):
@@ -474,7 +474,7 @@ class TestHealthCheckReportsEffectiveConfig:
         from llm_council.mcp_server import council_health_check
 
         with (
-            patch("llm_council.mcp_server.OPENROUTER_API_KEY", None),
+            patch("llm_council.mcp_server._get_openrouter_api_key", return_value=None),
             patch("llm_council.mcp_server._get_council_models", return_value=["same/a"]),
             patch("llm_council.mcp_server.create_tier_contract") as mk,
         ):
@@ -493,7 +493,7 @@ class TestHealthCheckReportsEffectiveConfig:
         from llm_council.mcp_server import council_health_check
 
         with (
-            patch("llm_council.mcp_server.OPENROUTER_API_KEY", None),
+            patch("llm_council.mcp_server._get_openrouter_api_key", return_value=None),
             patch("llm_council.mcp_server.create_tier_contract") as mk,
         ):
             mk.return_value = MagicMock(allowed_models=["first/model"])
@@ -514,7 +514,7 @@ class TestHealthCheckReportsEffectiveConfig:
         from llm_council.openrouter import STATUS_OK
 
         with (
-            patch("llm_council.mcp_server.OPENROUTER_API_KEY", "k"),
+            patch("llm_council.mcp_server._get_openrouter_api_key", return_value="k"),
             patch(
                 "llm_council.mcp_server.query_model_with_status",
                 new_callable=AsyncMock,
@@ -539,7 +539,7 @@ class TestHealthCheckReportsEffectiveConfig:
             return {"status": STATUS_OK, "content": "pong", "latency_ms": 7}
 
         with (
-            patch("llm_council.mcp_server.OPENROUTER_API_KEY", "k"),
+            patch("llm_council.mcp_server._get_openrouter_api_key", return_value="k"),
             patch("llm_council.mcp_server._get_chairman_model", return_value="chair/model"),
             patch("llm_council.mcp_server.query_model_with_status", side_effect=fake),
         ):
@@ -561,7 +561,7 @@ class TestHealthCheckReportsEffectiveConfig:
             return {"status": STATUS_OK, "content": "pong", "latency_ms": 5}
 
         with (
-            patch("llm_council.mcp_server.OPENROUTER_API_KEY", "k"),
+            patch("llm_council.mcp_server._get_openrouter_api_key", return_value="k"),
             patch("llm_council.mcp_server._get_chairman_model", return_value="chair/model"),
             patch("llm_council.mcp_server.query_model_with_status", side_effect=fake),
         ):
@@ -585,7 +585,7 @@ class TestHealthCheckReportsEffectiveConfig:
             return {"status": STATUS_OK, "content": "pong", "latency_ms": 5}
 
         with (
-            patch("llm_council.mcp_server.OPENROUTER_API_KEY", "k"),
+            patch("llm_council.mcp_server._get_openrouter_api_key", return_value="k"),
             patch("llm_council.mcp_server._get_chairman_model", return_value="chair/model"),
             patch("llm_council.mcp_server.query_model_with_status", side_effect=fake),
         ):
@@ -608,7 +608,7 @@ class TestHealthCheckReportsEffectiveConfig:
         from llm_council.openrouter import STATUS_OK
 
         with (
-            patch("llm_council.mcp_server.OPENROUTER_API_KEY", "k"),
+            patch("llm_council.mcp_server._get_openrouter_api_key", return_value="k"),
             patch(
                 "llm_council.mcp_server.create_tier_contract",
                 side_effect=ValueError("bad tier pool config"),
@@ -635,7 +635,7 @@ class TestHealthCheckReportsEffectiveConfig:
         from llm_council.openrouter import STATUS_OK
 
         with (
-            patch("llm_council.mcp_server.OPENROUTER_API_KEY", "k"),
+            patch("llm_council.mcp_server._get_openrouter_api_key", return_value="k"),
             patch("llm_council.mcp_server.create_tier_contract") as mk,
             patch(
                 "llm_council.mcp_server.query_model_with_status",
@@ -659,7 +659,7 @@ class TestHealthCheckReportsEffectiveConfig:
         from llm_council.mcp_server import council_health_check
 
         with (
-            patch("llm_council.mcp_server.OPENROUTER_API_KEY", None),
+            patch("llm_council.mcp_server._get_openrouter_api_key", return_value=None),
             patch("llm_council.mcp_server.create_tier_contract") as mk,
         ):
             mk.return_value = MagicMock(allowed_models=["quick/one"])
@@ -675,7 +675,7 @@ class TestHealthCheckReportsEffectiveConfig:
         from llm_council.mcp_server import council_health_check
 
         with (
-            patch("llm_council.mcp_server.OPENROUTER_API_KEY", None),
+            patch("llm_council.mcp_server._get_openrouter_api_key", return_value=None),
             patch("llm_council.mcp_server.create_tier_contract") as mk,
         ):
             mk.return_value = MagicMock(allowed_models=["h/1"])
@@ -707,7 +707,7 @@ class TestHealthCheckReportsEffectiveConfig:
         """`reasoning` is a real tier consult_council accepts; it was omitted."""
         from llm_council.mcp_server import council_health_check
 
-        with patch("llm_council.mcp_server.OPENROUTER_API_KEY", None):
+        with patch("llm_council.mcp_server._get_openrouter_api_key", return_value=None):
             data = json.loads(await council_health_check())
 
         for tier_name in ("quick", "balanced", "high", "reasoning"):

--- a/tests/test_secure_key_handling.py
+++ b/tests/test_secure_key_handling.py
@@ -403,7 +403,7 @@ class TestHealthCheckKeySource:
         from llm_council.mcp_server import council_health_check
 
         with (
-            patch("llm_council.mcp_server.OPENROUTER_API_KEY", "test-key"),
+            patch("llm_council.mcp_server._get_openrouter_api_key", return_value="test-key"),
             patch("llm_council.mcp_server.get_key_source", return_value="environment"),
             patch("llm_council.mcp_server.query_model_with_status") as mock_query,
         ):


### PR DESCRIPTION
Closes #609.

## The bug

`COUNCIL_MODELS`, `CHAIRMAN_MODEL`, `OPENROUTER_API_KEY` and `TIER_MODEL_POOLS` were computed **once at import**, so anything configured afterwards — a keychain re-auth, `llm-council setup-key`, an env change in a long-lived server process — never reached them. `council_health_check` reported `api_key_configured` from a frozen snapshot.

Same class as the #608 fix for the model list, and the same shape as #591 Bug 2: the health check describing something other than what a real run would do.

## The fix

Aliases are resolved **on access** via a module-level `__getattr__` (PEP 562) rather than assigned at import. They remain available as the documented back-compat surface and can no longer be stale.

```
key unset  -> OPENROUTER_API_KEY = ''
key added  -> OPENROUTER_API_KEY = 'sk-added-later'     # was: still ''
```

**`unittest.mock.patch` keeps working on them unchanged** — it `setattr`s a real module attribute (shadowing the hook), then `delattr`s on exit, restoring lazy resolution. I verified that against the actual mechanism before relying on it, and pinned it with a test. **17 of the 18 existing patch sites needed no edit.**

## The one subtlety worth knowing

Module `__getattr__` is **not** consulted for `LOAD_GLOBAL` *inside* the module — only for attribute access on the module object. So internal readers had to change to call the resolvers directly (`consult_council`'s tier lookup, the health check's tier lookup and `api_key_configured`).

That made exactly one existing test's patch target wrong: it patched the *alias* (what external readers see) while the health check now reads the *resolver*. Repointed, with a comment explaining which is which.

## Correcting my own issue text

#609 claimed *"13 call sites across two test files"*, and I used that to justify deferring this out of #608. It's actually **18**, and only **one** is in `tests/test_secure_key_handling.py` — and that one **didn't need changing**. The ADR-013 churn I cited as the reason to defer was overstated.

## Not addressed here

`gateway/openrouter.py:36` has the identical import-time-binding pattern. It sits behind the permanently-false `USE_GATEWAY_LAYER` flag (#524), so it's unreachable today and belongs with that decision rather than this fix.

## Test plan

- [x] 5 new tests in `TestConfigIsResolvedLiveNotAtImport`, confirmed red first (4 failing / 1 passing)
- [x] Covers: each alias reflecting current config, the health check seeing a key configured after import, and that the lazy hook still raises `AttributeError` for genuine typos
- [x] `tests/test_mcp_server.py` + `tests/test_secure_key_handling.py`: 56 passed
- [x] `make test-fast`: 3659 passed, 1 skipped, 2 deselected
- [x] `make lint`: clean