### PR TITLE
fix(verify): name the repository root in snapshot-resolution failures

### DIFF
--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -704,6 +704,10 @@ async def verify(
                 "error": "snapshot_resolution_failed",
                 "message": str(e),
                 "snapshot_id": e.snapshot_id,
+                # #581: the repository the daemon searched. This is the MCP
+                # surface, where the mis-rooted-daemon case actually bites —
+                # a client rooted in one repo driving work in a sibling.
+                "repo_root": getattr(e, "repo_root", None),
                 "unresolved_paths": e.unresolved_paths,
                 "expansion_warnings": e.expansion_warnings,
                 "exit_code": 2,

--- a/src/llm_council/verification/api.py
+++ b/src/llm_council/verification/api.py
@@ -234,10 +234,14 @@ async def _build_verification_prompt(
     )
 
     if target_paths and not expansion_metadata.get("expanded_paths"):
+        # #581: name the repository that was searched. The daemon resolves one
+        # root process-wide from its spawn cwd, so "not found" is frequently
+        # "found nothing HERE" — which the operator cannot tell without this.
         raise SnapshotResolutionError(
             snapshot_id=snapshot_id,
             unresolved_paths=list(target_paths),
             expansion_warnings=list(expansion_metadata.get("expansion_warnings", [])),
+            repo_root=await _get_git_root_async(),
         )
 
     evidence_instructions = _build_evidence_instructions(bool(kept_evidence))
@@ -725,6 +729,7 @@ async def _run_verification_pipeline(
         if _policy == "fail":
             raise SnapshotResolutionError(
                 snapshot_id=request.snapshot_id,
+                repo_root=await _get_git_root_async(),
                 unresolved_paths=[c["path"] for c in _clampers],
                 expansion_warnings=[
                     f"coverage: {c['path']} ({c['reason']}) not reviewed "
@@ -1243,6 +1248,8 @@ async def verify_endpoint(request: VerifyRequest) -> VerifyResponse:
                 "error": "snapshot_resolution_failed",
                 "message": str(e),
                 "snapshot_id": e.snapshot_id,
+                # #581: which repository the daemon actually searched.
+                "repo_root": e.repo_root,
                 "unresolved_paths": e.unresolved_paths,
                 "expansion_warnings": e.expansion_warnings,
             },

--- a/src/llm_council/verification/schemas.py
+++ b/src/llm_council/verification/schemas.py
@@ -171,9 +171,18 @@ class SnapshotResolutionError(Exception):
     read your code."
 
     Common upstream causes:
+      - the daemon is rooted in a DIFFERENT repository than the snapshot came
+        from (#581) — git operations run in one process-wide root discovered
+        from the server's spawn cwd, so in a multi-repo session a sibling
+        repo's commits are invisible
       - snapshot_id is on a branch not fetched in the daemon's local clone
       - push-replication race: commit was just pushed and hasn't propagated
       - paths refer to files that don't exist at this commit
+
+    #581: `repo_root` names the repository that was actually searched. Without
+    it the message read as "bad commit" and sent operators to inspect the SHA,
+    when the real cause was a correct SHA in a repository the daemon cannot
+    see.
     """
 
     def __init__(
@@ -182,16 +191,24 @@ class SnapshotResolutionError(Exception):
         snapshot_id: str,
         unresolved_paths: List[str],
         expansion_warnings: List[str],
+        repo_root: Optional[str] = None,
     ) -> None:
         self.snapshot_id = snapshot_id
         self.unresolved_paths = unresolved_paths
         self.expansion_warnings = expansion_warnings
+        self.repo_root = repo_root
         first = unresolved_paths[0] if unresolved_paths else "<none>"
+        where = (
+            f" Searched repository root: {repo_root}."
+            if repo_root
+            else " The repository root being searched could not be determined."
+        )
         super().__init__(
             f"None of the {len(unresolved_paths)} target_paths could be "
-            f"resolved at snapshot {snapshot_id} (first: {first}). "
-            "Verify the snapshot exists in the daemon's checkout and that "
-            "the paths exist at that commit."
+            f"resolved at snapshot {snapshot_id} (first: {first})."
+            f"{where} Check that this snapshot exists in THAT repository — in a "
+            "multi-repo session the daemon searches only the root it started "
+            "in — and that the paths exist at that commit."
         )
 
 

--- a/src/llm_council/verification/schemas.py
+++ b/src/llm_council/verification/schemas.py
@@ -197,19 +197,35 @@ class SnapshotResolutionError(Exception):
         self.unresolved_paths = unresolved_paths
         self.expansion_warnings = expansion_warnings
         self.repo_root = repo_root
-        first = unresolved_paths[0] if unresolved_paths else "<none>"
+        # Built as independent sentences rather than a variable prefix glued
+        # to a fixed suffix: the first version's suffix said "THAT repository",
+        # which dangled when no root had been named (#617 review).
+        if unresolved_paths:
+            first = unresolved_paths[0]
+            what = (
+                f"None of the {len(unresolved_paths)} target_paths could be "
+                f"resolved at snapshot {snapshot_id} (first: {first})."
+            )
+        else:
+            what = f"No target_paths could be resolved at snapshot {snapshot_id}."
+
         where = (
-            f" Searched repository root: {repo_root}."
+            f"Searched repository root: {repo_root}."
             if repo_root
-            else " The repository root being searched could not be determined."
+            else "The repository root being searched could not be determined."
         )
-        super().__init__(
-            f"None of the {len(unresolved_paths)} target_paths could be "
-            f"resolved at snapshot {snapshot_id} (first: {first})."
-            f"{where} Check that this snapshot exists in THAT repository — in a "
-            "multi-repo session the daemon searches only the root it started "
-            "in — and that the paths exist at that commit."
+
+        # All four documented causes, not just the multi-repo one. Leading on
+        # multi-repo alone would misdirect the more frequent cases — an
+        # unfetched branch or an unpropagated push (#617 review).
+        why = (
+            "Common causes: the snapshot lives in a different repository than "
+            "the one searched (a multi-repo session searches only the root the "
+            "daemon started in); the branch was never fetched there; a recent "
+            "push has not propagated yet; or the paths do not exist at that "
+            "commit."
         )
+        super().__init__(f"{what} {where} {why}")
 
 
 # =============================================================================

--- a/src/llm_council/verification/schemas.py
+++ b/src/llm_council/verification/schemas.py
@@ -183,6 +183,18 @@ class SnapshotResolutionError(Exception):
     it the message read as "bad commit" and sent operators to inspect the SHA,
     when the real cause was a correct SHA in a repository the daemon cannot
     see.
+
+    Disclosure note (#617 review): `repo_root` is an absolute server-side path
+    and is returned over both the MCP and HTTP error surfaces. On the MCP path
+    the server is the caller's own machine, so this discloses nothing. On a
+    remotely-deployed HTTP server it reveals the deployment's directory layout
+    to an authenticated caller. Judged an acceptable trade for a failure this
+    error otherwise cannot explain — but an operator exposing the HTTP API to
+    untrusted callers may want to scrub `detail.repo_root` at the edge.
+
+    `repo_root` is checked for truthiness rather than `is not None`: an empty
+    string is as undetermined as a missing one, and both should produce the
+    "could not be determined" wording.
     """
 
     def __init__(

--- a/tests/unit/verification/test_snapshot_resolution.py
+++ b/tests/unit/verification/test_snapshot_resolution.py
@@ -393,3 +393,59 @@ class TestErrorNamesTheRepoRoot:
         )
         text = str(err).lower()
         assert "repositor" in text or "root" in text
+
+    def test_message_is_coherent_when_root_is_unknown(self):
+        """Council review of #617: 'THAT repository' dangled with no antecedent.
+
+        The message was built by concatenating a variable prefix onto a fixed
+        suffix that assumed the prefix had just named a repository. With no
+        root determined it read "...could not be determined. Check that this
+        snapshot exists in THAT repository" — pointing at nothing.
+        """
+        from llm_council.verification.schemas import SnapshotResolutionError
+
+        text = str(
+            SnapshotResolutionError(
+                snapshot_id="abc1234",
+                unresolved_paths=["src/app.py"],
+                expansion_warnings=[],
+            )
+        )
+        assert "THAT repository" not in text, f"dangling reference: {text}"
+        assert "could not be determined" in text
+
+    def test_message_lists_the_other_common_causes_too(self):
+        """Multi-repo is one cause, and probably not the most frequent.
+
+        Leading on it alone risks sending an operator hunting a mis-rooted
+        daemon when the real cause is an unfetched branch or a push that has
+        not propagated — both documented in the class docstring.
+        """
+        from llm_council.verification.schemas import SnapshotResolutionError
+
+        text = str(
+            SnapshotResolutionError(
+                snapshot_id="abc1234",
+                unresolved_paths=["src/app.py"],
+                expansion_warnings=[],
+                repo_root="/repo/a",
+            )
+        ).lower()
+        assert "fetch" in text, "unfetched branch is a documented cause"
+        assert "push" in text or "propagat" in text, "push race is a documented cause"
+        assert "different repository" in text or "multi-repo" in text
+
+    def test_empty_unresolved_paths_reads_sensibly(self):
+        """'None of the 0 target_paths' is awkward; guard the degenerate case."""
+        from llm_council.verification.schemas import SnapshotResolutionError
+
+        text = str(
+            SnapshotResolutionError(
+                snapshot_id="abc1234",
+                unresolved_paths=[],
+                expansion_warnings=[],
+                repo_root="/repo/a",
+            )
+        )
+        assert "None of the 0" not in text, f"awkward phrasing: {text}"
+        assert "abc1234" in text

--- a/tests/unit/verification/test_snapshot_resolution.py
+++ b/tests/unit/verification/test_snapshot_resolution.py
@@ -327,3 +327,69 @@ class TestPipelineSurfacesExpansionMetadata:
 
             with pytest.raises(SnapshotResolutionError):
                 await run_verification(request, store)
+
+
+class TestErrorNamesTheRepoRoot:
+    """#581: the failure never said which repository was searched.
+
+    `_get_git_root_async()` discovers the git toplevel once, in the MCP
+    server's spawn cwd, and caches it process-wide; all eight git call sites
+    then run with `cwd=git_root`. In a multi-repo session — a client rooted in
+    repo A orchestrating work in sibling repo B — every snapshot from B fails,
+    because the daemon can only ever see A.
+
+    The error read "Verify the snapshot exists in the daemon's checkout",
+    which points at the right idea while withholding the one fact that
+    identifies the problem: *which* checkout. It reads as "bad commit",
+    sending the operator to look at the SHA rather than at the daemon's root.
+    """
+
+    def test_error_message_states_which_root_was_searched(self):
+        from llm_council.verification.schemas import SnapshotResolutionError
+
+        err = SnapshotResolutionError(
+            snapshot_id="abc1234",
+            unresolved_paths=["src/app.py"],
+            expansion_warnings=[],
+            repo_root="/Users/dev/projects/repo-a",
+        )
+        assert "/Users/dev/projects/repo-a" in str(err), (
+            f"the searched root must appear in the message; got: {err}"
+        )
+
+    def test_repo_root_is_exposed_as_an_attribute(self):
+        """Structured consumers shouldn't have to parse the prose."""
+        from llm_council.verification.schemas import SnapshotResolutionError
+
+        err = SnapshotResolutionError(
+            snapshot_id="abc1234",
+            unresolved_paths=["src/app.py"],
+            expansion_warnings=[],
+            repo_root="/repo/a",
+        )
+        assert err.repo_root == "/repo/a"
+
+    def test_repo_root_is_optional_for_back_compat(self):
+        """Existing raise sites and callers must keep working."""
+        from llm_council.verification.schemas import SnapshotResolutionError
+
+        err = SnapshotResolutionError(
+            snapshot_id="abc1234",
+            unresolved_paths=["src/app.py"],
+            expansion_warnings=[],
+        )
+        assert err.repo_root is None
+        assert "abc1234" in str(err)
+
+    def test_message_hints_at_the_multi_repo_cause(self):
+        """A mis-rooted daemon is the case the old wording concealed."""
+        from llm_council.verification.schemas import SnapshotResolutionError
+
+        err = SnapshotResolutionError(
+            snapshot_id="abc1234",
+            unresolved_paths=["src/app.py"],
+            expansion_warnings=[],
+            repo_root="/repo/a",
+        )
+        text = str(err).lower()
+        assert "repositor" in text or "root" in text


### PR DESCRIPTION
Part of #581 (item 5). Items 1–4 follow separately.

## The problem

`verify()` resolves **one git root process-wide**, discovered from the MCP server's spawn cwd and cached globally (`file_ops.py:33`); all **8** git call sites then run with `cwd=` that root. In a multi-repo session — a client rooted in repo A orchestrating work in sibling repo B — every snapshot from B fails, because the daemon can only ever see A.

The error gestured at the cause while withholding the fact that identifies it:

```
BEFORE:  ...could not be resolved at snapshot abc1234 (first: src/app.py).
         Verify the snapshot exists in the daemon's checkout and that the
         paths exist at that commit.

AFTER:   ...could not be resolved at snapshot abc1234 (first: src/app.py).
         Searched repository root: /Users/dev/projects/planning-repo.
         Check that this snapshot exists in THAT repository — in a multi-repo
         session the daemon searches only the root it started in — and that
         the paths exist at that commit.
```

"the daemon's checkout" reads as *"bad commit"*, sending the operator to inspect the SHA when the SHA is fine and the daemon is looking in the wrong repository. The reporter lost two verify calls to this before finding the cause in source.

## Change

`SnapshotResolutionError` gains an optional `repo_root`:
- named in the message, with an explicit pointer at the multi-repo case
- exposed as an attribute, so structured consumers don't parse prose
- carried in **both** error blobs — the HTTP 422 detail and the MCP tool's JSON (the MCP surface is where this actually bites)
- **optional**, so existing raise sites and callers are unaffected

Wired into both raise sites (`target_paths` unresolvable, and the `coverage_policy=fail` clamp).

## Why this ships on its own

It's the highest value-per-line part of #581: it turns a misleading error into a self-diagnosing one, with no API surface added and no behaviour change. The actual capability — `repo_root` parameter, `LLM_COUNCIL_REPO_ROOT`, and caching per root rather than globally — is a separate, larger change.

## Test plan

- [x] 4 new tests in `TestErrorNamesTheRepoRoot`, confirmed red first
- [x] Covers: root appears in the message, exposed as an attribute, **optional for back-compat**, and the message names the multi-repo cause
- [x] `tests/unit/verification/test_snapshot_resolution.py`: 14 passed
- [x] `make test-fast`: 3663 passed, 1 skipped, 2 deselected
- [x] `make lint`: clean