### PR TITLE
test(verify): make the event-loop test capable of failing

### DIFF
--- a/tests/unit/verification/test_async_file_fetch.py
+++ b/tests/unit/verification/test_async_file_fetch.py
@@ -10,6 +10,7 @@ These tests verify that:
 """
 
 import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -638,25 +639,102 @@ class TestEventLoopNotBlocked:
 
     @pytest.mark.asyncio
     async def test_event_loop_remains_responsive(self):
-        """Event loop should remain responsive during file fetch."""
-        from llm_council.verification.api import _fetch_file_at_commit_async
+        """The fetch must not starve the event loop while it runs (#588).
 
-        # Create a flag that will be set by a concurrent task
-        flag_set = False
+        The original version could not fail: it ran the fetch and a
+        flag-setter under `asyncio.gather`, then asserted the flag was set.
+        `gather` waits for BOTH, so the setter always completed and the flag
+        was always True — even if the fetch had frozen the loop for ten
+        seconds first. A guard on the invariant the async design exists to
+        protect, providing no protection.
 
-        async def set_flag():
-            nonlocal flag_set
-            await asyncio.sleep(0.01)  # Tiny delay
-            flag_set = True
+        A second attempt (parking the mocked read on an `asyncio.Event` that a
+        concurrent task must set) was ALSO insufficient, and was verified so:
+        synchronous blocking placed *before* the await simply delayed
+        everything and then completed, because the loop was free again by the
+        time the event mattered. Liveness alone cannot see starvation that has
+        already ended.
 
-        # Start file fetch and flag setter concurrently
-        await asyncio.gather(
-            _fetch_file_at_commit_async("HEAD", "pyproject.toml"),
-            set_flag(),
+        What can: sampling. A heartbeat ticks on a short interval throughout
+        the fetch, and the largest gap between ticks is the longest the loop
+        went unserviced. Synchronous blocking anywhere in the fetch path
+        shows up directly as an oversized gap.
+
+        On the flakiness this must not reintroduce (#585): that test compared
+        two similar real durations against a 1.5x margin, so ordinary
+        scheduling noise could flip it. This compares mocked work of roughly
+        zero against a one-second bound — three orders of magnitude of
+        headroom. It distinguishes "the loop was serviced" from "the loop was
+        frozen", not "fast" from "slow".
+        """
+        from llm_council.verification import file_ops
+
+        # Generous relative to the mocked work (~0ms); tight relative to any
+        # blocking call worth catching.
+        MAX_UNSERVICED_SECONDS = 1.0
+
+        ticks: list = []
+        stop = asyncio.Event()
+
+        async def heartbeat():
+            while not stop.is_set():
+                ticks.append(time.monotonic())
+                await asyncio.sleep(0.005)
+
+        # A few chunks, each preceded by a short ASYNC wait. The awaits keep
+        # the loop free by construction, so they give the heartbeat a window
+        # to sample without themselves creating gaps — anything that widens a
+        # gap has to come from the code under test.
+        chunks = [b"chunk-one", b"chunk-two", b"chunk-three", b""]
+
+        async def mock_read(size: int) -> bytes:
+            await asyncio.sleep(0.02)
+            return chunks.pop(0) if chunks else b""
+
+        mock_stdout = MagicMock()
+        mock_stdout.read = mock_read
+        mock_stderr = MagicMock()
+        mock_stderr.read = AsyncMock(return_value=b"")
+
+        mock_proc = MagicMock()
+        mock_proc.stdout = mock_stdout
+        mock_proc.stderr = mock_stderr
+        mock_proc.returncode = 0
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+
+        beat = asyncio.create_task(heartbeat())
+        await asyncio.sleep(0)  # let the heartbeat register a first tick
+        try:
+            with (
+                patch.object(
+                    file_ops, "_get_git_root_async", new_callable=AsyncMock, return_value="/mock"
+                ),
+                patch.object(
+                    file_ops,
+                    "_get_git_semaphore",
+                    new_callable=AsyncMock,
+                    return_value=asyncio.Semaphore(10),
+                ),
+                patch(
+                    "asyncio.create_subprocess_exec",
+                    new_callable=AsyncMock,
+                    return_value=mock_proc,
+                ),
+            ):
+                await file_ops._fetch_file_at_commit_async("HEAD", "some/file.py")
+        finally:
+            stop.set()
+            await beat
+
+        assert len(ticks) >= 2, "heartbeat never sampled; the test proves nothing"
+        gaps = [b - a for a, b in zip(ticks, ticks[1:])]
+        worst = max(gaps)
+        assert worst < MAX_UNSERVICED_SECONDS, (
+            f"event loop went unserviced for {worst:.2f}s during the fetch "
+            f"(bound {MAX_UNSERVICED_SECONDS}s) — something in the fetch path "
+            "is blocking rather than awaiting"
         )
-
-        # Flag should have been set (event loop wasn't blocked)
-        assert flag_set, "Event loop was blocked during file fetch"
 
     @pytest.mark.asyncio
     async def test_uses_asyncio_subprocess_not_sync(self):

--- a/tests/unit/verification/test_async_file_fetch.py
+++ b/tests/unit/verification/test_async_file_fetch.py
@@ -724,8 +724,13 @@ class TestEventLoopNotBlocked:
             ):
                 await file_ops._fetch_file_at_commit_async("HEAD", "some/file.py")
         finally:
+            # Never let heartbeat cleanup mask an exception from the fetch:
+            # this `finally` runs on the failure path too (#620 review).
             stop.set()
-            await beat
+            try:
+                await beat
+            except Exception:  # pragma: no cover - cleanup must not shadow
+                pass
 
         assert len(ticks) >= 2, "heartbeat never sampled; the test proves nothing"
         gaps = [b - a for a, b in zip(ticks, ticks[1:])]


### PR DESCRIPTION
Closes #588 (rescoped — see below).

## The bug

`test_event_loop_remains_responsive` **could not fail**:

```python
await asyncio.gather(
    _fetch_file_at_commit_async("HEAD", "pyproject.toml"),
    set_flag(),          # sleeps 0.01s, sets flag
)
assert flag_set          # always True
```

`gather` waits for **both**. `set_flag()` always completes. So the assertion held even if the fetch used blocking `subprocess.run()` and froze the loop for ten seconds. A guard on the invariant the async design exists to protect, providing none.

## Three attempts, each mutation-tested rather than trusted

| Attempt | Result |
|---|---|
| 1. Original (`gather` + flag) | Verified vacuous |
| 2. Park the mocked read on an `asyncio.Event` a concurrent task must set | **Also insufficient** — an 8s sync block *before* the await just delayed everything and passed. Liveness can't see starvation that already ended. |
| 3. Heartbeat sampling | Works |

Attempt 2 is worth calling out: **its docstring claimed a property it didn't have** — precisely the failure mode of the test it was replacing. Only mutation-testing it exposed that.

The final version runs a ticker throughout the fetch; the largest gap between ticks is the longest the loop went unserviced. The mocked read yields a few short *async* waits so there's a window to sample — those keep the loop free by construction, so any widened gap comes from the code under test.

**Mutation check:** a 3s synchronous block inside the read loop now fails with

```
event loop went unserviced for 3.01s during the fetch (bound 1.0s)
— something in the fetch path is blocking rather than awaiting
```

The same mutation **passed** under both earlier versions.

## Not reintroducing #585's flakiness

That test compared two similar real durations against a 1.5x margin, so scheduling noise could flip it. This compares mocked work of ~0ms against a **1 second** bound — three orders of magnitude of headroom. It distinguishes *serviced* from *frozen*, not *fast* from *slow*.

## Complements, doesn't duplicate

`test_uses_asyncio_subprocess_not_sync` catches swapping the spawn API to a synchronous one. It would **not** notice blocking introduced inside the read loop, which is what this covers.

## Rescoping #588

The issue listed six findings. Only this one warranted work:

- **Real-repo test dependencies** (finding 2) — I'm recommending this be **accepted by design** rather than left open. The council flags it on every whole-file pass, and this session has now spent rounds on it twice; the mixed mocked/real-repo pattern is deliberate. Recorded on the issue.
- **Patch-target inconsistency** (3) — already confirmed a false positive; restated on the issue so future passes don't re-derive it.
- Findings 4–6 — trivia or already-resolved.

## Test plan

- [x] Mutation-tested: 3s sync block fails the new test, passed both old ones
- [x] `tests/unit/verification/test_async_file_fetch.py`: 25 passed
- [x] `make test-fast`: 3666 passed, 1 skipped, 2 deselected
- [x] `make lint`: clean