### PR TITLE
Release v0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.0] - 2026-08-22
+
+**Two decided defaults land (ADR-053 #557 / ADR-054 #563).** Both are behavior changes from the 2026-08-21 maintainer decision batch; each has a one-variable escape hatch or a no-op migration. Release tracking: [#632](https://github.com/amiable-dev/llm-council/issues/632).
+
+### Changed
+
+- **`LLM_COUNCIL_FILE_SELECTION` now defaults to `content` ([#557](https://github.com/amiable-dev/llm-council/issues/557), PR [#631](https://github.com/amiable-dev/llm-council/pull/631))** — `verify`/`gate` review **any text file** by default, regardless of extension, closing the gap where a commit touching a `.zig`/`.tf`/`Justfile` could PASS without those files ever being read ([#542](https://github.com/amiable-dev/llm-council/issues/542)). Strictly stricter: nothing reviewed before stops being reviewed, but commits touching previously-unlisted files can gain findings and modest prompt cost; a few extra git calls per verify. The secret denylist and garbage filter are unchanged and still run first. **Migration:** set `LLM_COUNCIL_FILE_SELECTION=allowlist` to restore the previous behavior exactly. Decision evidence: 35 real shadow-mode runs with zero `would_drop` deltas. This release also satisfies the precondition for the coverage-clamp default flip (its own later release, per the sequencing recorded on #557).
+- **`confidence` is now explicitly telemetry, and the calibrated PASS gate is removed (ADR-054 D3a, [#563](https://github.com/amiable-dev/llm-council/issues/563), PR [#629](https://github.com/amiable-dev/llm-council/pull/629))** — verify's `confidence`/`confidence_calibrated` are reviewer-agreement-derived heuristics, not calibrated probabilities, and are now documented as such everywhere; no verdict threshold consumes the calibrated value. The `LLM_COUNCIL_CALIBRATED_CONFIDENCE` env flag is **deleted** (it defaulted off and no calibration mapping was ever fittable in practice, so flag-off users — everyone — see byte-identical behavior). **Migration:** none for flag-off users; a flag-on user loses calibrated thresholding. The raw-confidence low-confidence softening on the legacy verdict path is unchanged. D3b (findings-uncertainty confidence) is scoped as [#628](https://github.com/amiable-dev/llm-council/issues/628).
+
+### Fixed
+
+- Corrupt calibration mappings with coordinates outside `[0, 1]` are now rejected on load (soft-fail to identity), matching the existing monotonicity check (found by the [#629](https://github.com/amiable-dev/llm-council/pull/629) council gate).
+
 ## [0.43.0] - 2026-08-21
 
 **The #579 extraction chain: grounded consultation + compute-optimal telemetry.** Two features extracted from the STORM/Co-STORM research-mode proposal ([#579](https://github.com/amiable-dev/llm-council/issues/579)) — each justified on its own merits — plus the evidence-hardening their council reviews demanded. Design records: ADR-042 Amendment 1, ADR-044 implementation note.

--- a/server-card.json
+++ b/server-card.json
@@ -3,7 +3,7 @@
   "name": "io.github.amiable-dev/llm-council",
   "title": "LLM Council",
   "description": "Multi-model deliberation council with anonymized peer review, exposed as MCP tools.",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "websiteUrl": "https://github.com/amiable-dev/llm-council",
   "repository": {
     "source": "github",


### PR DESCRIPTION
Minor release: the two decided defaults land (release tracking #632) — `LLM_COUNCIL_FILE_SELECTION` default → `content` (#557/#631, with migration note) and ADR-054 D3a confidence demotion incl. flag deletion (#563/#629), plus the calibration-mapping range fix. Regenerates `server-card.json` at 0.44.0.

Pre-tag concurrent-session check done: v0.43.0 is latest everywhere; exactly #629 + #631 unreleased.

After merge: tag `v0.44.0` → publish → GitHub Release (auto-fires sync-action). This release satisfies the clamp-flip routine's STEP 4b release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1sSV9YoaFE8F35vXMUY7S