### PR TITLE
feat(config): refresh default model configuration to the Aug-2026 market

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Default model configuration refreshed to the August 2026 market ([#635](https://github.com/amiable-dev/llm-council/issues/635))** — every tier pool, the chairman, and all tier aggregators move to current-generation OpenRouter IDs, verified live against the catalog on 2026-08-22. Highlights: `anthropic/claude-opus-5` replaces `claude-opus-4.8` at the identical $5/$25 price (chairman moves from `google/gemini-3.1-pro-preview` to `claude-opus-5`, activating the ADR-049 prompt-cache path on chairman calls); `openai/gpt-5.6-sol[-pro]` replaces `gpt-5.4`/`gpt-5.4-pro` (the reasoning tier's OpenAI seat drops from $30/$180 to $2/$10 per 1M); two new provider families join — `x-ai/grok-4.6` (frontier) and `z-ai/glm-5.3` (reasoning, replacing the stale `deepseek/deepseek-r1`) — motivated by correlated-judge-error evidence (arXiv 2605.29800; follow-ups [#637](https://github.com/amiable-dev/llm-council/issues/637), [#638](https://github.com/amiable-dev/llm-council/issues/638)). `google/gemini-3.1-pro-preview` is deliberately held: Google ships no Pro-class successor. Full research: [discussion #636](https://github.com/amiable-dev/llm-council/discussions/636). **Migration:** none required — `LLM_COUNCIL_MODELS`, `LLM_COUNCIL_CHAIRMAN`, and YAML pool overrides keep working; prior-generation IDs remain valid on OpenRouter (set them explicitly to keep them). `models/registry.yaml` grows to 61 models / 10 providers (v1.4) with cache-read price classes for the new entries.
+
 ## [0.44.0] - 2026-08-22
 
 **Two decided defaults land (ADR-053 #557 / ADR-054 #563).** Both are behavior changes from the 2026-08-21 maintainer decision batch; each has a one-variable escape hatch or a no-op migration. Release tracking: [#632](https://github.com/amiable-dev/llm-council/issues/632).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Council core
 
 Tiering & model selection
 - `tier_contract.py` (ADR-022), `unified_config.py` (ADR-024, see below).
-- `metadata/` (ADR-026/028) — model metadata abstraction. `StaticRegistryProvider` (offline, bundled `models/registry.yaml`, ~31 models / 8 providers) and `DynamicMetadataProvider` (OpenRouter API + TTL cache). Background discovery worker + request-time discovery (ADR-028). `intersection.py` resolves tier membership for multi-tier models (e.g. o1-preview).
+- `metadata/` (ADR-026/028) — model metadata abstraction. `StaticRegistryProvider` (offline, bundled `models/registry.yaml`, ~61 models / 10 providers) and `DynamicMetadataProvider` (OpenRouter API + TTL cache). Background discovery worker + request-time discovery (ADR-028). `intersection.py` resolves tier membership for multi-tier models (e.g. o1-preview).
 - `triage/` (ADR-020), `reasoning/` (ADR-026 Phase 2 — effort levels), `performance/` (ADR-026 Phase 3 — internal performance index from real sessions).
 
 Frontier tier lifecycle (ADR-027/029)

--- a/llm_council.yaml
+++ b/llm_council.yaml
@@ -21,47 +21,47 @@ council:
       # QUICK: Fast models for simple queries (<5s latency)
       quick:
         models:
-          - openai/gpt-5-mini
+          - openai/gpt-5.6-luna
           - anthropic/claude-haiku-4.5
-          - google/gemini-3.1-flash-lite
-          - deepseek/deepseek-v3.2
+          - google/gemini-3.5-flash-lite
+          - deepseek/deepseek-v4-flash
         timeout_seconds: 30
 
       # BALANCED: Good quality with reasonable latency
       balanced:
         models:
-          - openai/gpt-5.4-mini
-          - anthropic/claude-sonnet-4.6
-          - google/gemini-3.1-flash-lite
-          - deepseek/deepseek-v3.2
+          - openai/gpt-5.6-luna
+          - anthropic/claude-sonnet-5
+          - google/gemini-3.7-flash
+          - deepseek/deepseek-v4-flash
         timeout_seconds: 90
 
       # HIGH: Full council deliberation with frontier models
       high:
         models:
-          - openai/gpt-5.4
-          - anthropic/claude-opus-4.8
+          - openai/gpt-5.6-sol
+          - anthropic/claude-opus-5
           - google/gemini-3.1-pro-preview
-          - deepseek/deepseek-v4-pro
+          - deepseek/deepseek-v4-pro-0813
         timeout_seconds: 180
 
       # REASONING: Deep reasoning with extended thinking
       reasoning:
         models:
-          - openai/gpt-5.4-pro
-          - anthropic/claude-opus-4.8
+          - openai/gpt-5.6-sol-pro
+          - anthropic/claude-opus-5
           - google/gemini-3.1-pro-preview
-          - deepseek/deepseek-r1
+          - z-ai/glm-5.3
         timeout_seconds: 600
 
       # FRONTIER: Cutting-edge/preview models (may be unstable)
       # Use for testing latest capabilities before promoting to 'high'
       frontier:
         models:
-          - openai/gpt-5.5-pro
-          - anthropic/claude-opus-4.8
+          - anthropic/claude-fable-5
+          - openai/gpt-5.6-sol-pro
+          - x-ai/grok-4.6
           - google/gemini-3.1-pro-preview
-          - deepseek/deepseek-v4-pro
         timeout_seconds: 600
         # Frontier-specific: accept higher latency/cost for newest models
         allow_preview: true

--- a/llm_council.yaml.example
+++ b/llm_council.yaml.example
@@ -5,8 +5,8 @@
 # https://llm-council.dev/reference/environment-variables/
 
 council:
-  # models: [openai/gpt-5.4, google/gemini-3.1-pro-preview, anthropic/claude-opus-4.8, deepseek/deepseek-v4-pro]
-  # chairman: google/gemini-3.1-pro-preview
+  # models: [openai/gpt-5.6-sol, google/gemini-3.1-pro-preview, anthropic/claude-opus-5, deepseek/deepseek-v4-pro-0813]
+  # chairman: anthropic/claude-opus-5
   synthesis_mode: consensus        # consensus | debate
   exclude_self_votes: true
   style_normalization: false

--- a/src/llm_council/cache_context.py
+++ b/src/llm_council/cache_context.py
@@ -52,6 +52,7 @@ MAX_BREAKPOINTS = 4  # Anthropic hard limit per request
 _ANTHROPIC_MIN_PREFIX: Dict[str, int] = {
     "anthropic/claude-fable-5": 512,
     "anthropic/claude-opus-4.8": 1024,
+    "anthropic/claude-opus-5": 1024,
     "anthropic/claude-sonnet-5": 1024,
     "anthropic/claude-haiku-4.5": 4096,
 }

--- a/src/llm_council/models/registry.yaml
+++ b/src/llm_council/models/registry.yaml
@@ -13,13 +13,43 @@
 #   modalities: List of input modalities (text, vision, audio)
 #   quality_tier: frontier | standard | economy | local
 
-version: "1.3"
-updated: "2026-06-02"
+version: "1.4"
+updated: "2026-08-22"
 
 models:
   # ============================================================================
-  # OpenAI Models (14)
+  # OpenAI Models (17)
   # ============================================================================
+  - id: "openai/gpt-5.6-sol"
+    context_window: 1050000
+    pricing:
+      prompt: 0.002
+      completion: 0.01
+      cache_read: 0.0002
+    supported_parameters: ["temperature", "top_p", "tools", "json_mode", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "frontier"
+
+  - id: "openai/gpt-5.6-sol-pro"
+    context_window: 1050000
+    pricing:
+      prompt: 0.002
+      completion: 0.01
+      cache_read: 0.0002
+    supported_parameters: ["temperature", "top_p", "tools", "json_mode", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "frontier"
+
+  - id: "openai/gpt-5.6-luna"
+    context_window: 1050000
+    pricing:
+      prompt: 0.0002
+      completion: 0.0012
+      cache_read: 0.00002
+    supported_parameters: ["temperature", "top_p", "tools", "json_mode", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "standard"
+
   - id: "openai/gpt-5.5-pro"
     context_window: 1050000
     pricing:
@@ -165,8 +195,44 @@ models:
     quality_tier: "standard"
 
   # ============================================================================
-  # Anthropic Models (9)
+  # Anthropic Models (12)
   # ============================================================================
+  - id: "anthropic/claude-opus-5"
+    context_window: 1000000
+    pricing:
+      prompt: 0.005
+      completion: 0.025
+      cache_read: 0.0005
+      cache_write_5m: 0.00625
+      cache_write_1h: 0.01
+    supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "frontier"
+
+  - id: "anthropic/claude-sonnet-5"
+    context_window: 1000000
+    pricing:
+      prompt: 0.002
+      completion: 0.01
+      cache_read: 0.0002
+      cache_write_5m: 0.0025
+      cache_write_1h: 0.004
+    supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "frontier"
+
+  - id: "anthropic/claude-fable-5"
+    context_window: 1000000
+    pricing:
+      prompt: 0.01
+      completion: 0.05
+      cache_read: 0.001
+      cache_write_5m: 0.0125
+      cache_write_1h: 0.02
+    supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "frontier"
+
   - id: "anthropic/claude-sonnet-4.6"
     context_window: 1000000
     pricing:
@@ -288,8 +354,29 @@ models:
     quality_tier: "standard"
 
   # ============================================================================
-  # Google Models (9)
+  # Google Models (11)
   # ============================================================================
+  - id: "google/gemini-3.7-flash"
+    context_window: 1048576
+    pricing:
+      # Standard rate; OpenRouter promo ($0.375/$1.875 per 1M) ends 2026-08-27
+      prompt: 0.00075
+      completion: 0.00375
+      cache_read: 0.000075
+    supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "standard"
+
+  - id: "google/gemini-3.5-flash-lite"
+    context_window: 1048576
+    pricing:
+      prompt: 0.0003
+      completion: 0.0025
+      cache_read: 0.00003
+    supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "economy"
+
   - id: "google/gemini-3.1-pro-preview"
     context_window: 1040000
     pricing:
@@ -372,8 +459,28 @@ models:
     quality_tier: "economy"
 
   # ============================================================================
-  # DeepSeek Models (4)
+  # DeepSeek Models (6)
   # ============================================================================
+  - id: "deepseek/deepseek-v4-pro-0813"
+    context_window: 1048576
+    pricing:
+      prompt: 0.00119
+      completion: 0.00356
+      cache_read: 0.00004
+    supported_parameters: ["temperature", "top_p", "reasoning"]
+    modalities: ["text"]
+    quality_tier: "frontier"
+
+  - id: "deepseek/deepseek-v4-flash"
+    context_window: 1048576
+    pricing:
+      prompt: 0.00007
+      completion: 0.00014
+      cache_read: 0.00001
+    supported_parameters: ["temperature", "top_p", "reasoning"]
+    modalities: ["text"]
+    quality_tier: "economy"
+
   - id: "deepseek/deepseek-v4-pro"
     context_window: 1048576
     pricing:
@@ -409,6 +516,32 @@ models:
     supported_parameters: ["temperature", "top_p"]
     modalities: ["text"]
     quality_tier: "economy"
+
+  # ============================================================================
+  # xAI Models (1)
+  # ============================================================================
+  - id: "x-ai/grok-4.6"
+    context_window: 500000
+    pricing:
+      prompt: 0.002
+      completion: 0.006
+      cache_read: 0.0005
+    supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
+    modalities: ["text", "vision"]
+    quality_tier: "frontier"
+
+  # ============================================================================
+  # Z.ai Models (1)
+  # ============================================================================
+  - id: "z-ai/glm-5.3"
+    context_window: 1048576
+    pricing:
+      prompt: 0.0014
+      completion: 0.0044
+      cache_read: 0.00026
+    supported_parameters: ["temperature", "top_p", "tools", "reasoning"]
+    modalities: ["text"]
+    quality_tier: "frontier"
 
   # ============================================================================
   # Meta/Llama Models (2)

--- a/src/llm_council/tier_contract.py
+++ b/src/llm_council/tier_contract.py
@@ -74,36 +74,39 @@ def get_tier_timeout(tier: str) -> Dict[str, int]:
 
 
 # Default pools used when config isn't loaded yet
+# Aug-2026 model refresh (#635): IDs verified against the live OpenRouter
+# catalog 2026-08-22. gemini-3.1-pro-preview is held deliberately — Google
+# ships no Pro-class successor; swap when a stable 3.x Pro lands.
 _DEFAULT_TIER_MODEL_POOLS = {
     "quick": [
-        "openai/gpt-5-mini",
+        "openai/gpt-5.6-luna",
         "anthropic/claude-haiku-4.5",
-        "google/gemini-3.1-flash-lite",
-        "deepseek/deepseek-v3.2",
+        "google/gemini-3.5-flash-lite",
+        "deepseek/deepseek-v4-flash",
     ],
     "balanced": [
-        "openai/gpt-5.4-mini",
-        "anthropic/claude-sonnet-4.6",
-        "google/gemini-3.1-flash-lite",
-        "deepseek/deepseek-v3.2",
+        "openai/gpt-5.6-luna",
+        "anthropic/claude-sonnet-5",
+        "google/gemini-3.7-flash",
+        "deepseek/deepseek-v4-flash",
     ],
     "high": [
-        "openai/gpt-5.4",
-        "anthropic/claude-opus-4.8",
+        "openai/gpt-5.6-sol",
+        "anthropic/claude-opus-5",
         "google/gemini-3.1-pro-preview",
-        "deepseek/deepseek-v4-pro",
+        "deepseek/deepseek-v4-pro-0813",
     ],
     "reasoning": [
-        "openai/gpt-5.4-pro",
-        "anthropic/claude-opus-4.8",
+        "openai/gpt-5.6-sol-pro",
+        "anthropic/claude-opus-5",
         "google/gemini-3.1-pro-preview",
-        "deepseek/deepseek-r1",
+        "z-ai/glm-5.3",
     ],
     "frontier": [
-        "openai/gpt-5.5-pro",
-        "anthropic/claude-opus-4.8",
+        "anthropic/claude-fable-5",
+        "openai/gpt-5.6-sol-pro",
+        "x-ai/grok-4.6",
         "google/gemini-3.1-pro-preview",
-        "deepseek/deepseek-v4-pro",
     ],
 }
 
@@ -119,11 +122,11 @@ if TYPE_CHECKING:
 # Tier-appropriate aggregator models (ADR-022 council recommendation)
 # Warning: Do not use a "mini" model to aggregate reasoning model outputs.
 TIER_AGGREGATORS: Dict[str, str] = {
-    "quick": "openai/gpt-5-mini",  # Speed-matched
-    "balanced": "openai/gpt-5.4-mini",  # Quality-matched
-    "high": "openai/gpt-5.4",  # Full capability
-    "reasoning": "anthropic/claude-opus-4.8",  # Can understand reasoning outputs
-    "frontier": "anthropic/claude-opus-4.8",  # Best available for cutting-edge synthesis (ADR-027)
+    "quick": "openai/gpt-5.6-luna",  # Speed-matched
+    "balanced": "anthropic/claude-sonnet-5",  # Quality-matched
+    "high": "openai/gpt-5.6-sol",  # Full capability
+    "reasoning": "anthropic/claude-opus-5",  # Can understand reasoning outputs
+    "frontier": "anthropic/claude-opus-5",  # Best available for cutting-edge synthesis (ADR-027)
 }
 
 

--- a/src/llm_council/unified_config.py
+++ b/src/llm_council/unified_config.py
@@ -14,8 +14,8 @@ apart exactly, because UnifiedConfig and CouncilConfig field names are disjoint.
 This is the shape ``llm_council.yaml.example`` ships:
 
     council:
-      models: [openai/gpt-5.4, anthropic/claude-opus-4.8]
-      chairman: google/gemini-3.1-pro-preview
+      models: [openai/gpt-5.6-sol, anthropic/claude-opus-5]
+      chairman: anthropic/claude-opus-5
     tiers:
       default: high
     gateways:
@@ -29,7 +29,7 @@ is the shape this repo's own ``llm_council.yaml`` uses:
         default: high
         pools:
           quick:
-            models: [openai/gpt-5-mini, anthropic/claude-haiku-4.5]
+            models: [openai/gpt-5.6-luna, anthropic/claude-haiku-4.5]
             timeout_seconds: 30
       triage:
         enabled: false
@@ -199,51 +199,54 @@ class TierConfig(BaseModel):
     @model_validator(mode="after")
     def ensure_default_pools(self) -> "TierConfig":
         """Ensure all standard tier pools exist with defaults."""
+        # Aug-2026 model refresh (#635): IDs verified against the live
+        # OpenRouter catalog 2026-08-22. gemini-3.1-pro-preview is held
+        # deliberately — Google ships no Pro-class successor.
         default_pools = {
             "quick": TierPoolConfig(
                 models=[
-                    "openai/gpt-5-mini",
+                    "openai/gpt-5.6-luna",
                     "anthropic/claude-haiku-4.5",
-                    "google/gemini-3.1-flash-lite",
-                    "deepseek/deepseek-v3.2",
+                    "google/gemini-3.5-flash-lite",
+                    "deepseek/deepseek-v4-flash",
                 ],
                 timeout_seconds=30,
                 peer_review="lightweight",
             ),
             "balanced": TierPoolConfig(
                 models=[
-                    "openai/gpt-5.4-mini",
-                    "anthropic/claude-sonnet-4.6",
-                    "google/gemini-3.1-flash-lite",
-                    "deepseek/deepseek-v3.2",
+                    "openai/gpt-5.6-luna",
+                    "anthropic/claude-sonnet-5",
+                    "google/gemini-3.7-flash",
+                    "deepseek/deepseek-v4-flash",
                 ],
                 timeout_seconds=90,
             ),
             "high": TierPoolConfig(
                 models=[
-                    "openai/gpt-5.4",
-                    "anthropic/claude-opus-4.8",
+                    "openai/gpt-5.6-sol",
+                    "anthropic/claude-opus-5",
                     "google/gemini-3.1-pro-preview",
-                    "deepseek/deepseek-v4-pro",
+                    "deepseek/deepseek-v4-pro-0813",
                 ],
                 timeout_seconds=180,
             ),
             "reasoning": TierPoolConfig(
                 models=[
-                    "openai/gpt-5.4-pro",
-                    "anthropic/claude-opus-4.8",
+                    "openai/gpt-5.6-sol-pro",
+                    "anthropic/claude-opus-5",
                     "google/gemini-3.1-pro-preview",
-                    "deepseek/deepseek-r1",
+                    "z-ai/glm-5.3",
                 ],
                 timeout_seconds=600,
             ),
             # ADR-027: Frontier tier for cutting-edge/preview models
             "frontier": TierPoolConfig(
                 models=[
-                    "openai/gpt-5.5-pro",
-                    "anthropic/claude-opus-4.8",
+                    "anthropic/claude-fable-5",
+                    "openai/gpt-5.6-sol-pro",
+                    "x-ai/grok-4.6",
                     "google/gemini-3.1-pro-preview",
-                    "deepseek/deepseek-v4-pro",
                 ],
                 timeout_seconds=600,
             ),
@@ -750,15 +753,15 @@ class CouncilConfig(BaseModel):
 
     models: ModelList = Field(
         default_factory=lambda: [
-            "openai/gpt-5.4",
+            "openai/gpt-5.6-sol",
             "google/gemini-3.1-pro-preview",
-            "anthropic/claude-opus-4.8",
-            "deepseek/deepseek-v4-pro",
+            "anthropic/claude-opus-5",
+            "deepseek/deepseek-v4-pro-0813",
         ],
         alias="LLM_COUNCIL_MODELS",
     )
     chairman: str = Field(
-        default="google/gemini-3.1-pro-preview",
+        default="anthropic/claude-opus-5",
         alias="LLM_COUNCIL_CHAIRMAN",
     )
     chairman_disabled: bool = Field(
@@ -778,7 +781,7 @@ class CouncilConfig(BaseModel):
         alias="LLM_COUNCIL_STYLE_NORMALIZATION",
     )
     normalizer_model: str = Field(
-        default="google/gemini-3.1-flash-lite-preview",
+        default="google/gemini-3.5-flash-lite",
         alias="LLM_COUNCIL_NORMALIZER_MODEL",
     )
     max_reviewers: Optional[int] = Field(

--- a/tests/test_tier_contract.py
+++ b/tests/test_tier_contract.py
@@ -149,8 +149,8 @@ class TestTierAggregators:
         from llm_council.tier_contract import TIER_AGGREGATORS
 
         aggregator = TIER_AGGREGATORS["quick"]
-        # Should be a mini/flash model
-        assert any(fast in aggregator.lower() for fast in ["mini", "flash", "haiku"])
+        # Should be a mini/flash-class model (luna = GPT-5.6 cost-efficient line)
+        assert any(fast in aggregator.lower() for fast in ["mini", "flash", "haiku", "luna"])
 
     def test_balanced_tier_uses_mid_aggregator(self):
         """Balanced tier should use a mid-tier model for aggregation."""

--- a/tests/test_tier_model_pools.py
+++ b/tests/test_tier_model_pools.py
@@ -69,6 +69,29 @@ class TestDefaultTierModelPools:
             r in model_names for r in ["o1", "r1", "gpt-5"]
         ), "Reasoning tier should have reasoning model variants"
 
+    def test_default_pools_are_aug_2026_refresh(self):
+        """Default pools reflect the Aug-2026 model refresh (#635)."""
+        from llm_council.tier_contract import _DEFAULT_TIER_MODEL_POOLS, TIER_AGGREGATORS
+
+        assert _DEFAULT_TIER_MODEL_POOLS["high"] == [
+            "openai/gpt-5.6-sol",
+            "anthropic/claude-opus-5",
+            "google/gemini-3.1-pro-preview",
+            "deepseek/deepseek-v4-pro-0813",
+        ]
+        assert "z-ai/glm-5.3" in _DEFAULT_TIER_MODEL_POOLS["reasoning"]
+        assert "anthropic/claude-fable-5" in _DEFAULT_TIER_MODEL_POOLS["frontier"]
+        assert "x-ai/grok-4.6" in _DEFAULT_TIER_MODEL_POOLS["frontier"]
+        # gpt-5.5-pro exits (Pareto-dominated by the GPT-5.6 family)
+        assert "openai/gpt-5.5-pro" not in _DEFAULT_TIER_MODEL_POOLS["frontier"]
+        assert TIER_AGGREGATORS == {
+            "quick": "openai/gpt-5.6-luna",
+            "balanced": "anthropic/claude-sonnet-5",
+            "high": "openai/gpt-5.6-sol",
+            "reasoning": "anthropic/claude-opus-5",
+            "frontier": "anthropic/claude-opus-5",
+        }
+
     def test_high_tier_is_default_equivalent(self):
         """High tier should be similar to current default COUNCIL_MODELS."""
         from llm_council.tier_contract import _DEFAULT_TIER_MODEL_POOLS

--- a/tests/test_unified_config.py
+++ b/tests/test_unified_config.py
@@ -1435,13 +1435,13 @@ class TestCouncilConfig:
 
         config = CouncilConfig()
 
-        # Defaults from config.py
-        assert "openai/gpt-5.4" in config.models
-        assert config.chairman == "google/gemini-3.1-pro-preview"
+        # Defaults from config.py (Aug-2026 model refresh, #635)
+        assert "openai/gpt-5.6-sol" in config.models
+        assert config.chairman == "anthropic/claude-opus-5"
         assert config.synthesis_mode == "consensus"
         assert config.exclude_self_votes is True
         assert config.style_normalization is False
-        assert config.normalizer_model == "google/gemini-3.1-flash-lite-preview"
+        assert config.normalizer_model == "google/gemini-3.5-flash-lite"
         assert config.max_reviewers is None
 
     def test_council_config_model_list_from_comma(self):


### PR DESCRIPTION
## Summary

Implements the accepted **Council Model Refresh** research (#635; full report + acceptance in [discussion #636](https://github.com/amiable-dev/llm-council/discussions/636)). Every tier pool, the chairman, and all tier aggregators move to current-generation OpenRouter IDs, verified live against the catalog on 2026-08-22.

| Tier | Council | Aggregator |
|---|---|---|
| quick | gpt-5.6-luna, claude-haiku-4.5 *(kept)*, gemini-3.5-flash-lite, deepseek-v4-flash | gpt-5.6-luna |
| balanced | gpt-5.6-luna, claude-sonnet-5, gemini-3.7-flash, deepseek-v4-flash | claude-sonnet-5 |
| high | gpt-5.6-sol, claude-opus-5, gemini-3.1-pro-preview *(held)*, deepseek-v4-pro-0813 | gpt-5.6-sol |
| reasoning | gpt-5.6-sol-pro, claude-opus-5, gemini-3.1-pro-preview, z-ai/glm-5.3 | claude-opus-5 |
| frontier | claude-fable-5, gpt-5.6-sol-pro, x-ai/grok-4.6, gemini-3.1-pro-preview | claude-opus-5 |

**Chairman:** `google/gemini-3.1-pro-preview` → `anthropic/claude-opus-5` (same-price generational upgrade over opus-4.8; activates the ADR-049 Anthropic prompt-cache breakpoints on chairman calls — `claude-opus-5` added to the cache min-prefix map at the Opus-class 1024).

## Changes

- `tier_contract.py` — `_DEFAULT_TIER_MODEL_POOLS` + `TIER_AGGREGATORS`
- `unified_config.py` — default pools, `CouncilConfig.models`/`chairman`, `normalizer_model` (stale preview lite → stable `gemini-3.5-flash-lite`), docstring examples
- `cache_context.py` — `claude-opus-5: 1024` min-prefix entry
- `models/registry.yaml` — v1.4: 12 new models (61 total, 10 providers incl. new xAI and Z.ai sections), cache-read price classes on new entries, full ADR-049 D3 write classes on Anthropic entries
- `llm_council.yaml` + `.example` — refreshed pools
- Tests: default pins updated (TDD red→green); new `test_default_pools_are_aug_2026_refresh` pins the refreshed pools + aggregators; quick-aggregator heuristic extended for the Luna line
- `CHANGELOG.md` (Unreleased), `CLAUDE.md` registry note

## Notes for reviewers

- **Migration:** none — `LLM_COUNCIL_MODELS` / `LLM_COUNCIL_CHAIRMAN` / YAML overrides keep working, and prior-generation IDs remain valid on OpenRouter.
- New-family seats (grok-4.6 frontier, glm-5.3 reasoning) enter via ADR-029 shadow audition per the accepted research; GLM-5.3's benchmark placement is deliberately unclaimed (refuted 0–3 in verification).
- `gemini-3.7-flash` is priced at the standard $0.75/$3.75 rate, not the promo ending 2026-08-27.
- Full fast suite: 3717 passed; the one failure (`test_real_chairman_payloads_now_parse`) is environmental (replays local `.council/logs`, empty in this worktree; auto-skips in CI). mypy's 98 errors pre-exist on master (CI Type Check is non-blocking).

Closes #635. Follow-ups: #637, #638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1sSV9YoaFE8F35vXMUY7S