### PR TITLE
Release v0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.45.0] - 2026-08-22
+
+**The Aug-2026 council model refresh.** One change, every tier: the default councils, chairman, and aggregators move to current-generation OpenRouter models per the accepted research in [discussion #636](https://github.com/amiable-dev/llm-council/discussions/636) (tracking: [#635](https://github.com/amiable-dev/llm-council/issues/635)).
 
 ### Changed
 

--- a/server-card.json
+++ b/server-card.json
@@ -3,7 +3,7 @@
   "name": "io.github.amiable-dev/llm-council",
   "title": "LLM Council",
   "description": "Multi-model deliberation council with anonymized peer review, exposed as MCP tools.",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "websiteUrl": "https://github.com/amiable-dev/llm-council",
   "repository": {
     "source": "github",


### PR DESCRIPTION
## Release v0.45.0

**The Aug-2026 council model refresh** (minor release — new default behavior, no breaking API changes).

- Promotes the Unreleased CHANGELOG entry to `[0.45.0] - 2026-08-22`: default councils, chairman, and aggregators for every tier move to current-generation OpenRouter models (#635, implemented in #639, research in discussion #636).
- Regenerates the `server-card.json` version stamp to 0.45.0 (content verified identical to the live tool registry apart from the version field).

After merge: tag `v0.45.0` from master → `publish.yml` builds and publishes to PyPI; GitHub Release backfilled via `gh release create`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1sSV9YoaFE8F35vXMUY7S