### PR TITLE
docs(security): record CVE-2026-77304 for GHSA-fpxw-qr53-pxfp

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 
 > [!WARNING]
-> **Security advisory (2026-07-10) — upgrade to `>= 0.39.0`.** Versions `0.22.0`–`0.38.2` could transmit credential files (`.env`, `.npmrc`, `.yarnrc`, …) **that were committed to your git repository** to your configured LLM provider during `verify` / `gate` runs. Untracked and `.gitignore`d files were never affected. If you committed credentials and ran a verification over a commit touching them, **rotate those credentials**. See [GHSA-fpxw-qr53-pxfp](https://github.com/amiable-dev/llm-council/security/advisories/GHSA-fpxw-qr53-pxfp).
+> **Security advisory (2026-07-10) — upgrade to `>= 0.39.0`.** Versions `0.22.0`–`0.38.2` could transmit credential files (`.env`, `.npmrc`, `.yarnrc`, …) **that were committed to your git repository** to your configured LLM provider during `verify` / `gate` runs. Untracked and `.gitignore`d files were never affected. If you committed credentials and ran a verification over a commit touching them, **rotate those credentials**. See [GHSA-fpxw-qr53-pxfp / CVE-2026-77304](https://github.com/amiable-dev/llm-council/security/advisories/GHSA-fpxw-qr53-pxfp).
 
 ## What is This?
 

--- a/docs/security/advisory-draft-verify-secret-transmission.md
+++ b/docs/security/advisory-draft-verify-secret-transmission.md
@@ -1,7 +1,7 @@
 # GitHub Security Advisory (record): verify() transmits committed credential files to third-party LLM providers
 
 > **Status: PUBLISHED 2026-07-10.** [GHSA-fpxw-qr53-pxfp](https://github.com/amiable-dev/llm-council/security/advisories/GHSA-fpxw-qr53-pxfp)
-> — CVE **pending** (GitHub CNA review; the advisory records the CVE id once assigned).
+> — CVE **CVE-2026-77304**.
 >
 > This file is the repo-side record of the advisory. The **Form fields** below map
 > to the discrete GHSA form inputs; the **Description** section is verbatim the


### PR DESCRIPTION
## Summary

- GitHub assigned **CVE-2026-77304** to [GHSA-fpxw-qr53-pxfp](https://github.com/amiable-dev/llm-council/security/advisories/GHSA-fpxw-qr53-pxfp) (the `verify()` committed-credential-transmission advisory, fixed in v0.39.0). The re-submitted request (2026-08-20, following the original request's stall) resolved.
- Replaces the `CVE **pending**` header note in `docs/security/advisory-draft-verify-secret-transmission.md` with the assigned id.
- Appends the CVE id to the GHSA link text in the README security notice.
- No other content changed.

Related: #551, #546

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqoVH1PKcaDms9wyVLaGsq)_