### PR TITLE
feat(ci): auto-create GitHub Release and announce on Discord after publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,17 +78,17 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
-
+      # No checkout needed: gh targets the repo directly via --repo, which
+      # also avoids pulling third-party actions into this privileged job.
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${GITHUB_REF_NAME}"
-          if gh release view "$TAG" >/dev/null 2>&1; then
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "Release $TAG already exists, skipping creation"
           else
-            gh release create "$TAG" --verify-tag --generate-notes
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --verify-tag --generate-notes
           fi
 
       # Soft-fail by design: a Discord outage or unset webhook secret must

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,3 +70,47 @@ jobs:
       
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  announce:
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping creation"
+          else
+            gh release create "$TAG" --verify-tag --generate-notes
+          fi
+
+      # Soft-fail by design: a Discord outage or unset webhook secret must
+      # never turn a successful PyPI publish red.
+      - name: Announce on Discord
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASES_WEBHOOK }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_RELEASES_WEBHOOK not configured, skipping announcement"
+            exit 0
+          fi
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          curl -sf -H "Content-Type: application/json" -d "$(jq -n \
+            --arg tag "$TAG" \
+            --arg version "$VERSION" \
+            --arg repo "${{ github.repository }}" \
+            '{embeds: [{
+              title: "LLM Council \($tag) released",
+              url: "https://github.com/\($repo)/releases/tag/\($tag)",
+              description: "Now on PyPI: `pip install llm-council-core==\($version)`\n\n[Release notes](https://github.com/\($repo)/releases/tag/\($tag)) · [Changelog](https://github.com/\($repo)/blob/master/CHANGELOG.md)",
+              color: 5793266
+            }]}')" "$DISCORD_WEBHOOK_URL"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,8 +191,8 @@ The flow is async/parallel wherever possible to minimize latency.
 5. Open PR: `gh pr create --title "Release v0.X.0" --body "…"`.
 6. Wait for required checks: **Test, Lint, Type Check, DCO** (DCO needs `--signoff`). Do not merge until green.
 7. `gh pr merge --squash --delete-branch`.
-8. **After merge**, tag from updated master: `git tag -a v0.X.0 -m "…" && git push origin v0.X.0` — this triggers `publish.yml` (build → test wheel → publish to PyPI).
-9. Verify: `gh run list --workflow=publish.yml --limit=1`, then `pip index versions llm-council-core`.
+8. **After merge**, tag from updated master: `git tag -a v0.X.0 -m "…" && git push origin v0.X.0` — this triggers `publish.yml` (build → test wheel → publish to PyPI → announce: auto-creates the GitHub Release with `--generate-notes` and posts a Discord embed via `DISCORD_RELEASES_WEBHOOK` secret; both idempotent/soft-fail, #644).
+9. Verify: `gh run list --workflow=publish.yml --limit=1`, then `pip index versions llm-council-core`. The GitHub Release no longer needs manual backfill (announce job creates it).
 
 **Versioning:** git tags via `hatch-vcs`/setuptools-scm; `src/llm_council/_version.py` is auto-generated + gitignored. SemVer (MAJOR breaking / MINOR feature / PATCH fix).
 


### PR DESCRIPTION
Closes #644

## What

Adds an `announce` job to `.github/workflows/publish.yml`, running after the PyPI `publish` job succeeds (tag pushes only):

1. **Create GitHub Release** — `gh release create "$TAG" --verify-tag --generate-notes`, idempotent (skips if the release already exists). `contents: write` is scoped to this job only; the build/publish jobs keep their minimal permissions. Closes the manual `gh release create` backfill gap.
2. **Announce on Discord** — posts an embed (version, release-notes link, `pip install llm-council-core==X.Y.Z`) to the `DISCORD_RELEASES_WEBHOOK` secret via `curl`. No third-party action, no bot. Soft-fail by design: unset secret ⇒ step skips cleanly; `continue-on-error: true` ⇒ a Discord outage never turns a successful publish red.

Also updates the CLAUDE.md Release Workflow note (steps 8–9) to reflect the automation.

## Enablement (manual, once — repo admin)

- Discord: Server Settings → Integrations → Webhooks → New Webhook → bind to the target channel; copy the URL.
- GitHub: `gh secret set DISCORD_RELEASES_WEBHOOK` with that URL.

Until the secret is set, the announce step is a no-op and the workflow stays green.

## Testing

- YAML validated locally (`yaml.safe_load`).
- Behavior is tag-gated (`if: startsWith(github.ref, 'refs/tags/')`) — full end-to-end exercise happens on the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1sSV9YoaFE8F35vXMUY7S