### PR TITLE
feat(ci): create releases with RELEASE_PAT so release-security.yml fires

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,9 +80,14 @@ jobs:
     steps:
       # No checkout needed: gh targets the repo directly via --repo, which
       # also avoids pulling third-party actions into this privileged job.
+      # RELEASE_PAT (fine-grained, Contents: read+write on this repo, #646):
+      # releases created with the default GITHUB_TOKEN don't emit workflow
+      # triggers, so release-security.yml (SBOM + provenance) never fires.
+      # A PAT-authored release does. Falls back to github.token when the
+      # secret is unset/expired — release creation must never block publish.
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
         run: |
           TAG="${GITHUB_REF_NAME}"
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ The flow is async/parallel wherever possible to minimize latency.
 5. Open PR: `gh pr create --title "Release v0.X.0" --body "…"`.
 6. Wait for required checks: **Test, Lint, Type Check, DCO** (DCO needs `--signoff`). Do not merge until green.
 7. `gh pr merge --squash --delete-branch`.
-8. **After merge**, tag from updated master: `git tag -a v0.X.0 -m "…" && git push origin v0.X.0` — this triggers `publish.yml` (build → test wheel → publish to PyPI → announce: auto-creates the GitHub Release with `--generate-notes` and posts a Discord embed via `DISCORD_RELEASES_WEBHOOK` secret; both idempotent/soft-fail, #644).
+8. **After merge**, tag from updated master: `git tag -a v0.X.0 -m "…" && git push origin v0.X.0` — this triggers `publish.yml` (build → test wheel → publish to PyPI → announce: auto-creates the GitHub Release with `--generate-notes` and posts a Discord embed via `DISCORD_RELEASES_WEBHOOK` secret; both idempotent/soft-fail, #644). Release creation authenticates with the `RELEASE_PAT` secret (fine-grained PAT, Contents: read+write) so the `release: published` event triggers `release-security.yml` (SBOM + SLSA provenance, #646) — default-token releases don't emit workflow triggers; falls back to `github.token` (release still created, SBOM skipped) when the PAT is unset/expired, so **rotate the PAT before it expires**.
 9. Verify: `gh run list --workflow=publish.yml --limit=1`, then `pip index versions llm-council-core`. The GitHub Release no longer needs manual backfill (announce job creates it).
 
 **Versioning:** git tags via `hatch-vcs`/setuptools-scm; `src/llm_council/_version.py` is auto-generated + gitignored. SemVer (MAJOR breaking / MINOR feature / PATCH fix).


### PR DESCRIPTION
Closes #646 (option A)

## What

One-line behavior change in the `announce` job of `publish.yml`:

```yaml
GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
```

Releases created with the default `GITHUB_TOKEN` don't emit workflow triggers (GitHub's recursion guard), so auto-created releases from #645 never fired `release-security.yml` — no SBOM, no SLSA provenance. A release authored via a fine-grained PAT emits `release: published` normally, restoring the full chain: tag → PyPI → GitHub Release → SBOM attach + provenance attestation → Discord.

**Fallback by design:** when `RELEASE_PAT` is unset or expired, the expression falls back to `github.token` — the release is still created (SBOM skipped), so a lapsed PAT can never block a publish. Also updates the CLAUDE.md release-workflow note (incl. PAT rotation reminder).

## Enablement (manual, once — before next tag)

1. Create a fine-grained PAT: GitHub → Settings → Developer settings → Fine-grained tokens → Generate new token; **Repository access:** only `amiable-dev/llm-council`; **Permissions:** Contents → Read and write; expiry per preference (1 year suggested — set a rotation reminder).
2. `gh secret set RELEASE_PAT --repo amiable-dev/llm-council` and paste the token.

Merging without the secret is safe (fallback path = current behavior).

## Testing

- YAML validated locally.
- Tag-gated; end-to-end proof is the next `v*` tag: check the release for the `llm-council-vX.Y.Z-sbom.json` asset and a green `Release Security` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1sSV9YoaFE8F35vXMUY7S