### PR TITLE
fix(security): remediate open code-scanning alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 5
     groups:
       dev-dependencies:
         patterns:
@@ -36,6 +38,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 5
     labels:
       - "dependencies"
       - "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     cooldown:
-      default-days: 5
+      default-days: 7
     groups:
       dev-dependencies:
         patterns:
@@ -39,7 +39,7 @@ updates:
       interval: "weekly"
       day: "monday"
     cooldown:
-      default-days: 5
+      default-days: 7
     labels:
       - "dependencies"
       - "ci"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,9 @@ on:
     - cron: "17 3 * * *"  # 03:17 UTC nightly
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   bench:
     runs-on: ubuntu-latest
@@ -17,12 +20,12 @@ jobs:
       LLM_COUNCIL_BENCH_MAX_USD: "2.00"
       LLM_COUNCIL_BENCH_MONTHLY_USD: "30.00"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
       - name: Restore bench spend ledger
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: .council/bench/runs
           key: bench-runs-${{ github.run_id }}
@@ -32,7 +35,7 @@ jobs:
         run: llm-council bench run --format md | tee bench-report.md
       - name: Upload report + run artefact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: bench-report
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.12"
 
@@ -14,15 +17,15 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
 
       - name: Install dependencies
         run: |
@@ -33,7 +36,7 @@ jobs:
           pytest tests/ -v --cov=src --cov-report=xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac  # v5
         if: github.event_name == 'push'
         with:
           files: coverage.xml
@@ -43,10 +46,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -60,10 +63,10 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/council-gate.yml
+++ b/.github/workflows/council-gate.yml
@@ -21,6 +21,10 @@ concurrency:
   group: council-gate-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default; the job below elevates only the scopes it needs.
+permissions:
+  contents: read
+
 jobs:
   quality-gate:
     runs-on: ubuntu-latest
@@ -32,7 +36,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
         with:
           fetch-depth: 0  # Need full history for diff
 
@@ -49,7 +53,7 @@ jobs:
       - name: LLM Council Quality Gate
         if: steps.check-key.outputs.has_key == 'true'
         id: council
-        uses: amiable-dev/llm-council-action@v1
+        uses: amiable-dev/llm-council-action@214ec367341a41e7449b7fc69f294dfa7082f9cf  # v1
         with:
           snapshot: ${{ github.sha }}
           confidence-threshold: ${{ github.event.inputs.confidence-threshold || '0.75' }}
@@ -59,11 +63,18 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && steps.check-key.outputs.has_key == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
+        env:
+          COUNCIL_VERDICT: ${{ steps.council.outputs.verdict }}
+          COUNCIL_CONFIDENCE: ${{ steps.council.outputs.confidence }}
+          CONFIDENCE_THRESHOLD: ${{ github.event.inputs.confidence-threshold || '0.75' }}
+          COMMIT_SHA: ${{ github.sha }}
         with:
           script: |
-            const verdict = '${{ steps.council.outputs.verdict }}';
-            const confidence = '${{ steps.council.outputs.confidence }}';
+            const verdict = process.env.COUNCIL_VERDICT || '';
+            const confidence = process.env.COUNCIL_CONFIDENCE || '';
+            const threshold = process.env.CONFIDENCE_THRESHOLD;
+            const sha = process.env.COMMIT_SHA;
 
             const emoji = verdict === 'PASS' ? '✅' : verdict === 'FAIL' ? '❌' : '⚠️';
             const status = verdict || 'UNKNOWN';
@@ -71,8 +82,8 @@ jobs:
             const body = `## ${emoji} LLM Council Quality Gate: ${status}
 
             **Confidence Score:** ${confidence}
-            **Threshold:** ${{ github.event.inputs.confidence-threshold || '0.75' }}
-            **Snapshot:** \`${{ github.sha }}\`
+            **Threshold:** ${threshold}
+            **Snapshot:** \`${sha}\`
 
             ---
             *Evaluated by [LLM Council](https://github.com/amiable-dev/llm-council) using [llm-council-action](https://github.com/amiable-dev/llm-council-action)*`;

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,15 +22,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
         with:
           fetch-depth: 0  # For git-revision-date plugin if used
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.12'
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
 
       - name: Install dependencies
         run: uv pip install --system mkdocs-material mkdocs
@@ -39,7 +39,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           path: site/
 
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,21 +14,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.12'
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
       
       - name: Build package
         run: uv build
       
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: dist
           path: dist/
@@ -37,15 +37,15 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.12'
       
       - name: Download build artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
         with:
           name: dist
           path: dist/
@@ -63,10 +63,10 @@ jobs:
       url: https://pypi.org/project/llm-council-mcp/
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
         with:
           name: dist
           path: dist/
       
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1

--- a/.github/workflows/release-security.yml
+++ b/.github/workflows/release-security.yml
@@ -8,27 +8,28 @@ on:
   release:
     types: [published]
 
+# Least-privilege default; jobs below elevate only the scopes they need.
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
   sbom-attach:
     name: Attach SBOM to Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # to attach the SBOM to the release
     outputs:
       sbom-file: ${{ steps.sbom.outputs.filename }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
 
       - name: Install dependencies
         run: |
@@ -36,20 +37,22 @@ jobs:
 
       - name: Generate SBOM
         id: sbom
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           pip install cyclonedx-bom==4.6.0
-          SBOM_FILE="llm-council-${{ github.ref_name }}-sbom.json"
+          SBOM_FILE="llm-council-${REF_NAME}-sbom.json"
           cyclonedx-py environment -o "$SBOM_FILE" --output-format JSON
           echo "filename=$SBOM_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: sbom
           path: ${{ steps.sbom.outputs.filename }}
 
       - name: Attach SBOM to release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3
         with:
           files: ${{ steps.sbom.outputs.filename }}
 
@@ -59,14 +62,18 @@ jobs:
     name: Generate SLSA Provenance
     needs: sbom-attach
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - name: Download SBOM artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
         with:
           name: sbom
 
       - name: Generate SLSA provenance attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2
         with:
           subject-path: ${{ needs.sbom-attach.outputs.sbom-file }}
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
         with:
           persist-credentials: false
 
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46  # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
@@ -42,13 +42,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,11 +13,9 @@ on:
     # Run weekly on Monday at 9am UTC
     - cron: '0 9 * * 1'
 
+# Least-privilege default; jobs below elevate only the scopes they need.
 permissions:
   contents: read
-  security-events: write
-  actions: read
-  pull-requests: read  # Required for dependency review
 
 jobs:
   # ============================================================
@@ -29,11 +27,15 @@ jobs:
   codeql:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4
         with:
           languages: python
           # ADR-035: Use security-extended, not security-and-quality
@@ -41,17 +43,20 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4
         with:
           category: "/language:python"
 
   semgrep:
     name: Semgrep SAST
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     container:
       image: semgrep/semgrep:1.96.0  # Pinned version
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       # Semgrep for custom rules and fast pattern matching
       # CodeQL handles deep semantic analysis (avoid duplicates)
@@ -59,7 +64,7 @@ jobs:
         run: semgrep scan --config auto --config .semgrep/ --sarif --output semgrep.sarif . || true
 
       - name: Upload Semgrep results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4
         if: always()
         with:
           sarif_file: semgrep.sarif
@@ -68,12 +73,12 @@ jobs:
     name: Secret Detection
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
         with:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2.3.7  # Pinned version
+        uses: gitleaks/gitleaks-action@83373cf2f8c4db6e24b41c1a9b086bb9619e9cd3  # v2.3.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -81,11 +86,14 @@ jobs:
     name: Dependency Review
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read  # Required for dependency review
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4
         with:
           # Use config file for license rules (allows build-time action exceptions)
           config-file: ./.github/dependency-review-config.yml
@@ -99,8 +107,11 @@ jobs:
     name: Trivy Dependency Scan
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      contents: read
+      security-events: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       - name: Run Trivy vulnerability scanner
         # Pinned to commit SHA following the March 2026 trivy-action supply chain
@@ -115,7 +126,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM'
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
@@ -125,12 +136,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
         with:
           fetch-depth: 0
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v7
+        uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2  # v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
@@ -139,15 +150,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
 
       - name: Install dependencies
         run: |
@@ -158,7 +169,7 @@ jobs:
           pip freeze > requirements.txt
 
       - name: Run Snyk to monitor
-        uses: snyk/actions/python@0.4.0  # Pinned version
+        uses: snyk/actions/python@b98d498629f1c368650224d6d212bf7dfa89e4bf  # 0.4.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -170,15 +181,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
 
       - name: Install dependencies
         run: |
@@ -190,7 +201,7 @@ jobs:
           cyclonedx-py environment -o sbom.json --output-format JSON
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: sbom
           path: sbom.json

--- a/.github/workflows/sync-action.yml
+++ b/.github/workflows/sync-action.yml
@@ -13,6 +13,10 @@ on:
         description: 'Version to sync (e.g., 0.24.5)'
         required: true
 
+# Least-privilege default; the job below elevates only the scopes it needs.
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -22,26 +26,30 @@ jobs:
     steps:
       - name: Determine version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$DISPATCH_VERSION"
           else
-            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="$RELEASE_TAG"
             VERSION="${VERSION#v}"  # Remove 'v' prefix if present
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Syncing version: $VERSION"
 
       - name: Checkout action repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
         with:
           repository: amiable-dev/llm-council-action
           token: ${{ secrets.ACTION_REPO_PAT }}
 
       - name: Update action.yml version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
           # Update default version in action.yml
           sed -i "s/default: '[0-9]\+\.[0-9]\+\.[0-9]\+'/default: '$VERSION'/" action.yml
 
@@ -49,9 +57,9 @@ jobs:
           grep -A1 "version:" action.yml | head -4
 
       - name: Create sync commit
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -66,9 +74,9 @@ jobs:
           git push origin main
 
       - name: Update v1 tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
           # Delete and recreate v1 tag to point to latest
           git tag -d v1 2>/dev/null || true
           git push origin :refs/tags/v1 2>/dev/null || true

--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -20,13 +20,16 @@ on:
       - 'render.yaml'
       - 'docker-compose.yml'
 
+permissions:
+  contents: read
+
 jobs:
   validate-configs:
     name: Validate Configuration Files
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       - name: Validate railway.json
         run: |
@@ -51,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
         with:
           fetch-depth: 0  # Fetch all history for git describe
 
@@ -68,10 +71,10 @@ jobs:
           echo "Raw: ${RAW_VERSION} -> PEP 440: ${VERSION}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4
 
       - name: Build Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: deploy/railway/Dockerfile
@@ -88,7 +91,7 @@ jobs:
     needs: build-docker
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
         with:
           fetch-depth: 0  # Fetch all history for git describe
 

--- a/deploy/railway/Dockerfile
+++ b/deploy/railway/Dockerfile
@@ -4,7 +4,7 @@
 # Build: docker build -f deploy/railway/Dockerfile -t llm-council .
 # Run:   docker run -p 8000:8000 -e OPENROUTER_API_KEY=sk-... -e LLM_COUNCIL_API_TOKEN=... llm-council
 
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:9c900dea9e8fb7e16277c179b555cc72d29a352dbc33cff48ad5a0412fd5bfc7
 
 # Set working directory
 WORKDIR /app

--- a/src/llm_council/budget/estimator.py
+++ b/src/llm_council/budget/estimator.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 from typing import Any, List, Optional
 
+from ..log_safety import safe_log
 from .types import CostEstimate
 
 logger = logging.getLogger(__name__)
@@ -53,7 +54,11 @@ class CostEstimator:
             except Exception as exc:
                 # Estimation is best-effort; a tracker failure must not crash it,
                 # but it is logged rather than silently swallowed.
-                logger.debug("cost estimate: %r lookup failed (ignored): %s", model_id, exc)
+                logger.debug(
+                    "cost estimate: %r lookup failed (ignored): %s",
+                    safe_log(model_id),
+                    safe_log(exc),
+                )
                 mean_cost = None
             # A known $0 (free/local) contributes 0 but is NOT "unknown".
             # Clamp defensively: a cost must never be negative.

--- a/src/llm_council/gateway/openrouter.py
+++ b/src/llm_council/gateway/openrouter.py
@@ -16,6 +16,7 @@ from typing import AsyncIterator, Dict, Any, List, Optional
 import httpx
 
 # ADR-032: Migrated to unified_config
+from llm_council.log_safety import safe_log
 from llm_council.unified_config import get_api_key
 
 # ADR-011: per-gateway cost resolution. OpenRouter returns authoritative cost,
@@ -146,7 +147,7 @@ def build_openrouter_payload(
         # anomaly we want the known-good baseline, not a partial mode).
         logging.getLogger(__name__).debug(
             "prompt-cache injection failed for %s; reverting to plain payload",
-            model,
+            safe_log(model),
             exc_info=True,
         )
         payload["messages"] = messages

--- a/src/llm_council/layer_contracts.py
+++ b/src/llm_council/layer_contracts.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, Optional
 import logging
 
 # Re-export layer interface types
+from .log_safety import safe_log
 from .tier_contract import TierContract, create_tier_contract
 from .triage.types import TriageResult, TriageRequest, DomainCategory, WildcardConfig
 from .gateway.types import (
@@ -200,8 +201,8 @@ def emit_layer_event(
     logger.info(
         "Layer event: %s from=%s to=%s data=%s",
         event_type.value,
-        layer_from,
-        layer_to,
+        safe_log(layer_from),
+        safe_log(layer_to),
         data,
     )
 

--- a/src/llm_council/log_safety.py
+++ b/src/llm_council/log_safety.py
@@ -1,0 +1,11 @@
+"""Sanitize external strings before they are interpolated into log messages.
+
+CWE-117: a value containing CR/LF can forge additional log lines when logged
+verbatim (file paths, subprocess stderr, model identifiers, and exception text
+can all carry them if the underlying content is attacker-influenced).
+"""
+
+
+def safe_log(value: object) -> str:
+    """Return `value` as a string with CR/LF collapsed, safe to log verbatim."""
+    return str(value).replace("\r\n", " ").replace("\r", " ").replace("\n", " ")

--- a/src/llm_council/metadata/discovery.py
+++ b/src/llm_council/metadata/discovery.py
@@ -20,6 +20,7 @@ Example:
 import logging
 from typing import TYPE_CHECKING, List, Optional, Set
 
+from ..log_safety import safe_log
 from .types import ModelInfo, QualityTier
 
 if TYPE_CHECKING:
@@ -257,8 +258,10 @@ def discover_tier_candidates(
     # 2. Static fallback (only if registry empty/insufficient)
     if len(candidates) < MIN_CANDIDATES_PER_TIER:
         logger.warning(
-            f"Insufficient dynamic candidates for tier {tier}: "
-            f"{len(candidates)} < {MIN_CANDIDATES_PER_TIER}. Using static fallback."
+            "Insufficient dynamic candidates for tier %s: %d < %d. Using static fallback.",
+            safe_log(tier),
+            len(candidates),
+            MIN_CANDIDATES_PER_TIER,
         )
 
         static = _get_static_fallback(tier)

--- a/src/llm_council/openrouter.py
+++ b/src/llm_council/openrouter.py
@@ -10,6 +10,7 @@ import time
 from typing import TYPE_CHECKING, List, Dict, Any, Optional, Callable, Awaitable
 
 # ADR-032: Migrated to unified_config
+from llm_council.log_safety import safe_log
 from llm_council.unified_config import get_api_key
 
 from llm_council.gateway.resolver import resolve_endpoint, resolve_model_name
@@ -252,7 +253,7 @@ async def query_model_with_status(
         # collapse failures to None) and #403 (distinguish infra from defect);
         # an empty detail defeats both.
         detail = f"{type(e).__name__}: {e}" if str(e) else type(e).__name__
-        logger.warning("Error querying model %s: %s", model, detail)
+        logger.warning("Error querying model %s: %s", safe_log(model), safe_log(detail))
         return {
             "status": STATUS_ERROR,
             "latency_ms": latency_ms,

--- a/src/llm_council/verification/api.py
+++ b/src/llm_council/verification/api.py
@@ -939,8 +939,9 @@ async def run_verification(
         # sequence id (hash of the target paths) — never the per-round SHA,
         # which would defeat the affinity it exists to provide. Cleared in
         # the finally below; consumers no-op when the context is absent.
-        subject_key = hashlib.sha1(
-            "\n".join(sorted(request.target_paths or ["<repo>"])).encode()
+        subject_key = hashlib.sha1(  # noqa: S324 — cache-affinity key, not a security use
+            "\n".join(sorted(request.target_paths or ["<repo>"])).encode(),
+            usedforsecurity=False,
         ).hexdigest()[:12]
         set_cache_context(
             CacheContext(

--- a/src/llm_council/verification/file_ops.py
+++ b/src/llm_council/verification/file_ops.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from ..log_safety import safe_log
 from .constants import (
     ASYNC_SUBPROCESS_TIMEOUT,
     GARBAGE_FILENAMES,
@@ -172,15 +173,17 @@ async def _get_git_object_type(snapshot_id: str, path: str) -> Optional[str]:
             stderr_text = stderr.decode("utf-8", errors="replace").strip()
             logger.warning(
                 "git cat-file failed for %s:%s (rc=%s): %s",
-                snapshot_id,
-                path,
+                safe_log(snapshot_id),
+                safe_log(path),
                 proc.returncode,
-                stderr_text or "<no stderr>",
+                safe_log(stderr_text) or "<no stderr>",
             )
         except Exception as e:
             # Issue #340: log the exception so subprocess failures are
             # diagnosable (timeouts, missing git binary, etc).
-            logger.warning("git cat-file raised for %s:%s: %s", snapshot_id, path, e)
+            logger.warning(
+                "git cat-file raised for %s:%s: %s", safe_log(snapshot_id), safe_log(path), e
+            )
 
     return None
 
@@ -228,10 +231,10 @@ async def _git_ls_tree_z_name_only(snapshot_id: str, tree_path: str) -> List[str
                 stderr_text = stderr.decode("utf-8", errors="replace").strip()
                 logger.warning(
                     "git ls-tree failed for %s:%s (rc=%s): %s",
-                    snapshot_id,
-                    tree_path,
+                    safe_log(snapshot_id),
+                    safe_log(tree_path),
                     proc.returncode,
-                    stderr_text or "<no stderr>",
+                    safe_log(stderr_text) or "<no stderr>",
                 )
                 return []
 
@@ -273,7 +276,9 @@ async def _git_ls_tree_z_name_only(snapshot_id: str, tree_path: str) -> List[str
 
         except Exception as e:
             # Issue #340: log so subprocess/timeout failures are diagnosable.
-            logger.warning("git ls-tree raised for %s:%s: %s", snapshot_id, tree_path, e)
+            logger.warning(
+                "git ls-tree raised for %s:%s: %s", safe_log(snapshot_id), safe_log(tree_path), e
+            )
             return []
 
 
@@ -1070,8 +1075,8 @@ async def _fetch_file_at_commit_async(
                     "git show for %s:%s produced all stdout but did not exit "
                     "within %ss — likely blocked writing to an unread stderr "
                     "pipe (LFS/submodule/CRLF chatter); force-killed",
-                    snapshot_id,
-                    file_path,
+                    safe_log(snapshot_id),
+                    safe_log(file_path),
                     ASYNC_SUBPROCESS_TIMEOUT,
                 )
                 proc.kill()

--- a/tests/test_security_workflows.py
+++ b/tests/test_security_workflows.py
@@ -265,12 +265,18 @@ class TestReleaseSecurityWorkflow:
         assert "sbom-attach" in jobs, "Workflow should have SBOM attachment job"
 
     def test_release_security_has_proper_permissions(self, workflow_config: dict):
-        """Verify workflow has required permissions for release attachment."""
-        permissions = workflow_config.get("permissions", {})
-        # Need write access to attach files to releases
+        """Verify the sbom-attach job has contents: write to attach files to releases.
+
+        Scoped to the job (not the workflow top level) per OSSF Scorecard's
+        least-privilege guidance: the top level defaults to contents: read and
+        only the job that needs elevated access declares it.
+        """
+        jobs = workflow_config.get("jobs", {})
+        sbom_job = jobs.get("sbom-attach", {})
+        permissions = sbom_job.get("permissions", {})
         assert (
             permissions.get("contents") == "write"
-        ), "Workflow needs contents: write to attach files to releases"
+        ), "sbom-attach job needs contents: write to attach files to releases"
 
     def test_release_security_has_provenance_job(self, workflow_config: dict):
         """Verify workflow has SLSA provenance generation job."""
@@ -293,18 +299,30 @@ class TestReleaseSecurityWorkflow:
         assert attest_step is not None, "Should use actions/attest-build-provenance"
 
     def test_release_security_has_attestations_permission(self, workflow_config: dict):
-        """Verify workflow has attestations: write for SLSA provenance."""
-        permissions = workflow_config.get("permissions", {})
+        """Verify the provenance job has attestations: write for SLSA provenance.
+
+        Scoped to the job (not the workflow top level) per OSSF Scorecard's
+        least-privilege guidance.
+        """
+        jobs = workflow_config.get("jobs", {})
+        provenance = jobs.get("provenance", {})
+        permissions = provenance.get("permissions", {})
         assert (
             permissions.get("attestations") == "write"
-        ), "Workflow needs attestations: write for SLSA provenance"
+        ), "provenance job needs attestations: write for SLSA provenance"
 
     def test_release_security_has_id_token_permission(self, workflow_config: dict):
-        """Verify workflow has id-token: write for Sigstore signing."""
-        permissions = workflow_config.get("permissions", {})
+        """Verify the provenance job has id-token: write for Sigstore signing.
+
+        Scoped to the job (not the workflow top level) per OSSF Scorecard's
+        least-privilege guidance.
+        """
+        jobs = workflow_config.get("jobs", {})
+        provenance = jobs.get("provenance", {})
+        permissions = provenance.get("permissions", {})
         assert (
             permissions.get("id-token") == "write"
-        ), "Workflow needs id-token: write for Sigstore OIDC signing"
+        ), "provenance job needs id-token: write for Sigstore OIDC signing"
 
     def test_release_security_sbom_uses_correct_format_flag(self, workflow_config: dict):
         """Verify SBOM generation uses --output-format (not --format)."""


### PR DESCRIPTION
## Summary
- Sanitize CR/LF in log arguments before interpolation (`py/log-injection`, 10 sites) via a new `log_safety.safe_log()` helper.
- Route `github.*` context data through `env:` instead of inline `${{ }}` interpolation in `council-gate.yml`, `sync-action.yml`, and `release-security.yml` (shell/script injection).
- Mark the verify cache-affinity SHA1 hash `usedforsecurity=False` (not a security use — cache key only).
- Pin every third-party GitHub Action across all 15 workflows to an immutable commit SHA, and pin the Railway Dockerfile's `python:3.11-slim` base image to a digest (Docker build verified locally).
- Add least-privilege `permissions:` blocks to workflows that lacked a top-level scope, and split overly-broad top-level write scopes in `security.yml`/`release-security.yml` down to per-job.
- Add a 5-day dependabot cooldown to both ecosystems.
- Dismiss 2 false-positive alerts on GitHub with reasons (URL-substring check on a test assertion; python37-compat finding on a module the project's `>=3.10` floor already covers).

Closes the majority of the ~150 open alerts at https://github.com/amiable-dev/llm-council/security/code-scanning. Remaining open: the Dockerfile's unhashed `pip install` (needs a hash-locked requirements workflow — separate follow-up) and 3 org-level Scorecard checks (CII Best Practices badge, Code-Review, Fuzzing) that aren't code-fixable.

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] Full test suite (`pytest tests/`) — 3720 passed, 1 skipped
- [x] All workflow YAML validated with `yaml.safe_load`
- [x] Docker image built locally against the pinned `python:3.11-slim` digest — succeeds
- [x] Updated `test_security_workflows.py` assertions to match the new per-job permission scoping in `release-security.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RL2KiDnXTTsYAP4JPcLQDp