### PR TITLE
fix(security): close residual sha1 and log-injection alerts from #649

### DIFF
--- a/src/llm_council/layer_contracts.py
+++ b/src/llm_council/layer_contracts.py
@@ -203,7 +203,7 @@ def emit_layer_event(
         event_type.value,
         safe_log(layer_from),
         safe_log(layer_to),
-        data,
+        safe_log(data),
     )
 
     # Notify subscribed metrics adapters (ADR-030)

--- a/src/llm_council/verification/api.py
+++ b/src/llm_council/verification/api.py
@@ -939,9 +939,8 @@ async def run_verification(
         # sequence id (hash of the target paths) — never the per-round SHA,
         # which would defeat the affinity it exists to provide. Cleared in
         # the finally below; consumers no-op when the context is absent.
-        subject_key = hashlib.sha1(  # noqa: S324 — cache-affinity key, not a security use
-            "\n".join(sorted(request.target_paths or ["<repo>"])).encode(),
-            usedforsecurity=False,
+        subject_key = hashlib.sha256(
+            "\n".join(sorted(request.target_paths or ["<repo>"])).encode()
         ).hexdigest()[:12]
         set_cache_context(
             CacheContext(


### PR DESCRIPTION
## Summary
Follow-up to #649. After that PR merged and master's Security Scanning workflow re-ran, 2 of the alerts I'd believed fixed were still open, for reasons the earlier diff alone didn't surface:

- `api.py:942` (alert #348) — `usedforsecurity=False` doesn't satisfy Semgrep's `insecure-hash-algorithm-sha1` rule, which pattern-matches any `hashlib.sha1()` call regardless of kwargs. Switched to `sha256` outright; it's a cache-affinity key, not a security use, so the algorithm choice was always arbitrary.
- `layer_contracts.py:206` (alert #115) — the earlier fix sanitized `layer_from`/`layer_to` but left the `data` dict argument unwrapped, so CodeQL's taint tracking still flagged the log sink. Wrapped it in `safe_log()` too for a consistent barrier.

## Remaining open alerts (not addressed here)
- 6 `PinnedDependenciesID` "pipCommand not pinned by hash" findings (`ci.yml` x3, `security.yml`, `bench.yml`, `release-security.yml`) + the Dockerfile's unhashed `pip install ".[http]"` (#83) — same class, needs a hash-locked requirements workflow (`--require-hashes`), which is a bigger design decision (lockfile tooling/regeneration) than a mechanical fix. Tracking as a separate follow-up.
- 3 org-level OpenSSF Scorecard checks with no associated file (CII Best Practices badge, Code-Review, Fuzzing) — not code-fixable; would need external registration / branch-protection review / OSS-Fuzz setup.

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] Full test suite (`pytest tests/`) — 3720 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RL2KiDnXTTsYAP4JPcLQDp